### PR TITLE
fix(api): stream Hermes run events SSE without buffering

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ This project implements **robust, secure, and efficient SMTP and IMAP servers** 
 - **Email storage** (MongoDB or local filesystem).
 - **DKIM signature handling** (optional).
 - **Environment variable configuration** (`.env.example` provided).
-- **Hermes chat gateway** (`POST /api/hermes/chat`) for secure server-to-server AI calls.
+- **Hermes chat gateway** (`POST /api/hermes/chat`) for secure server-to-server AI calls, including optional explicit `sessionId`/`sessionKey` overrides for cross-service thread continuity.
 
 ### 1.3 Technology Stack
 - **Rust** (2021 edition)

--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ DKIM_SERVICE_URL=http://your-dkim-service:3000/sign
 
 # Hermes gateway (server-to-server)
 # Keep HERMES_BASE_URL on private VPC address only (no public 8642)
+# `/v1` suffix is accepted too (normalized internally to avoid /v1/v1)
 HERMES_BASE_URL=http://172.16.12.2:8642
 HERMES_API_KEY=your_hermes_api_key
 HERMES_MODEL=hermes-agent

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ This project implements **robust, secure, and efficient SMTP and IMAP servers** 
 - **Email storage** (MongoDB or local filesystem).
 - **DKIM signature handling** (optional).
 - **Environment variable configuration** (`.env.example` provided).
-- **Hermes chat gateway** (`POST /api/hermes/chat`) for secure server-to-server AI calls, including optional explicit `sessionId`/`sessionKey` overrides for cross-service thread continuity.
+- **Hermes gateway** (`POST /api/hermes/chat` and `POST /api/hermes/runs`) for secure server-to-server AI calls, including optional explicit `sessionId`/`sessionKey` overrides for cross-service thread continuity.
 
 ### 1.3 Technology Stack
 - **Rust** (2021 edition)

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ This project implements **robust, secure, and efficient SMTP and IMAP servers** 
 - **Email storage** (MongoDB or local filesystem).
 - **DKIM signature handling** (optional).
 - **Environment variable configuration** (`.env.example` provided).
-- **Hermes gateway** (`POST /api/hermes/chat` and `POST /api/hermes/runs`) for secure server-to-server AI calls, including optional explicit `sessionId`/`sessionKey` overrides for cross-service thread continuity.
+- **Hermes gateway** (`POST /api/hermes/chat`, `POST /api/hermes/runs`, `GET /api/hermes/runs/{runId}`, `GET /api/hermes/runs/{runId}/events`) for secure server-to-server AI calls, including optional explicit `sessionId`/`sessionKey` overrides for cross-service thread continuity.
 
 ### 1.3 Technology Stack
 - **Rust** (2021 edition)

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ This project implements **robust, secure, and efficient SMTP and IMAP servers** 
 - **Email storage** (MongoDB or local filesystem).
 - **DKIM signature handling** (optional).
 - **Environment variable configuration** (`.env.example` provided).
-- **Hermes gateway** (`POST /api/hermes/chat`, `POST /api/hermes/runs`, `GET /api/hermes/runs/{runId}`, `GET /api/hermes/runs/{runId}/events`) for secure server-to-server AI calls, including optional explicit `sessionId`/`sessionKey` overrides for cross-service thread continuity.
+- **Hermes gateway** (`POST /api/hermes/chat`, `POST /api/hermes/runs`, `GET /api/hermes/runs/{runId}`, `GET /api/hermes/runs/{runId}/events`) for secure server-to-server AI calls, including optional explicit `sessionId`/`sessionKey` overrides for cross-service thread continuity; events endpoint now streams SSE passthrough for live run updates.
 
 ### 1.3 Technology Stack
 - **Rust** (2021 edition)

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ This project implements **robust, secure, and efficient SMTP and IMAP servers** 
 - **Email storage** (MongoDB or local filesystem).
 - **DKIM signature handling** (optional).
 - **Environment variable configuration** (`.env.example` provided).
+- **Hermes chat gateway** (`POST /api/hermes/chat`) for secure server-to-server AI calls.
 
 ### 1.3 Technology Stack
 - **Rust** (2021 edition)
@@ -122,6 +123,12 @@ USE_MONGODB=true  # Set to "false" for local file storage
 
 # DKIM (optional)
 DKIM_SERVICE_URL=http://your-dkim-service:3000/sign
+
+# Hermes gateway (server-to-server)
+# Keep HERMES_BASE_URL on private VPC address only (no public 8642)
+HERMES_BASE_URL=http://172.16.12.2:8642
+HERMES_API_KEY=your_hermes_api_key
+HERMES_MODEL=hermes-agent
 
 # Logging
 RUST_LOG=debug

--- a/env.example
+++ b/env.example
@@ -31,6 +31,12 @@ IMAP_SERVER_API_PORT=8080
 # API Server Configuration
 API_SERVER_ADDR=0.0.0.0:8000
 
+# Hermes gateway (server-to-server)
+# Keep HERMES_BASE_URL on private VPC address only (no public 8642)
+HERMES_BASE_URL=http://172.16.12.2:8642
+HERMES_API_KEY=
+HERMES_MODEL=hermes-agent
+
 # Logging
 RUST_LOG=debug
 

--- a/src/bin/email_api.rs
+++ b/src/bin/email_api.rs
@@ -1330,6 +1330,133 @@ async fn api_hermes_runs(
     .json(body_json)
 }
 
+#[derive(Deserialize)]
+struct HermesRunPath {
+    run_id: String,
+}
+
+async fn api_hermes_run_status(path: web::Path<HermesRunPath>) -> impl Responder {
+    let run_id = path.into_inner().run_id;
+    if run_id.trim().is_empty() {
+        return HttpResponse::BadRequest().json(serde_json::json!({
+            "error": "runId is required"
+        }));
+    }
+
+    let base =
+        env::var("HERMES_BASE_URL").unwrap_or_else(|_| "http://172.16.12.2:8642".to_string());
+    let api_key = match env::var("HERMES_API_KEY") {
+        Ok(v) if !v.trim().is_empty() => v,
+        _ => {
+            return HttpResponse::InternalServerError().json(serde_json::json!({
+                "error": "HERMES_API_KEY is not configured"
+            }))
+        }
+    };
+
+    let url = format!("{}/v1/runs/{}", base.trim_end_matches('/'), run_id);
+
+    let client = reqwest::Client::new();
+    let response = match client.get(url).bearer_auth(api_key).send().await {
+        Ok(r) => r,
+        Err(e) => {
+            eprintln!("Hermes upstream request error: {}", e);
+            return HttpResponse::BadGateway().json(serde_json::json!({
+                "error": "Hermes upstream unavailable"
+            }));
+        }
+    };
+
+    let status = response.status();
+    let body_json = match response.json::<serde_json::Value>().await {
+        Ok(v) => v,
+        Err(e) => {
+            eprintln!("Hermes upstream JSON parse error: {}", e);
+            return HttpResponse::BadGateway().json(serde_json::json!({
+                "error": "Invalid Hermes upstream response"
+            }));
+        }
+    };
+
+    HttpResponse::build(
+        actix_web::http::StatusCode::from_u16(status.as_u16())
+            .unwrap_or(actix_web::http::StatusCode::BAD_GATEWAY),
+    )
+    .json(body_json)
+}
+
+async fn api_hermes_run_events(path: web::Path<HermesRunPath>, req: HttpRequest) -> impl Responder {
+    let run_id = path.into_inner().run_id;
+    if run_id.trim().is_empty() {
+        return HttpResponse::BadRequest().json(serde_json::json!({
+            "error": "runId is required"
+        }));
+    }
+
+    let base =
+        env::var("HERMES_BASE_URL").unwrap_or_else(|_| "http://172.16.12.2:8642".to_string());
+    let api_key = match env::var("HERMES_API_KEY") {
+        Ok(v) if !v.trim().is_empty() => v,
+        _ => {
+            return HttpResponse::InternalServerError().json(serde_json::json!({
+                "error": "HERMES_API_KEY is not configured"
+            }))
+        }
+    };
+
+    let query = req.query_string();
+    let mut url = format!(
+        "{}/v1/runs/{}/events",
+        base.trim_end_matches('/'),
+        urlencoding::encode(&run_id)
+    );
+    if !query.trim().is_empty() {
+        url = format!("{}?{}", url, query);
+    }
+
+    let client = reqwest::Client::new();
+    let response = match client
+        .get(url)
+        .bearer_auth(api_key)
+        .header("Accept", "text/event-stream")
+        .send()
+        .await
+    {
+        Ok(r) => r,
+        Err(e) => {
+            eprintln!("Hermes upstream request error: {}", e);
+            return HttpResponse::BadGateway().json(serde_json::json!({
+                "error": "Hermes upstream unavailable"
+            }));
+        }
+    };
+
+    let status = response.status();
+    let content_type = response
+        .headers()
+        .get(reqwest::header::CONTENT_TYPE)
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("text/event-stream")
+        .to_string();
+
+    let body_bytes = match response.bytes().await {
+        Ok(v) => v,
+        Err(e) => {
+            eprintln!("Hermes upstream body read error: {}", e);
+            return HttpResponse::BadGateway().json(serde_json::json!({
+                "error": "Invalid Hermes upstream response"
+            }));
+        }
+    };
+
+    HttpResponse::build(
+        actix_web::http::StatusCode::from_u16(status.as_u16())
+            .unwrap_or(actix_web::http::StatusCode::BAD_GATEWAY),
+    )
+    .content_type(content_type)
+    .body(body_bytes)
+}
+
 // --- Calendar types ---
 
 #[derive(Deserialize)]
