### PR TITLE
feat: migrate from Azure ACR to Scaleway Container Registry

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -1,4 +1,4 @@
-name: CI/CD Pipeline - SMTP Rust + DKIM (Azure ACR -> Scaleway VM)
+name: CI/CD Pipeline - SMTP Rust + DKIM (Scaleway Container Registry -> Scaleway VM)
 
 on:
   push:
@@ -10,8 +10,7 @@ on:
     types: [deploy]
 
 env:
-  ACR_NAME: ${{ secrets.ACR_NAME }}
-  ACR_LOGIN_SERVER: ${{ secrets.ACR_LOGIN_SERVER }}
+  SCW_REGISTRY_ENDPOINT: ${{ secrets.SCW_REGISTRY_ENDPOINT }}
   VM_IP: ${{ secrets.VM_IP }}
 
 jobs:
@@ -34,11 +33,11 @@ jobs:
         run: cargo check --lib --bins --verbose
 
   # ============================================================
-  # JOB 2 : Build & Push SMTP image via az acr build
+  # JOB 2 : Build & Push SMTP image via Docker Buildx to SCW Registry
   #          SKIPPED on repository_dispatch (DKIM-only change)
   # ============================================================
   build-push-smtp:
-    name: Build & Push SMTP image (az acr build)
+    name: Build & Push SMTP image (SCW Registry)
     needs: test
     runs-on: ubuntu-latest
     if: >-
@@ -47,25 +46,32 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Azure Login
-        uses: azure/login@v2
-        with:
-          creds: ${{ secrets.AZURE_CREDENTIALS }}
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
 
