### PR TITLE
fix(deploy): set footer build versions from deployed image digests

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -201,6 +201,29 @@ jobs:
             # Pull latest images from Scaleway Container Registry
             sudo docker pull "$INJECT_SCW_REGISTRY_ENDPOINT/smtp-server:latest"
             sudo docker pull "$INJECT_SCW_REGISTRY_ENDPOINT/dkim-service:latest"
+            sudo docker pull "$INJECT_SCW_REGISTRY_ENDPOINT/misfits-web:latest"
+
+            # Persist concrete deployed image digests into .env.deploy for footer traceability
+            upsert_env_file() {
+              key="$1"
+              val="$2"
+              file="/home/debian/.env.deploy"
+              if grep -q "^${key}=" "$file"; then
+                sed -i "s|^${key}=.*|${key}=${val}|" "$file"
+              else
+                printf "\n%s=%s\n" "$key" "$val" >> "$file"
+              fi
+            }
+
+            MISFITS_WEB_DIGEST=$(sudo docker image inspect "$INJECT_SCW_REGISTRY_ENDPOINT/misfits-web:latest" --format '{{index .RepoDigests 0}}' 2>/dev/null | sed 's|.*@||' || true)
+            SMTP_SERVER_DIGEST=$(sudo docker image inspect "$INJECT_SCW_REGISTRY_ENDPOINT/smtp-server:latest" --format '{{index .RepoDigests 0}}' 2>/dev/null | sed 's|.*@||' || true)
+
+            if [ -z "$MISFITS_WEB_DIGEST" ]; then MISFITS_WEB_DIGEST="unknown"; fi
+            if [ -z "$SMTP_SERVER_DIGEST" ]; then SMTP_SERVER_DIGEST="unknown"; fi
+
+            upsert_env_file NEXT_PUBLIC_MISFITS_WEB_BUILD_VERSION "misfits-web@${MISFITS_WEB_DIGEST}"
+            upsert_env_file NEXT_PUBLIC_REIMAGINED_GUIDE_BUILD_VERSION "reimagined-guide@${SMTP_SERVER_DIGEST}"
+            echo "Footer versions set in .env.deploy"
 
             # Source .env.deploy so docker compose can resolve ${VAR} in the YAML
             # (avoids misleading "variable is not set" warnings)

--- a/docker-compose.deploy.yml
+++ b/docker-compose.deploy.yml
@@ -172,6 +172,9 @@ services:
       - NEXT_TELEMETRY_DISABLED=1
       # Prefer email-api HTTP (used on next image rebuild)
       - BACKEND_URL=http://email-api:8000
+      # Build versions rendered in global footer
+      - NEXT_PUBLIC_MISFITS_WEB_BUILD_VERSION=${NEXT_PUBLIC_MISFITS_WEB_BUILD_VERSION:-unknown}
+      - NEXT_PUBLIC_REIMAGINED_GUIDE_BUILD_VERSION=${NEXT_PUBLIC_REIMAGINED_GUIDE_BUILD_VERSION:-unknown}
       # OpenRouter (server-only AI proxy /api/ai) — set in .env.deploy
       - OPENROUTER_API_KEY=${OPENROUTER_API_KEY:-}
       - AI_MODEL=${AI_MODEL:-qwen/qwen3.7-flash}


### PR DESCRIPTION
## Problème
Le footer global affiche actuellement:
`Build misfits-web: unknown|reimagined-guide: unknown`
car les variables de version ne sont pas injectées en runtime sur la VM de déploiement.

## Correctif
1. `docker-compose.deploy.yml`
- Passe les variables suivantes au container `misfits-web`:
  - `NEXT_PUBLIC_MISFITS_WEB_BUILD_VERSION`
  - `NEXT_PUBLIC_REIMAGINED_GUIDE_BUILD_VERSION`

2. `.github/workflows/cicd.yml` (job deploy, sur VM)
- Pull explicite de l’image `misfits-web:latest`.
- Lecture des digests réellement déployés via `docker image inspect`.
- Upsert dans `/home/debian/.env.deploy`:
  - `NEXT_PUBLIC_MISFITS_WEB_BUILD_VERSION=misfits-web@sha256:...`
  - `NEXT_PUBLIC_REIMAGINED_GUIDE_BUILD_VERSION=reimagined-guide@sha256:...`
- `source /home/debian/.env.deploy` avant `docker compose up`.

## Résultat attendu
Après ce pipeline, le footer affiche des versions déterministes basées sur les digests des images effectivement déployées (plus `unknown`).

## Validation
- Vérification ad-hoc du workflow: `AD_HOC_VERIFY=PASS`.
