### PR TITLE
fix(deploy): set runtime build vars for web footer

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -221,6 +221,8 @@ jobs:
             if [ -z "$MISFITS_WEB_DIGEST" ]; then MISFITS_WEB_DIGEST="unknown"; fi
             if [ -z "$SMTP_SERVER_DIGEST" ]; then SMTP_SERVER_DIGEST="unknown"; fi
 
+            upsert_env_file MISFITS_WEB_BUILD_VERSION "misfits-web@${MISFITS_WEB_DIGEST}"
+            upsert_env_file REIMAGINED_GUIDE_BUILD_VERSION "reimagined-guide@${SMTP_SERVER_DIGEST}"
             upsert_env_file NEXT_PUBLIC_MISFITS_WEB_BUILD_VERSION "misfits-web@${MISFITS_WEB_DIGEST}"
             upsert_env_file NEXT_PUBLIC_REIMAGINED_GUIDE_BUILD_VERSION "reimagined-guide@${SMTP_SERVER_DIGEST}"
             echo "Footer versions set in .env.deploy"

--- a/docker-compose.deploy.yml
+++ b/docker-compose.deploy.yml
@@ -173,6 +173,8 @@ services:
       # Prefer email-api HTTP (used on next image rebuild)
       - BACKEND_URL=http://email-api:8000
       # Build versions rendered in global footer
+      - MISFITS_WEB_BUILD_VERSION=${MISFITS_WEB_BUILD_VERSION:-unknown}
+      - REIMAGINED_GUIDE_BUILD_VERSION=${REIMAGINED_GUIDE_BUILD_VERSION:-unknown}
       - NEXT_PUBLIC_MISFITS_WEB_BUILD_VERSION=${NEXT_PUBLIC_MISFITS_WEB_BUILD_VERSION:-unknown}
       - NEXT_PUBLIC_REIMAGINED_GUIDE_BUILD_VERSION=${NEXT_PUBLIC_REIMAGINED_GUIDE_BUILD_VERSION:-unknown}
       # OpenRouter (server-only AI proxy /api/ai) — set in .env.deploy


### PR DESCRIPTION
## Correctif complémentaire
Le footer restait `unknown` malgré l’injection `NEXT_PUBLIC_*`.

Cause probable: les variables `NEXT_PUBLIC_*` peuvent être figées au build selon la manière dont Next standalone a été construit. Donc injection runtime seule peut ne pas suffire.

## Changement
- Ajout des variables runtime non-public dans `misfits-web` service:
  - `MISFITS_WEB_BUILD_VERSION`
  - `REIMAGINED_GUIDE_BUILD_VERSION`
- Le workflow deploy écrit désormais **aussi** ces 2 clés dans `.env.deploy` (en plus des `NEXT_PUBLIC_*`).

Les routes/footer côté misfits-web lisent déjà ces fallbacks runtime, donc l’affichage doit maintenant sortir de `unknown`.