-      - name: Build & push SMTP image (remote ACR build, no local Docker)
-        run: |
-          set -euo pipefail
-          az acr build \
-            --image smtp-server:latest \
-            --image smtp-server:${{ github.sha }} \
-            --registry ${{ env.ACR_NAME }} \
-            --file Dockerfile \
-            .
+      - name: Login to Scaleway Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.SCW_REGISTRY_ENDPOINT }}
+          username: ${{ secrets.SCW_ACCESS_KEY }}
+          password: ${{ secrets.SCW_SECRET_KEY }}
+
+      - name: Build & push SMTP image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          tags: |
+            ${{ env.SCW_REGISTRY_ENDPOINT }}/smtp-server:latest
+            ${{ env.SCW_REGISTRY_ENDPOINT }}/smtp-server:${{ github.sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
   # ============================================================
   # JOB 3 : Déploiement sur la VM Scaleway
   #          - charge les secrets depuis 1Password
-  #          - SSH -> pull des deux images (SMTP + DKIM) depuis ACR
+  #          - SSH -> pull des deux images (SMTP + DKIM) depuis SCW Registry
   #          - docker-compose up -d
   # ============================================================
   deploy:
@@ -93,8 +99,8 @@ jobs:
         env:
           # Format: ENV_VAR_NAME=op://<vault>/<item>/<field>
           # À adapter selon l'organisation du vault 1Password
-          ACR_USERNAME: op://smtp-project/acr/username
-          ACR_PASSWORD: op://smtp-project/acr/password
+          SCW_ACCESS_KEY: op://smtp-project/scaleway/access-key
+          SCW_SECRET_KEY: op://smtp-project/scaleway/secret-key
           VM_SSH_KEY: op://smtp-project/vm/ssh-private-key
           VM_KNOWN_HOSTS: op://smtp-project/vm/known-hosts
 
@@ -116,14 +122,14 @@ jobs:
             set -euo pipefail
             cd /home/ubuntu
 
-            # Login to Azure ACR on the VM
-            echo "${{ env.ACR_PASSWORD }}" | docker login \
-              ${{ env.ACR_LOGIN_SERVER }} \
-              -u ${{ env.ACR_USERNAME }} --password-stdin
+            # Login to Scaleway Container Registry on the VM
+            echo "${{ secrets.SCW_SECRET_KEY }}" | docker login \
+              ${{ env.SCW_REGISTRY_ENDPOINT }} \
+              -u ${{ secrets.SCW_ACCESS_KEY }} --password-stdin
 
-            # Pull latest images from Azure ACR
-            docker pull ${{ env.ACR_LOGIN_SERVER }}/smtp-server:latest
-            docker pull ${{ env.ACR_LOGIN_SERVER }}/dkim-service:latest
+            # Pull latest images from Scaleway Container Registry
+            docker pull ${{ env.SCW_REGISTRY_ENDPOINT }}/smtp-server:latest
+            docker pull ${{ env.SCW_REGISTRY_ENDPOINT }}/dkim-service:latest
 
             # Deploy with unified compose
             docker compose -f docker-compose.deploy.yml --env-file .env.deploy up -d --remove-orphans

--- a/docker-compose.deploy.yml
+++ b/docker-compose.deploy.yml
@@ -1,7 +1,7 @@
 # docker-compose.deploy.yml
 # Déploiement unifié sur la VM Scaleway
 # 5 services : smtp-server, email-api, imap-server, mongodb, dkim-service
-# Images pulled from Azure Container Registry
+# Images pulled from Scaleway Container Registry
 #
 # Usage sur la VM :
 #   docker compose -f docker-compose.deploy.yml --env-file .env.deploy up -d
@@ -32,10 +32,10 @@ services:
       - mailnet
 
   # ----------------------------------------------------------
-  # SMTP Server (Rust) - image from Azure ACR
+  # SMTP Server (Rust) - image from Scaleway Container Registry
   # ----------------------------------------------------------
   smtp-server:
-    image: ${ACR_LOGIN_SERVER}/smtp-server:latest
+    image: ${SCW_REGISTRY_ENDPOINT}/smtp-server:latest
     container_name: smtp-server
     restart: always
     ports:
@@ -71,7 +71,7 @@ services:
   # Email API (Rust) - same image, different command
   # ----------------------------------------------------------
   email-api:
-    image: ${ACR_LOGIN_SERVER}/smtp-server:latest
+    image: ${SCW_REGISTRY_ENDPOINT}/smtp-server:latest
     container_name: email-api
     restart: always
     ports:
@@ -96,7 +96,7 @@ services:
   # IMAP Server (Rust) - same image, different command
   # ----------------------------------------------------------
   imap-server:
-    image: ${ACR_LOGIN_SERVER}/smtp-server:latest
+    image: ${SCW_REGISTRY_ENDPOINT}/smtp-server:latest
     container_name: imap-server
     restart: always
     ports:
@@ -123,10 +123,10 @@ services:
       - mailnet
 
   # ----------------------------------------------------------
-  # DKIM Service (Node.js 22) - image from Azure ACR
+  # DKIM Service (Node.js 22) - image from Scaleway Container Registry
   # ----------------------------------------------------------
   dkim-service:
-    image: ${ACR_LOGIN_SERVER}/dkim-service:latest
+    image: ${SCW_REGISTRY_ENDPOINT}/dkim-service:latest
     container_name: dkim-service
     restart: always
     ports:

--- a/infra/init-vm.sh
+++ b/infra/init-vm.sh
@@ -16,13 +16,13 @@ sudo usermod -aG docker $USER
 sudo curl -L "https://github.com/docker/compose/releases/download/v2.23.0/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
 sudo chmod +x /usr/local/bin/docker-compose
 
-# Configurer le login ACR
-ACR_NAME="${ACR_NAME}"
-ACR_USERNAME="${ACR_USERNAME}"
-ACR_PASSWORD="${ACR_PASSWORD}"
+# Configurer le login Scaleway Container Registry
+SCW_REGISTRY_ENDPOINT="${SCW_REGISTRY_ENDPOINT}"
+SCW_ACCESS_KEY="${SCW_ACCESS_KEY}"
+SCW_SECRET_KEY="${SCW_SECRET_KEY}"
 
-echo "Logging into ACR $ACR_NAME..."
-echo $ACR_PASSWORD | docker login $ACR_NAME.azurecr.io -u $ACR_USERNAME --password-stdin
+echo "Logging into Scaleway Container Registry $SCW_REGISTRY_ENDPOINT..."
+echo $SCW_SECRET_KEY | docker login $SCW_REGISTRY_ENDPOINT -u $SCW_ACCESS_KEY --password-stdin
 
 # Créer le répertoire pour les configs
 mkdir -p /home/smtpadmin/smtp-config
@@ -36,7 +36,7 @@ After=network.target
 [Service]
 Restart=always
 User=smtpadmin
-ExecStart=/usr/bin/docker run --rm -p 25:25 -p 587:587 -p 143:143 -p 8080:8080 -v /home/smtpadmin/smtp-config:/config $ACR_NAME.azurecr.io/smtp-server:latest
+ExecStart=/usr/bin/docker run --rm -p 25:25 -p 587:587 -p 143:143 -p 8080:8080 -v /home/smtpadmin/smtp-config:/config $SCW_REGISTRY_ENDPOINT/smtp-server:latest
 WorkingDirectory=/home/smtpadmin
 
 [Install]

--- a/setup-secrets.sh
+++ b/setup-secrets.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# setup-secrets.sh - Script pour configurer les secrets GitHub (Scaleway)
+# setup-secrets.sh - Script pour configurer les secrets GitHub (Scaleway Container Registry)
 
 # Vérifier que gh CLI est installé
 gh --version >/dev/null 2>&1 || { echo "GitHub CLI (gh) n'est pas installé. Installe-le avec : sudo apt install gh"; exit 1; }
@@ -9,7 +9,7 @@ gh auth status >/dev/null 2>&1 || gh auth login
 
 # Demander les informations
 read -p "Nom du dépôt GitHub (ex: canatac/reimagined-guide): " REPO
-read -p "Nom du registre Scaleway (ex: smtp-rust-registry): " REGISTRY_NAME
+read -p "Endpoint du registre Scaleway (ex: rg.fr-par.scw.cloud/smtp-rust-registry): " SCW_REGISTRY_ENDPOINT
 read -p "IP publique de la VM: " VM_IP
 read -p "Chemin vers ta clé SSH privée (ex: ~/.ssh/id_rsa): " SSH_KEY_PATH
 
@@ -27,12 +27,15 @@ read -p "Scaleway Default Project ID: " SCW_DEFAULT_PROJECT_ID
 # Configurer les secrets GitHub
 echo "Configuration des secrets GitHub pour $REPO..."
 
-echo $REGISTRY_NAME | gh secret set REGISTRY_NAME --repo $REPO --app actions
-echo $VM_IP | gh secret set VM_IP --repo $REPO --app actions
+echo "$SCW_REGISTRY_ENDPOINT" | gh secret set SCW_REGISTRY_ENDPOINT --repo $REPO --app actions
+echo "$SCW_ACCESS_KEY" | gh secret set SCW_ACCESS_KEY --repo $REPO --app actions
+echo "$SCW_SECRET_KEY" | gh secret set SCW_SECRET_KEY --repo $REPO --app actions
+echo "$VM_IP" | gh secret set VM_IP --repo $REPO --app actions
 echo "$SSH_KEY" | gh secret set VM_SSH_KEY --repo $REPO --app actions
 echo "$KNOWN_HOSTS" | gh secret set VM_KNOWN_HOSTS --repo $REPO --app actions
-echo $SCW_ACCESS_KEY | gh secret set SCW_ACCESS_KEY --repo $REPO --app actions
-echo $SCW_SECRET_KEY | gh secret set SCW_SECRET_KEY --repo $REPO --app actions
-echo $SCW_DEFAULT_PROJECT_ID | gh secret set SCW_DEFAULT_PROJECT_ID --repo $REPO --app actions
+echo "$SCW_DEFAULT_PROJECT_ID" | gh secret set SCW_DEFAULT_PROJECT_ID --repo $REPO --app actions
 
 echo "✅ Secrets configurés avec succès !"
+echo ""
+echo "📌 Secrets à configurer également sur le repo studious-octo-rotary-phone :"
+echo "   SCW_REGISTRY_ENDPOINT, SCW_ACCESS_KEY, SCW_SECRET_KEY"


### PR DESCRIPTION
## Summary
Migration complète d'Azure Container Registry vers Scaleway Container Registry.

### Changements
- **`.github/workflows/cicd.yml`** : Remplacement d'`az acr build` + `azure/login` par `docker buildx build` + `docker/login-action` avec credentials Scaleway
- **`docker-compose.deploy.yml`** : Toutes les références d'images `${ACR_LOGIN_SERVER}/` remplacées par `${SCW_REGISTRY_ENDPOINT}/`
- **`infra/init-vm.sh`** : Login au registre Scaleway au lieu d'Azure ACR
- **`setup-secrets.sh`** : Secrets GitHub mis à jour pour Scaleway (SCW_REGISTRY_ENDPOINT, SCW_ACCESS_KEY, SCW_SECRET_KEY)

### Secrets GitHub à configurer
| Secret | Description |
|--------|-------------|
| `SCW_REGISTRY_ENDPOINT` | Endpoint du registry (ex: `rg.fr-par.scw.cloud/smtp-rust-registry`) |
| `SCW_ACCESS_KEY` | Scaleway Access Key |
| `SCW_SECRET_KEY` | Scaleway Secret Key |

### Secrets à supprimer
- `ACR_NAME`, `ACR_LOGIN_SERVER`, `AZURE_CREDENTIALS`

### Améliorations
- Docker Buildx avec cache GHA pour builds plus rapides
- Fix du secret `GH_PAT` dans le job trigger-deploy (était masqué comme `***`)

## Test Plan
- [ ] Configurer les nouveaux secrets GitHub
- [ ] Vérifier que le Terraform crée bien le `scaleway_registry_namespace`
- [ ] Tester le pipeline CICD avec un push sur master