### PR TITLE
fix(api-send): avoid false 500 when DKIM service already delivered

### DIFF
--- a/src/bin/email_api.rs
+++ b/src/bin/email_api.rs
@@ -2072,7 +2072,14 @@ async fn api_send(
         },
     };
 
-    let send_result = send_outgoing_email(&email).await;
+    // If the DKIM service already delivered the message (success response
+    // without a dkim signature), skip direct SMTP relay. This prevents false
+    // negatives when relay ports are closed but delivery already happened.
+    let send_result = if already_delivered {
+        Ok(())
+    } else {
+        send_outgoing_email(&email).await
+    };
 
     match send_result {
         Ok(_) => {


### PR DESCRIPTION
## Summary
- Reproduced production API send failure on `https://mail.misfits.ai/api/send`:
  - `{"sent":false,"message":"Failed to send email: No open SMTP ports found"}`
- Fixed `/api/send` flow in Rust backend:
  - when DKIM service reports success but returns no `dkimSignature`, treat it as already delivered and skip direct `send_outgoing_email` relay.
- Preserve normal relay path when a DKIM signature is provided.

## Root cause
`api_send` computed `already_delivered` from DKIM response but ignored it, always attempting direct SMTP relay afterwards. In environments where relay ports are closed, this forced a 500 even though DKIM service may already have delivered.

## Validation
- Runtime repro (prod API): done, fails before fix with 500 and `No open SMTP ports found`.
- Local Rust tests in this environment are blocked by missing OpenSSL/pkg-config toolchain.

## Risk
- Low: conditional only changes the path where DKIM service already signaled successful delivery.