@@ -1658,6 +1785,14 @@ async fn main() -> std::io::Result<()> {
                 .route("/api/settings/ai", web::put().to(api_put_ai_settings))
                 .route("/api/hermes/chat", web::post().to(api_hermes_chat))
                 .route("/api/hermes/runs", web::post().to(api_hermes_runs))
+                .route(
+                    "/api/hermes/runs/{run_id}",
+                    web::get().to(api_hermes_run_status),
+                )
+                .route(
+                    "/api/hermes/runs/{run_id}/events",
+                    web::get().to(api_hermes_run_events),
+                )
                 .route("/api/send/undo", web::post().to(api_send))
                 .route("/api/send/schedule", web::post().to(api_send))
                 .route(
@@ -1851,6 +1986,36 @@ mod tests {
         assert_eq!(parsed.session_id.as_deref(), Some("mail-thread-explicit"));
         assert_eq!(parsed.session_key.as_deref(), Some("user-explicit"));
         assert_eq!(parsed.model.as_deref(), Some("hermes-agent"));
+    }
+
+    #[actix_web::test]
+    async fn test_api_hermes_run_status_requires_run_id() {
+        let app = test::init_service(App::new().route(
+            "/api/hermes/runs/{run_id}",
+            web::get().to(api_hermes_run_status),
+        ))
+        .await;
+
+        let req = test::TestRequest::get()
+            .uri("/api/hermes/runs/%20")
+            .to_request();
+        let resp = test::call_service(&app, req).await;
+        assert_eq!(resp.status(), actix_web::http::StatusCode::BAD_REQUEST);
+    }
+
+    #[actix_web::test]
+    async fn test_api_hermes_run_events_requires_run_id() {
+        let app = test::init_service(App::new().route(
+            "/api/hermes/runs/{run_id}/events",
+            web::get().to(api_hermes_run_events),
+        ))
+        .await;
+
+        let req = test::TestRequest::get()
+            .uri("/api/hermes/runs/%20/events")
+            .to_request();
+        let resp = test::call_service(&app, req).await;
+        assert_eq!(resp.status(), actix_web::http::StatusCode::BAD_REQUEST);
     }
 }
 

--- a/src/bin/email_api.rs
+++ b/src/bin/email_api.rs
@@ -1115,6 +1115,23 @@ struct HermesChatProxyRequest {
     max_tokens: Option<u32>,
 }
 
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct HermesRunsProxyRequest {
+    #[serde(default)]
+    input: Option<serde_json::Value>,
+    #[serde(default)]
+    model: Option<String>,
+    #[serde(default)]
+    thread_id: Option<String>,
+    #[serde(default)]
+    user_id: Option<String>,
+    #[serde(default)]
+    session_id: Option<String>,
+    #[serde(default)]
+    session_key: Option<String>,
+}
+
 async fn api_hermes_chat(
     req: HttpRequest,
     body: web::Json<HermesChatProxyRequest>,
@@ -1178,6 +1195,103 @@ async fn api_hermes_chat(
     if let Some(max_tokens) = body.max_tokens {
         payload["max_tokens"] = serde_json::json!(max_tokens);
     }
+
+    let client = reqwest::Client::new();
+    let response = match client
+        .post(url)
+        .bearer_auth(api_key)
+        .header("X-Hermes-Session-Id", session_id)
+        .header("X-Hermes-Session-Key", session_key)
+        .json(&payload)
+        .send()
+        .await
+    {
+        Ok(r) => r,
+        Err(e) => {
+            eprintln!("Hermes upstream request error: {}", e);
+            return HttpResponse::BadGateway().json(serde_json::json!({
+                "error": "Hermes upstream unavailable"
+            }));
+        }
+    };
+
+    let status = response.status();
+    let body_json = match response.json::<serde_json::Value>().await {
+        Ok(v) => v,
+        Err(e) => {
+            eprintln!("Hermes upstream JSON parse error: {}", e);
+            return HttpResponse::BadGateway().json(serde_json::json!({
+                "error": "Invalid Hermes upstream response"
+            }));
+        }
+    };
+
+    HttpResponse::build(
+        actix_web::http::StatusCode::from_u16(status.as_u16())
+            .unwrap_or(actix_web::http::StatusCode::BAD_GATEWAY),
+    )
+    .json(body_json)
+}
+
+async fn api_hermes_runs(
+    req: HttpRequest,
+    body: web::Json<HermesRunsProxyRequest>,
+) -> impl Responder {
+    let input = match body.input.clone().filter(|v| !v.is_null()) {
+        Some(v) => v,
+        None => {
+            return HttpResponse::BadRequest().json(serde_json::json!({
+                "error": "input is required"
+            }))
+        }
+    };
+
+    let base =
+        env::var("HERMES_BASE_URL").unwrap_or_else(|_| "http://172.16.12.2:8642".to_string());
+    let api_key = match env::var("HERMES_API_KEY") {
+        Ok(v) if !v.trim().is_empty() => v,
+        _ => {
+            return HttpResponse::InternalServerError().json(serde_json::json!({
+                "error": "HERMES_API_KEY is not configured"
+            }))
+        }
+    };
+
+    let url = format!("{}/v1/runs", base.trim_end_matches('/'));
+    let model = body
+        .model
+        .clone()
+        .unwrap_or_else(|| env::var("HERMES_MODEL").unwrap_or_else(|_| "hermes-agent".to_string()));
+
+    let thread_id = body
+        .thread_id
+        .clone()
+        .filter(|s| !s.trim().is_empty())
+        .unwrap_or_else(|| Uuid::new_v4().to_string());
+
+    let fallback_user_id = resolve_user_id(&req);
+    let user_id = body
+        .user_id
+        .clone()
+        .filter(|s| !s.trim().is_empty())
+        .unwrap_or(fallback_user_id);
+
+    let session_id = body
+        .session_id
+        .clone()
+        .filter(|s| !s.trim().is_empty())
+        .unwrap_or_else(|| format!("mail-thread-{}", thread_id));
+
+    let session_key = body
+        .session_key
+        .clone()
+        .filter(|s| !s.trim().is_empty())
+        .unwrap_or_else(|| format!("user-{}", user_id));
+
+    let payload = serde_json::json!({
+        "model": model,
+        "input": input,
+    });
 
     let client = reqwest::Client::new();
     let response = match client
@@ -1543,6 +1657,7 @@ async fn main() -> std::io::Result<()> {
                 .route("/api/settings/ai", web::get().to(api_get_ai_settings))
                 .route("/api/settings/ai", web::put().to(api_put_ai_settings))
                 .route("/api/hermes/chat", web::post().to(api_hermes_chat))
+                .route("/api/hermes/runs", web::post().to(api_hermes_runs))
                 .route("/api/send/undo", web::post().to(api_send))
                 .route("/api/send/schedule", web::post().to(api_send))
                 .route(
@@ -1700,6 +1815,42 @@ mod tests {
         assert_eq!(parsed.session_id.as_deref(), Some("mail-thread-explicit"));
         assert_eq!(parsed.session_key.as_deref(), Some("user-explicit"));
         assert_eq!(parsed.max_tokens, Some(1200));
+    }
+
+    #[actix_web::test]
+    async fn test_api_hermes_runs_requires_input() {
+        let app = test::init_service(
+            App::new().route("/api/hermes/runs", web::post().to(api_hermes_runs)),
+        )
+        .await;
+
+        let req = test::TestRequest::post()
+            .uri("/api/hermes/runs")
+            .set_json(serde_json::json!({}))
+            .to_request();
+
+        let resp = test::call_service(&app, req).await;
+        assert_eq!(resp.status(), actix_web::http::StatusCode::BAD_REQUEST);
+    }
+
+    #[test]
+    fn test_hermes_runs_request_accepts_explicit_session_overrides() {
+        let parsed: HermesRunsProxyRequest = serde_json::from_value(serde_json::json!({
+            "input": [{"role":"user","content":"hello"}],
+            "threadId": "thread-123",
+            "userId": "admin",
+            "sessionId": "mail-thread-explicit",
+            "sessionKey": "user-explicit",
+            "model": "hermes-agent"
+        }))
+        .expect("HermesRunsProxyRequest should deserialize");
+
+        assert!(parsed.input.is_some());
+        assert_eq!(parsed.thread_id.as_deref(), Some("thread-123"));
+        assert_eq!(parsed.user_id.as_deref(), Some("admin"));
+        assert_eq!(parsed.session_id.as_deref(), Some("mail-thread-explicit"));
+        assert_eq!(parsed.session_key.as_deref(), Some("user-explicit"));
+        assert_eq!(parsed.model.as_deref(), Some("hermes-agent"));
     }
 }
 

--- a/src/bin/email_api.rs
+++ b/src/bin/email_api.rs
@@ -42,6 +42,7 @@ use serde::{Deserialize, Serialize};
 
 use chrono::Utc;
 use dotenv::dotenv;
+use futures_util::TryStreamExt;
 use mongodb::bson;
 use mongodb::bson::doc;
 use reqwest;
@@ -1405,11 +1406,7 @@ async fn api_hermes_run_events(path: web::Path<HermesRunPath>, req: HttpRequest)
     };
 
     let query = req.query_string();
-    let mut url = format!(
-        "{}/v1/runs/{}/events",
-        base.trim_end_matches('/'),
-        urlencoding::encode(&run_id)
-    );
+    let mut url = format!("{}/v1/runs/{}/events", base.trim_end_matches('/'), run_id);
     if !query.trim().is_empty() {
         url = format!("{}?{}", url, query);
     }
@@ -1439,22 +1436,35 @@ async fn api_hermes_run_events(path: web::Path<HermesRunPath>, req: HttpRequest)
         .unwrap_or("text/event-stream")
         .to_string();
 
-    let body_bytes = match response.bytes().await {
-        Ok(v) => v,
-        Err(e) => {
-            eprintln!("Hermes upstream body read error: {}", e);
-            return HttpResponse::BadGateway().json(serde_json::json!({
-                "error": "Invalid Hermes upstream response"
-            }));
-        }
-    };
+    if !status.is_success() {
+        let body_text = match response.text().await {
+            Ok(v) => v,
+            Err(e) => {
+                eprintln!("Hermes upstream body read error: {}", e);
+                return HttpResponse::BadGateway().json(serde_json::json!({
+                    "error": "Invalid Hermes upstream response"
+                }));
+            }
+        };
+
+        return HttpResponse::build(
+            actix_web::http::StatusCode::from_u16(status.as_u16())
+                .unwrap_or(actix_web::http::StatusCode::BAD_GATEWAY),
+        )
+        .content_type(content_type)
+        .body(body_text);
+    }
+
+    let stream = response.bytes_stream().map_err(|e| {
+        actix_web::error::ErrorBadGateway(format!("Hermes upstream stream error: {}", e))
+    });
 
     HttpResponse::build(
         actix_web::http::StatusCode::from_u16(status.as_u16())
             .unwrap_or(actix_web::http::StatusCode::BAD_GATEWAY),
     )
     .content_type(content_type)
-    .body(body_bytes)
+    .streaming(stream)
 }
 
 // --- Calendar types ---

--- a/src/bin/email_api.rs
+++ b/src/bin/email_api.rs
@@ -35,26 +35,26 @@ curl -X POST http://localhost:3000/send_email \
 The API server will attempt to send the email using the SMTP client and return the result.
 */
 
-use actix_web::{web, App, HttpResponse, HttpServer, Responder};
+use actix_cors::Cors;
+use actix_web::{web, App, HttpRequest, HttpResponse, HttpServer, Responder};
 use openssl::ssl::{SslAcceptor, SslFiletype, SslMethod};
 use serde::{Deserialize, Serialize};
-use actix_cors::Cors;
 
-use std::fs::{File, create_dir_all};
-use std::io::{Write, BufRead, BufReader};
-use std::path::Path;
-use dotenv::dotenv;
-use std::env;
-use std::sync::Arc;
-use reqwest;
-use simple_smtp_server::entities::{Email, CalendarEvent};
-use simple_smtp_server::logic::Logic;
-use uuid::Uuid;
 use chrono::Utc;
-use simple_smtp_server::smtp_client::send_outgoing_email;
+use dotenv::dotenv;
 use mongodb::bson;
 use mongodb::bson::doc;
+use reqwest;
+use simple_smtp_server::entities::{CalendarEvent, Email};
+use simple_smtp_server::logic::Logic;
+use simple_smtp_server::smtp_client::send_outgoing_email;
 use std::collections::HashMap;
+use std::env;
+use std::fs::{create_dir_all, File};
+use std::io::{BufRead, BufReader, Write};
+use std::path::Path;
+use std::sync::Arc;
+use uuid::Uuid;
 
 // --- Auth types ---
 
@@ -158,10 +158,12 @@ async fn create_mailing_list(mailing_list: web::Json<MailingListRequest>) -> imp
     let file_path = mailing_list_dir.join(format!("{}.csv", mailing_list.label));
     let mut file = match File::create(&file_path) {
         Ok(file) => file,
-        Err(e) => return HttpResponse::InternalServerError().json(serde_json::json!({
-            "status": "error",
-            "message": format!("Failed to create file: {}", e)
-        })),
+        Err(e) => {
+            return HttpResponse::InternalServerError().json(serde_json::json!({
+                "status": "error",
+                "message": format!("Failed to create file: {}", e)
+            }))
+        }
     };
 
     for email in &mailing_list.emails {
@@ -180,8 +182,9 @@ async fn create_mailing_list(mailing_list: web::Json<MailingListRequest>) -> imp
 }
 
 async fn send_to_mailing_list(email_req: web::Json<MailingListEmailRequest>) -> impl Responder {
-    let mailing_list_path = Path::new("mailing-lists").join(format!("{}.csv", email_req.mailing_list));
-    
+    let mailing_list_path =
+        Path::new("mailing-lists").join(format!("{}.csv", email_req.mailing_list));
+
     if !mailing_list_path.exists() {
         return HttpResponse::NotFound().json(serde_json::json!({
             "status": "error",
@@ -191,10 +194,12 @@ async fn send_to_mailing_list(email_req: web::Json<MailingListEmailRequest>) -> 
 
     let file = match File::open(&mailing_list_path) {
         Ok(file) => file,
-        Err(e) => return HttpResponse::InternalServerError().json(serde_json::json!({
-            "status": "error",
-            "message": format!("Failed to open mailing list file: {}", e)
-        })),
+        Err(e) => {
+            return HttpResponse::InternalServerError().json(serde_json::json!({
+                "status": "error",
+                "message": format!("Failed to open mailing list file: {}", e)
+            }))
+        }
     };
 
     let reader = BufReader::new(file);
@@ -209,12 +214,12 @@ async fn send_to_mailing_list(email_req: web::Json<MailingListEmailRequest>) -> 
                 continue;
             }
         };
-    
+
         let from = email_req.from.clone();
         let to = to_email;
         let subject = email_req.subject.clone();
         let body = email_req.body.clone();
-    
+
         let _email_content = format!(
             "From: {}\r\nTo: {}\r\nSubject: {}\r\n\r\n{}",
             from, to, subject, body
@@ -222,7 +227,8 @@ async fn send_to_mailing_list(email_req: web::Json<MailingListEmailRequest>) -> 
         let client = reqwest::Client::new();
         let dkim_service_url = env::var("DKIM_SERVICE_URL").expect("DKIM_SERVICE_URL not set");
 
-        let _dkim_response = match client.post(&dkim_service_url)
+        let _dkim_response = match client
+            .post(&dkim_service_url)
             .json(&serde_json::json!({
                 "from": from,
                 "to": to,
@@ -230,23 +236,24 @@ async fn send_to_mailing_list(email_req: web::Json<MailingListEmailRequest>) -> 
                 "text": body
             }))
             .send()
-            .await {
-                Ok(resp) => {
-                    if resp.status().is_success() {
-                        success_count += 1;
-                    } else {
-                        failure_count += 1;
-                    }
-                },
-                Err(_) => {
+            .await
+        {
+            Ok(resp) => {
+                if resp.status().is_success() {
+                    success_count += 1;
+                } else {
                     failure_count += 1;
                 }
-            };
+            }
+            Err(_) => {
+                failure_count += 1;
+            }
+        };
     }
 
     HttpResponse::Ok().json(serde_json::json!({
         "status": "success",
-        "message": format!("Emails sent to mailing list '{}'. Successful: {}, Failed: {}", 
+        "message": format!("Emails sent to mailing list '{}'. Successful: {}, Failed: {}",
                            email_req.mailing_list, success_count, failure_count)
     }))
 }
@@ -270,12 +277,25 @@ async fn send_email_handler(
                         to: email_req.to.clone(),
                         subject: email_req.subject.clone(),
                         body: email_req.body.clone(),
-                        headers: vec![("DKIM-Signature".to_string(), dkim_result["dkimSignature"].as_str().unwrap_or("").to_string())],
+                        headers: vec![(
+                            "DKIM-Signature".to_string(),
+                            dkim_result["dkimSignature"]
+                                .as_str()
+                                .unwrap_or("")
+                                .to_string(),
+                        )],
                         flags: vec![],
                         sequence_number: 0,
                         uid: 0,
-                        internal_date: mongodb::bson::DateTime::from_millis(Utc::now().timestamp_millis()),
-                        dkim_signature: Some(dkim_result["dkimSignature"].as_str().unwrap_or("").to_string()),
+                        internal_date: mongodb::bson::DateTime::from_millis(
+                            Utc::now().timestamp_millis(),
+                        ),
+                        dkim_signature: Some(
+                            dkim_result["dkimSignature"]
+                                .as_str()
+                                .unwrap_or("")
+                                .to_string(),
+                        ),
                     };
 
                     // Send the email
@@ -312,14 +332,15 @@ async fn send_email_handler(
 
 // --- Auth handlers ---
 
-async fn auth_login(
-    req: web::Json<LoginRequest>,
-    logic: web::Data<Arc<Logic>>,
-) -> impl Responder {
+async fn auth_login(req: web::Json<LoginRequest>, logic: web::Data<Arc<Logic>>) -> impl Responder {
     // Try to authenticate against MongoDB
     match logic.authenticate_user(&req.email, &req.password).await {
         Ok(Some(user)) => {
-            let display = if user.mailbox.is_empty() { req.email.clone() } else { user.mailbox.clone() };
+            let display = if user.mailbox.is_empty() {
+                req.email.clone()
+            } else {
+                user.mailbox.clone()
+            };
             HttpResponse::Ok().json(make_session(&req.email, &display))
         }
         Ok(None) => {
@@ -356,7 +377,10 @@ async fn auth_register(
     req: web::Json<RegisterRequest>,
     logic: web::Data<Arc<Logic>>,
 ) -> impl Responder {
-    let display = req.display_name.clone().unwrap_or_else(|| req.email.split('@').next().unwrap_or("user").to_string());
+    let display = req
+        .display_name
+        .clone()
+        .unwrap_or_else(|| req.email.split('@').next().unwrap_or("user").to_string());
     // Try to create user in MongoDB
     match logic.create_user(&req.email, &req.password, "inbox").await {
         Ok(_) => HttpResponse::Ok().json(make_session(&req.email, &display)),
@@ -449,11 +473,7 @@ fn resolve_user_id(req: &actix_web::HttpRequest) -> String {
         .map(str::trim)
         .filter(|s| !s.is_empty())
     {
-        return email
-            .split('@')
-            .next()
-            .unwrap_or(email)
-            .to_string();
+        return email.split('@').next().unwrap_or(email).to_string();
     }
     env::var("SMTP_USERNAME").unwrap_or_else(|_| "admin".to_string())
 }
@@ -528,7 +548,9 @@ fn strip_tags(html: &str) -> String {
 fn email_to_dto(email: &Email, folder: &str, include_body: bool) -> EmailDto {
     let flags_l: Vec<String> = email.flags.iter().map(|f| f.to_ascii_lowercase()).collect();
     let is_read = flags_l.iter().any(|f| f == "seen" || f == "\\seen");
-    let is_starred = flags_l.iter().any(|f| f == "flagged" || f == "\\flagged" || f == "starred");
+    let is_starred = flags_l
+        .iter()
+        .any(|f| f == "flagged" || f == "\\flagged" || f == "starred");
     let body_type = if email.body.to_ascii_lowercase().contains("<html")
         || email.body.contains("</")
         || email.body.contains("<p")
@@ -641,7 +663,9 @@ async fn api_emails(
     let page_size = query.page_size.clamp(1, 100);
     // Over-fetch a single page-sized chunk per mailbox candidate, then merge.
     // Skip huge dumps: limit from Mongo already newest-first.
-    let fetch_limit = (page_size as i64).saturating_mul(page as i64).max(page_size as i64);
+    let fetch_limit = (page_size as i64)
+        .saturating_mul(page as i64)
+        .max(page_size as i64);
 
     let mut collected: Vec<Email> = Vec::new();
     for mailbox in folder_to_mailboxes(&folder) {
@@ -664,7 +688,12 @@ async fn api_emails(
     let mut seen = std::collections::HashSet::new();
     collected.retain(|e| {
         let key = if e.id.is_empty() {
-            format!("{}|{}|{}", e.from, e.subject, e.internal_date.timestamp_millis())
+            format!(
+                "{}|{}|{}",
+                e.from,
+                e.subject,
+                e.internal_date.timestamp_millis()
+            )
         } else {
             e.id.clone()
         };
@@ -788,40 +817,41 @@ async fn api_send(
     // both sign and deliver via Nodemailer — when no dkimSignature is
     // returned we treat success as "already delivered by dkim-service".
     let dkim_service: Box<dyn DkimService> = Box::new(RealDkimService);
-    let (dkim_sig, message_id_hdr, already_delivered) = match dkim_service.sign_email(&email_req).await {
-        Ok(dkim_result) => {
-            let status = dkim_result["status"].as_str().unwrap_or("");
-            if status != "success" {
-                let msg = dkim_result["message"]
+    let (dkim_sig, message_id_hdr, already_delivered) =
+        match dkim_service.sign_email(&email_req).await {
+            Ok(dkim_result) => {
+                let status = dkim_result["status"].as_str().unwrap_or("");
+                if status != "success" {
+                    let msg = dkim_result["message"]
+                        .as_str()
+                        .or_else(|| dkim_result["error"].as_str())
+                        .unwrap_or("DKIM signing failed");
+                    return HttpResponse::InternalServerError().json(serde_json::json!({
+                        "sent": false,
+                        "message": format!("Failed to sign email: {}", msg),
+                    }));
+                }
+                let sig = dkim_result["dkimSignature"]
                     .as_str()
-                    .or_else(|| dkim_result["error"].as_str())
-                    .unwrap_or("DKIM signing failed");
+                    .or_else(|| dkim_result["dkim_signature"].as_str())
+                    .unwrap_or("")
+                    .to_string();
+                let mid = dkim_result["messageId"]
+                    .as_str()
+                    .or_else(|| dkim_result["message_id"].as_str())
+                    .unwrap_or("")
+                    .to_string();
+                let delivered = sig.is_empty();
+                (sig, mid, delivered)
+            }
+            Err(e) => {
+                eprintln!("DKIM service error on /api/send: {}", e);
                 return HttpResponse::InternalServerError().json(serde_json::json!({
                     "sent": false,
-                    "message": format!("Failed to sign email: {}", msg),
+                    "message": "Failed to generate DKIM signature",
                 }));
             }
-            let sig = dkim_result["dkimSignature"]
-                .as_str()
-                .or_else(|| dkim_result["dkim_signature"].as_str())
-                .unwrap_or("")
-                .to_string();
-            let mid = dkim_result["messageId"]
-                .as_str()
-                .or_else(|| dkim_result["message_id"].as_str())
-                .unwrap_or("")
-                .to_string();
-            let delivered = sig.is_empty();
-            (sig, mid, delivered)
-        }
-        Err(e) => {
-            eprintln!("DKIM service error on /api/send: {}", e);
-            return HttpResponse::InternalServerError().json(serde_json::json!({
-                "sent": false,
-                "message": "Failed to generate DKIM signature",
-            }));
-        }
-    };
+        };
 
     let id = Uuid::new_v4().to_string();
     let message_id = if message_id_hdr.is_empty() {
@@ -834,10 +864,7 @@ async fn api_send(
 
     let mut headers = vec![
         ("Message-ID".to_string(), message_id.clone()),
-        (
-            "Date".to_string(),
-            Utc::now().to_rfc2822(),
-        ),
+        ("Date".to_string(), Utc::now().to_rfc2822()),
         ("MIME-Version".to_string(), "1.0".to_string()),
         (
             "Content-Type".to_string(),
@@ -1068,6 +1095,111 @@ async fn api_templates() -> impl Responder {
     HttpResponse::Ok().json(serde_json::json!({"templates": []}))
 }
 
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct HermesChatProxyRequest {
+    messages: Vec<serde_json::Value>,
+    #[serde(default)]
+    model: Option<String>,
+    #[serde(default)]
+    thread_id: Option<String>,
+    #[serde(default)]
+    user_id: Option<String>,
+    #[serde(default)]
+    temperature: Option<f32>,
+    #[serde(default)]
+    max_tokens: Option<u32>,
+}
+
+async fn api_hermes_chat(
+    req: HttpRequest,
+    body: web::Json<HermesChatProxyRequest>,
+) -> impl Responder {
+    if body.messages.is_empty() {
+        return HttpResponse::BadRequest().json(serde_json::json!({
+            "error": "messages is required"
+        }));
+    }
+
+    let base =
+        env::var("HERMES_BASE_URL").unwrap_or_else(|_| "http://172.16.12.2:8642".to_string());
+    let api_key = match env::var("HERMES_API_KEY") {
+        Ok(v) if !v.trim().is_empty() => v,
+        _ => {
+            return HttpResponse::InternalServerError().json(serde_json::json!({
+                "error": "HERMES_API_KEY is not configured"
+            }))
+        }
+    };
+
+    let url = format!("{}/v1/chat/completions", base.trim_end_matches('/'));
+    let model = body
+        .model
+        .clone()
+        .unwrap_or_else(|| env::var("HERMES_MODEL").unwrap_or_else(|_| "hermes-agent".to_string()));
+
+    let thread_id = body
+        .thread_id
+        .clone()
+        .filter(|s| !s.trim().is_empty())
+        .unwrap_or_else(|| Uuid::new_v4().to_string());
+
+    let fallback_user_id = resolve_user_id(&req);
+    let user_id = body
+        .user_id
+        .clone()
+        .filter(|s| !s.trim().is_empty())
+        .unwrap_or(fallback_user_id);
+
+    let mut payload = serde_json::json!({
+        "model": model,
+        "messages": body.messages,
+    });
+
+    if let Some(temp) = body.temperature {
+        payload["temperature"] = serde_json::json!(temp);
+    }
+    if let Some(max_tokens) = body.max_tokens {
+        payload["max_tokens"] = serde_json::json!(max_tokens);
+    }
+
+    let client = reqwest::Client::new();
+    let response = match client
+        .post(url)
+        .bearer_auth(api_key)
+        .header("X-Hermes-Session-Id", format!("mail-thread-{}", thread_id))
+        .header("X-Hermes-Session-Key", format!("user-{}", user_id))
+        .json(&payload)
+        .send()
+        .await
+    {
+        Ok(r) => r,
+        Err(e) => {
+            eprintln!("Hermes upstream request error: {}", e);
+            return HttpResponse::BadGateway().json(serde_json::json!({
+                "error": "Hermes upstream unavailable"
+            }));
+        }
+    };
+
+    let status = response.status();
+    let body_json = match response.json::<serde_json::Value>().await {
+        Ok(v) => v,
+        Err(e) => {
+            eprintln!("Hermes upstream JSON parse error: {}", e);
+            return HttpResponse::BadGateway().json(serde_json::json!({
+                "error": "Invalid Hermes upstream response"
+            }));
+        }
+    };
+
+    HttpResponse::build(
+        actix_web::http::StatusCode::from_u16(status.as_u16())
+            .unwrap_or(actix_web::http::StatusCode::BAD_GATEWAY),
+    )
+    .json(body_json)
+}
+
 // --- Calendar types ---
 
 #[derive(Deserialize)]
@@ -1075,8 +1207,8 @@ struct CreateCalendarEventRequest {
     title: String,
     #[serde(default)]
     description: String,
-    start: String,  // ISO 8601
-    end: String,    // ISO 8601
+    start: String, // ISO 8601
+    end: String,   // ISO 8601
     #[serde(default = "default_event_type_str")]
     event_type: String,
     #[serde(default = "default_color_str")]
@@ -1085,8 +1217,12 @@ struct CreateCalendarEventRequest {
     location: String,
 }
 
-fn default_event_type_str() -> String { "default".to_string() }
-fn default_color_str() -> String { "#3788d8".to_string() }
+fn default_event_type_str() -> String {
+    "default".to_string()
+}
+fn default_color_str() -> String {
+    "#3788d8".to_string()
+}
 
 #[derive(Deserialize)]
 struct UpdateCalendarEventRequest {
@@ -1109,9 +1245,9 @@ struct UpdateCalendarEventRequest {
 #[derive(Deserialize)]
 struct CalendarQueryParams {
     #[serde(default)]
-    start: Option<String>,  // ISO 8601
+    start: Option<String>, // ISO 8601
     #[serde(default)]
-    end: Option<String>,    // ISO 8601
+    end: Option<String>, // ISO 8601
 }
 
 fn parse_iso_to_bson(s: &str) -> Option<bson::DateTime> {
@@ -1122,7 +1258,11 @@ fn parse_iso_to_bson(s: &str) -> Option<bson::DateTime> {
 
 fn get_user_from_headers(req: &actix_web::HttpRequest) -> String {
     // Try x-user-email header, fallback to query param, fallback to env SMTP_USERNAME
-    if let Some(email) = req.headers().get("x-user-email").and_then(|v| v.to_str().ok()) {
+    if let Some(email) = req
+        .headers()
+        .get("x-user-email")
+        .and_then(|v| v.to_str().ok())
+    {
         return email.to_string();
     }
     // Fallback: use SMTP_USERNAME env var
@@ -1140,11 +1280,17 @@ async fn calendar_create_event(
 
     let start = match parse_iso_to_bson(&req_body.start) {
         Some(dt) => dt,
-        None => return HttpResponse::BadRequest().json(serde_json::json!({"error": "Invalid start date format, use ISO 8601"})),
+        None => {
+            return HttpResponse::BadRequest()
+                .json(serde_json::json!({"error": "Invalid start date format, use ISO 8601"}))
+        }
     };
     let end = match parse_iso_to_bson(&req_body.end) {
         Some(dt) => dt,
-        None => return HttpResponse::BadRequest().json(serde_json::json!({"error": "Invalid end date format, use ISO 8601"})),
+        None => {
+            return HttpResponse::BadRequest()
+                .json(serde_json::json!({"error": "Invalid end date format, use ISO 8601"}))
+        }
     };
 
     let mut event = CalendarEvent::new(&user, &req_body.title, start, end);
@@ -1157,7 +1303,8 @@ async fn calendar_create_event(
         Ok(_) => HttpResponse::Created().json(&event),
         Err(e) => {
             eprintln!("Calendar create error: {}", e);
-            HttpResponse::InternalServerError().json(serde_json::json!({"error": "Failed to create event"}))
+            HttpResponse::InternalServerError()
+                .json(serde_json::json!({"error": "Failed to create event"}))
         }
     }
 }
@@ -1172,11 +1319,17 @@ async fn calendar_list_events(
     let start_after = query.start.as_ref().and_then(|s| parse_iso_to_bson(s));
     let start_before = query.end.as_ref().and_then(|s| parse_iso_to_bson(s));
 
-    match logic.get_calendar_events(&user, start_after, start_before).await {
-        Ok(events) => HttpResponse::Ok().json(serde_json::json!({"events": events, "total": events.len()})),
+    match logic
+        .get_calendar_events(&user, start_after, start_before)
+        .await
+    {
+        Ok(events) => {
+            HttpResponse::Ok().json(serde_json::json!({"events": events, "total": events.len()}))
+        }
         Err(e) => {
             eprintln!("Calendar list error: {}", e);
-            HttpResponse::InternalServerError().json(serde_json::json!({"error": "Failed to list events"}))
+            HttpResponse::InternalServerError()
+                .json(serde_json::json!({"error": "Failed to list events"}))
         }
     }
 }
@@ -1194,7 +1347,8 @@ async fn calendar_get_event(
         Ok(None) => HttpResponse::NotFound().json(serde_json::json!({"error": "Event not found"})),
         Err(e) => {
             eprintln!("Calendar get error: {}", e);
-            HttpResponse::InternalServerError().json(serde_json::json!({"error": "Failed to get event"}))
+            HttpResponse::InternalServerError()
+                .json(serde_json::json!({"error": "Failed to get event"}))
         }
     }
 }
@@ -1209,26 +1363,47 @@ async fn calendar_update_event(
     let event_id = path.into_inner();
 
     let mut update = bson::Document::new();
-    if let Some(title) = &req_body.title { update.insert("title", title.clone()); }
-    if let Some(desc) = &req_body.description { update.insert("description", desc.clone()); }
+    if let Some(title) = &req_body.title {
+        update.insert("title", title.clone());
+    }
+    if let Some(desc) = &req_body.description {
+        update.insert("description", desc.clone());
+    }
     if let Some(start) = &req_body.start {
         match parse_iso_to_bson(start) {
-            Some(dt) => { update.insert("start", dt); }
-            None => return HttpResponse::BadRequest().json(serde_json::json!({"error": "Invalid start date format"})),
+            Some(dt) => {
+                update.insert("start", dt);
+            }
+            None => {
+                return HttpResponse::BadRequest()
+                    .json(serde_json::json!({"error": "Invalid start date format"}))
+            }
         }
     }
     if let Some(end) = &req_body.end {
         match parse_iso_to_bson(end) {
-            Some(dt) => { update.insert("end", dt); }
-            None => return HttpResponse::BadRequest().json(serde_json::json!({"error": "Invalid end date format"})),
+            Some(dt) => {
+                update.insert("end", dt);
+            }
+            None => {
+                return HttpResponse::BadRequest()
+                    .json(serde_json::json!({"error": "Invalid end date format"}))
+            }
         }
     }
-    if let Some(et) = &req_body.event_type { update.insert("event_type", et.clone()); }
-    if let Some(color) = &req_body.color { update.insert("color", color.clone()); }
-    if let Some(loc) = &req_body.location { update.insert("location", loc.clone()); }
+    if let Some(et) = &req_body.event_type {
+        update.insert("event_type", et.clone());
+    }
+    if let Some(color) = &req_body.color {
+        update.insert("color", color.clone());
+    }
+    if let Some(loc) = &req_body.location {
+        update.insert("location", loc.clone());
+    }
 
     if update.is_empty() {
-        return HttpResponse::BadRequest().json(serde_json::json!({"error": "No fields to update"}));
+        return HttpResponse::BadRequest()
+            .json(serde_json::json!({"error": "No fields to update"}));
     }
 
     match logic.update_calendar_event(&user, &event_id, update).await {
@@ -1236,7 +1411,8 @@ async fn calendar_update_event(
         Ok(None) => HttpResponse::NotFound().json(serde_json::json!({"error": "Event not found"})),
         Err(e) => {
             eprintln!("Calendar update error: {}", e);
-            HttpResponse::InternalServerError().json(serde_json::json!({"error": "Failed to update event"}))
+            HttpResponse::InternalServerError()
+                .json(serde_json::json!({"error": "Failed to update event"}))
         }
     }
 }
@@ -1253,7 +1429,8 @@ async fn calendar_delete_event(
         Ok(_) => HttpResponse::Ok().json(serde_json::json!({"deleted": true})),
         Err(e) => {
             eprintln!("Calendar delete error: {}", e);
-            HttpResponse::InternalServerError().json(serde_json::json!({"error": "Failed to delete event"}))
+            HttpResponse::InternalServerError()
+                .json(serde_json::json!({"error": "Failed to delete event"}))
         }
     }
 }
@@ -1265,13 +1442,20 @@ async fn main() -> std::io::Result<()> {
     // Connect to MongoDB for auth
     let mongo_user = env::var("MONGODB_USERNAME").unwrap_or_default();
     let mongo_pass = env::var("MONGODB_PASSWORD").unwrap_or_default();
-    let mongo_cluster = env::var("MONGODB_CLUSTER_URL").unwrap_or_else(|_| "mongodb:27017".to_string());
+    let mongo_cluster =
+        env::var("MONGODB_CLUSTER_URL").unwrap_or_else(|_| "mongodb:27017".to_string());
     let mongo_app = env::var("MONGODB_APP_NAME").unwrap_or_else(|_| "mailserver".to_string());
 
     let client_uri = if mongo_cluster.contains(".mongodb.net") {
-        format!("mongodb+srv://{}:{}@{}/?retryWrites=true&w=majority&appName={}", mongo_user, mongo_pass, mongo_cluster, mongo_app)
+        format!(
+            "mongodb+srv://{}:{}@{}/?retryWrites=true&w=majority&appName={}",
+            mongo_user, mongo_pass, mongo_cluster, mongo_app
+        )
     } else {
-        format!("mongodb://{}:{}@{}/?authSource=admin&appName={}", mongo_user, mongo_pass, mongo_cluster, mongo_app)
+        format!(
+            "mongodb://{}:{}@{}/?authSource=admin&appName={}",
+            mongo_user, mongo_pass, mongo_cluster, mongo_app
+        )
     };
 
     let use_mongodb = env::var("USE_MONGODB").unwrap_or_else(|_| "false".to_string()) == "true";
@@ -1289,19 +1473,28 @@ async fn main() -> std::io::Result<()> {
     };
 
     let fallback_client = Arc::new(
-        mongodb::Client::with_uri_str("mongodb://localhost:27017").await.unwrap()
+        mongodb::Client::with_uri_str("mongodb://localhost:27017")
+            .await
+            .unwrap(),
     );
-    let shared_mongo = mongo_client.clone().unwrap_or_else(|| fallback_client.clone());
+    let shared_mongo = mongo_client
+        .clone()
+        .unwrap_or_else(|| fallback_client.clone());
     let logic = web::Data::new(Arc::new(Logic::new(
-        mongo_client.unwrap_or(fallback_client)
+        mongo_client.unwrap_or(fallback_client),
     )));
     let mongo_data = web::Data::new(shared_mongo);
 
     let mut builder = SslAcceptor::mozilla_intermediate(SslMethod::tls()).unwrap();
     builder
-        .set_private_key_file(env::var("PRIVKEY_PATH").expect("PRIVKEY_PATH must be set"), SslFiletype::PEM)
+        .set_private_key_file(
+            env::var("PRIVKEY_PATH").expect("PRIVKEY_PATH must be set"),
+            SslFiletype::PEM,
+        )
         .unwrap();
-    builder.set_certificate_chain_file(env::var("FULLCHAIN_PATH").expect("FULLCHAIN_PATH must be set")).unwrap();
+    builder
+        .set_certificate_chain_file(env::var("FULLCHAIN_PATH").expect("FULLCHAIN_PATH must be set"))
+        .unwrap();
 
     // Start HTTP server on 8000 (for frontend proxy, no TLS)
     let http_logic = logic.clone();
@@ -1333,16 +1526,32 @@ async fn main() -> std::io::Result<()> {
                 .route("/api/templates", web::get().to(api_templates))
                 .route("/api/settings/ai", web::get().to(api_get_ai_settings))
                 .route("/api/settings/ai", web::put().to(api_put_ai_settings))
+                .route("/api/hermes/chat", web::post().to(api_hermes_chat))
                 .route("/api/send/undo", web::post().to(api_send))
                 .route("/api/send/schedule", web::post().to(api_send))
-                .route("/api/calendar/events", web::post().to(calendar_create_event))
+                .route(
+                    "/api/calendar/events",
+                    web::post().to(calendar_create_event),
+                )
                 .route("/api/calendar/events", web::get().to(calendar_list_events))
-                .route("/api/calendar/events/{id}", web::get().to(calendar_get_event))
-                .route("/api/calendar/events/{id}", web::put().to(calendar_update_event))
-                .route("/api/calendar/events/{id}", web::delete().to(calendar_delete_event))
+                .route(
+                    "/api/calendar/events/{id}",
+                    web::get().to(calendar_get_event),
+                )
+                .route(
+                    "/api/calendar/events/{id}",
+                    web::put().to(calendar_update_event),
+                )
+                .route(
+                    "/api/calendar/events/{id}",
+                    web::delete().to(calendar_delete_event),
+                )
                 .route("/send-email", web::post().to(send_email_handler))
                 .route("/create-mailing-list", web::post().to(create_mailing_list))
-                .route("/send-to-mailing-list", web::post().to(send_to_mailing_list))
+                .route(
+                    "/send-to-mailing-list",
+                    web::post().to(send_to_mailing_list),
+                )
         })
         .bind(http_addr)
         .expect("Failed to bind HTTP on 8000")
@@ -1366,7 +1575,10 @@ async fn main() -> std::io::Result<()> {
             .app_data(web::Data::new(RealDkimService))
             .route("/send-email", web::post().to(send_email_handler))
             .route("/create-mailing-list", web::post().to(create_mailing_list))
-            .route("/send-to-mailing-list", web::post().to(send_to_mailing_list))
+            .route(
+                "/send-to-mailing-list",
+                web::post().to(send_to_mailing_list),
+            )
     })
     .bind_openssl("0.0.0.0:8443", builder)?
     .run()
@@ -1378,8 +1590,8 @@ mod tests {
     use super::*;
     use actix_web::{test, App};
     use dotenv::dotenv;
-    use mockall::predicate::eq;
     use mockall::mock;
+    use mockall::predicate::eq;
 
     mock! {
         pub DkimService {
@@ -1389,7 +1601,10 @@ mod tests {
 
     #[async_trait::async_trait]
     impl DkimService for MockDkimService {
-        async fn sign_email(&self, email: &EmailRequest) -> Result<serde_json::Value, std::io::Error> {
+        async fn sign_email(
+            &self,
+            email: &EmailRequest,
+        ) -> Result<serde_json::Value, std::io::Error> {
             self.sign_email(email).await
         }
     }
@@ -1412,9 +1627,12 @@ mod tests {
 
         let app = test::init_service(
             App::new()
-            .app_data(web::Data::new(Box::new(mock_dkim_service) as Box<dyn DkimService>))
-            .route("/send-email", web::post().to(send_email_handler))
-        ).await;
+                .app_data(web::Data::new(
+                    Box::new(mock_dkim_service) as Box<dyn DkimService>
+                ))
+                .route("/send-email", web::post().to(send_email_handler)),
+        )
+        .await;
 
         let email_request = EmailRequest {
             from: "sender@example.com".to_string(),
@@ -1432,6 +1650,22 @@ mod tests {
         println!("Response status: {:?}", resp.status());
         assert!(resp.status().is_success());
     }
+
+    #[actix_web::test]
+    async fn test_api_hermes_chat_requires_messages() {
+        let app = test::init_service(
+            App::new().route("/api/hermes/chat", web::post().to(api_hermes_chat)),
+        )
+        .await;
+
+        let req = test::TestRequest::post()
+            .uri("/api/hermes/chat")
+            .set_json(serde_json::json!({ "messages": [] }))
+            .to_request();
+
+        let resp = test::call_service(&app, req).await;
+        assert_eq!(resp.status(), actix_web::http::StatusCode::BAD_REQUEST);
+    }
 }
 
 #[async_trait::async_trait]
@@ -1447,7 +1681,8 @@ impl DkimService for RealDkimService {
         let dkim_service_url = env::var("DKIM_SERVICE_URL").expect("DKIM_SERVICE_URL not set");
         let client = reqwest::Client::new();
 
-        let response = client.post(&dkim_service_url)
+        let response = client
+            .post(&dkim_service_url)
             .json(&serde_json::json!({
                 "from": email.from,
                 "to": email.to,
@@ -1459,9 +1694,15 @@ impl DkimService for RealDkimService {
             .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?;
 
         if response.status().is_success() {
-            response.json().await.map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))
+            response
+                .json()
+                .await
+                .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))
         } else {
-            Err(std::io::Error::new(std::io::ErrorKind::Other, "Failed to sign email"))
+            Err(std::io::Error::new(
+                std::io::ErrorKind::Other,
+                "Failed to sign email",
+            ))
         }
     }
 }

--- a/src/bin/email_api.rs
+++ b/src/bin/email_api.rs
@@ -1133,6 +1133,21 @@ struct HermesRunsProxyRequest {
     session_key: Option<String>,
 }
 
+fn normalize_hermes_base_url(raw: &str) -> String {
+    let trimmed = raw.trim().trim_end_matches('/');
+    if let Some(without_v1) = trimmed.strip_suffix("/v1") {
+        without_v1.to_string()
+    } else {
+        trimmed.to_string()
+    }
+}
+
+fn resolve_hermes_base_url() -> String {
+    let base =
+        env::var("HERMES_BASE_URL").unwrap_or_else(|_| "http://172.16.12.2:8642".to_string());
+    normalize_hermes_base_url(&base)
+}
+
 async fn api_hermes_chat(
     req: HttpRequest,
     body: web::Json<HermesChatProxyRequest>,
@@ -1143,8 +1158,7 @@ async fn api_hermes_chat(
         }));
     }
 
-    let base =
-        env::var("HERMES_BASE_URL").unwrap_or_else(|_| "http://172.16.12.2:8642".to_string());
+    let base = resolve_hermes_base_url();
     let api_key = match env::var("HERMES_API_KEY") {
         Ok(v) if !v.trim().is_empty() => v,
         _ => {
@@ -1154,7 +1168,7 @@ async fn api_hermes_chat(
         }
     };
 
-    let url = format!("{}/v1/chat/completions", base.trim_end_matches('/'));
+    let url = format!("{}/v1/chat/completions", base);
     let model = body
         .model
         .clone()
@@ -1247,8 +1261,7 @@ async fn api_hermes_runs(
         }
     };
 
-    let base =
-        env::var("HERMES_BASE_URL").unwrap_or_else(|_| "http://172.16.12.2:8642".to_string());
+    let base = resolve_hermes_base_url();
     let api_key = match env::var("HERMES_API_KEY") {
         Ok(v) if !v.trim().is_empty() => v,
         _ => {
@@ -1258,7 +1271,7 @@ async fn api_hermes_runs(
         }
     };
 
-    let url = format!("{}/v1/runs", base.trim_end_matches('/'));
+    let url = format!("{}/v1/runs", base);
     let model = body
         .model
         .clone()
@@ -1344,8 +1357,7 @@ async fn api_hermes_run_status(path: web::Path<HermesRunPath>) -> impl Responder
         }));
     }
 
-    let base =
-        env::var("HERMES_BASE_URL").unwrap_or_else(|_| "http://172.16.12.2:8642".to_string());
+    let base = resolve_hermes_base_url();
     let api_key = match env::var("HERMES_API_KEY") {
         Ok(v) if !v.trim().is_empty() => v,
         _ => {
@@ -1355,7 +1367,7 @@ async fn api_hermes_run_status(path: web::Path<HermesRunPath>) -> impl Responder
         }
     };
 
-    let url = format!("{}/v1/runs/{}", base.trim_end_matches('/'), run_id);
+    let url = format!("{}/v1/runs/{}", base, run_id);
 
     let client = reqwest::Client::new();
     let response = match client.get(url).bearer_auth(api_key).send().await {
@@ -1394,8 +1406,7 @@ async fn api_hermes_run_events(path: web::Path<HermesRunPath>, req: HttpRequest)
         }));
     }
 
-    let base =
-        env::var("HERMES_BASE_URL").unwrap_or_else(|_| "http://172.16.12.2:8642".to_string());
+    let base = resolve_hermes_base_url();
     let api_key = match env::var("HERMES_API_KEY") {
         Ok(v) if !v.trim().is_empty() => v,
         _ => {
@@ -1406,7 +1417,7 @@ async fn api_hermes_run_events(path: web::Path<HermesRunPath>, req: HttpRequest)
     };
 
     let query = req.query_string();
-    let mut url = format!("{}/v1/runs/{}/events", base.trim_end_matches('/'), run_id);
+    let mut url = format!("{}/v1/runs/{}/events", base, run_id);
     if !query.trim().is_empty() {
         url = format!("{}?{}", url, query);
     }
@@ -1996,6 +2007,30 @@ mod tests {
         assert_eq!(parsed.session_id.as_deref(), Some("mail-thread-explicit"));
         assert_eq!(parsed.session_key.as_deref(), Some("user-explicit"));
         assert_eq!(parsed.model.as_deref(), Some("hermes-agent"));
+    }
+
+    #[test]
+    fn test_normalize_hermes_base_url_strips_trailing_v1_and_slash() {
+        assert_eq!(
+            normalize_hermes_base_url("http://172.16.12.2:8642/v1/"),
+            "http://172.16.12.2:8642"
+        );
+        assert_eq!(
+            normalize_hermes_base_url("http://172.16.12.2:8642/v1"),
+            "http://172.16.12.2:8642"
+        );
+    }
+
+    #[test]
+    fn test_normalize_hermes_base_url_keeps_base_without_v1() {
+        assert_eq!(
+            normalize_hermes_base_url("http://172.16.12.2:8642"),
+            "http://172.16.12.2:8642"
+        );
+        assert_eq!(
+            normalize_hermes_base_url(" http://172.16.12.2:8642/ "),
+            "http://172.16.12.2:8642"
+        );
     }
 
     #[actix_web::test]

--- a/src/bin/email_api.rs
+++ b/src/bin/email_api.rs
@@ -1106,6 +1106,10 @@ struct HermesChatProxyRequest {
     #[serde(default)]
     user_id: Option<String>,
     #[serde(default)]
+    session_id: Option<String>,
+    #[serde(default)]
+    session_key: Option<String>,
+    #[serde(default)]
     temperature: Option<f32>,
     #[serde(default)]
     max_tokens: Option<u32>,
@@ -1151,6 +1155,18 @@ async fn api_hermes_chat(
         .filter(|s| !s.trim().is_empty())
         .unwrap_or(fallback_user_id);
 
+    let session_id = body
+        .session_id
+        .clone()
+        .filter(|s| !s.trim().is_empty())
+        .unwrap_or_else(|| format!("mail-thread-{}", thread_id));
+
+    let session_key = body
+        .session_key
+        .clone()
+        .filter(|s| !s.trim().is_empty())
+        .unwrap_or_else(|| format!("user-{}", user_id));
+
     let mut payload = serde_json::json!({
         "model": model,
         "messages": body.messages,
@@ -1167,8 +1183,8 @@ async fn api_hermes_chat(
     let response = match client
         .post(url)
         .bearer_auth(api_key)
-        .header("X-Hermes-Session-Id", format!("mail-thread-{}", thread_id))
-        .header("X-Hermes-Session-Key", format!("user-{}", user_id))
+        .header("X-Hermes-Session-Id", session_id)
+        .header("X-Hermes-Session-Key", session_key)
         .json(&payload)
         .send()
         .await
@@ -1665,6 +1681,25 @@ mod tests {
 
         let resp = test::call_service(&app, req).await;
         assert_eq!(resp.status(), actix_web::http::StatusCode::BAD_REQUEST);
+    }
+
+    #[test]
+    fn test_hermes_chat_request_accepts_explicit_session_overrides() {
+        let parsed: HermesChatProxyRequest = serde_json::from_value(serde_json::json!({
+            "messages": [{"role":"user","content":"hello"}],
+            "threadId": "thread-123",
+            "userId": "admin",
+            "sessionId": "mail-thread-explicit",
+            "sessionKey": "user-explicit",
+            "maxTokens": 1200
+        }))
+        .expect("HermesChatProxyRequest should deserialize");
+
+        assert_eq!(parsed.thread_id.as_deref(), Some("thread-123"));
+        assert_eq!(parsed.user_id.as_deref(), Some("admin"));
+        assert_eq!(parsed.session_id.as_deref(), Some("mail-thread-explicit"));
+        assert_eq!(parsed.session_key.as_deref(), Some("user-explicit"));
+        assert_eq!(parsed.max_tokens, Some(1200));
     }
 }
 


### PR DESCRIPTION
## Summary
- fix `/api/hermes/runs/{run_id}/events` gateway to stream SSE instead of buffering full upstream body
- keep query passthrough for stream flags
- preserve upstream status/content-type behavior:
  - success => streaming response (`bytes_stream` -> `HttpResponse::streaming`)
  - non-success => return upstream body text with upstream status
- update README note to mention SSE passthrough for live run updates

## Why
The previous implementation used `response.bytes().await`, which buffers the full upstream response and breaks long-lived SSE semantics.

## Validation
- `rustfmt --edition 2021 src/bin/email_api.rs` ✅
- ad-hoc verification script ✅
  - confirms `.bytes_stream()` + `.streaming(stream)`
  - confirms old buffering path `response.bytes().await` is removed
- local cargo test remains blocked by environment dependency (known): missing `pkg-config` / OpenSSL dev (`openssl-sys` build error)

## Stacking
- base branch: `feat/hermes-gateway-runs-read`
- this is a focused follow-up fix to #193.