### PR TITLE
fix(ci): gate deploy on successful compile and enable reqwest stream

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -79,10 +79,16 @@ jobs:
     needs: [test, build-push-smtp]
     runs-on: ubuntu-latest
     if: >-
-      always() &&
-      (github.event_name == 'push' && github.ref == 'refs/heads/master') ||
-       github.event_name == 'workflow_dispatch' ||
-       github.event_name == 'repository_dispatch'
+      needs.test.result == 'success' &&
+      (
+        (
+          (github.event_name == 'push' && github.ref == 'refs/heads/master') ||
+          github.event_name == 'workflow_dispatch'
+        ) &&
+        needs.build-push-smtp.result == 'success'
+        ||
+        github.event_name == 'repository_dispatch'
+      )
     steps:
       - uses: actions/checkout@v4
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ rustls = { version = "0.23.12", default-features = false, features = ["std", "aw
 webpki-roots = "1.0.9"
 trust-dns-resolver = "0.23.2"
 clap = "4.6.4"
-reqwest = { version = "0.13.4", features = ["json"] }
+reqwest = { version = "0.13.4", features = ["json", "stream"] }
 actix-cors = "0.7.0"
 bcrypt = "0.15"
 


### PR DESCRIPTION
## Summary
- fix deploy job condition: stop running deploy when compile job fails
- require successful build job for push/workflow_dispatch deploy paths
- keep repository_dispatch deploy path supported
- enable reqwest `stream` feature for `Response::bytes_stream()` used by Hermes events SSE proxy

## Validation
- ad-hoc workflow condition check: PASS
- cargo check --lib --bins: blocked locally by missing pkg-config/OpenSSL dev on this runner (known env limitation)

## Why
- latest master run failed compile but still deployed; this patch prevents unsafe deploy on red compile
- fixes compile error seen in CI: no method `bytes_stream` on reqwest::Response