### PR TITLE
feat(mail): add persistent mailbox action API

### DIFF
--- a/src/bin/email_api.rs
+++ b/src/bin/email_api.rs
@@ -1615,6 +1615,14 @@ fn folder_to_mailboxes(folder: &str) -> Vec<String> {
     }
 }
 
+fn canonical_folder(folder: &str) -> Option<String> {
+    let f = folder.trim().to_ascii_lowercase();
+    match f.as_str() {
+        "inbox" | "sent" | "drafts" | "archive" | "trash" | "spam" => Some(f),
+        _ => None,
+    }
+}
+
 /// Resolve mailbox local-part. Convention: user_id = `admin` (not admin@misfits.ai).
 fn resolve_user_id(req: &actix_web::HttpRequest) -> String {
     if let Some(id) = req
@@ -2354,6 +2362,73 @@ async fn api_email_by_id(
             eprintln!("fetch_email error: {}", e);
             HttpResponse::InternalServerError().json(serde_json::json!({
                 "message": "Failed to fetch email",
+            }))
+        }
+    }
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct EmailActionRequest {
+    action: String,
+    #[serde(default)]
+    target_folder: Option<String>,
+}
+
+async fn api_email_action(
+    path: web::Path<String>,
+    body: web::Json<EmailActionRequest>,
+    req: actix_web::HttpRequest,
+    logic: web::Data<Arc<Logic>>,
+) -> impl Responder {
+    let user_id = resolve_user_id(&req);
+    let email_id = path.into_inner();
+    let action = body.action.trim().to_ascii_lowercase();
+
+    let result = match action.as_str() {
+        "archive" => logic.move_email_to_mailbox(&user_id, &email_id, "archive").await,
+        "trash" | "delete" => logic.move_email_to_mailbox(&user_id, &email_id, "trash").await,
+        "restore" => logic.move_email_to_mailbox(&user_id, &email_id, "inbox").await,
+        "move" => {
+            let Some(target) = body
+                .target_folder
+                .as_ref()
+                .and_then(|f| canonical_folder(f))
+            else {
+                return HttpResponse::BadRequest().json(serde_json::json!({
+                    "ok": false,
+                    "message": "targetFolder must be one of inbox|sent|drafts|archive|trash|spam",
+                }));
+            };
+            logic.move_email_to_mailbox(&user_id, &email_id, &target).await
+        }
+        "markread" => logic.set_email_read(&user_id, &email_id, true).await,
+        "markunread" => logic.set_email_read(&user_id, &email_id, false).await,
+        "star" => logic.set_email_starred(&user_id, &email_id, true).await,
+        "unstar" => logic.set_email_starred(&user_id, &email_id, false).await,
+        _ => {
+            return HttpResponse::BadRequest().json(serde_json::json!({
+                "ok": false,
+                "message": "Unsupported action. Use move|archive|trash|delete|restore|markRead|markUnread|star|unstar",
+            }))
+        }
+    };
+
+    match result {
+        Ok(true) => HttpResponse::Ok().json(serde_json::json!({
+            "ok": true,
+            "id": email_id,
+            "action": body.action,
+        })),
+        Ok(false) => HttpResponse::NotFound().json(serde_json::json!({
+            "ok": false,
+            "message": "Email not found",
+        })),
+        Err(e) => {
+            eprintln!("api_email_action error: {}", e);
+            HttpResponse::InternalServerError().json(serde_json::json!({
+                "ok": false,
+                "message": "Failed to apply email action",
             }))
         }
     }
@@ -3236,6 +3311,7 @@ async fn main() -> std::io::Result<()> {
                 )
                 .route("/api/emails", web::get().to(api_emails))
                 .route("/api/emails/{id}", web::get().to(api_email_by_id))
+                .route("/api/emails/{id}/action", web::post().to(api_email_action))
                 .route("/api/tags", web::get().to(api_tags))
                 .route("/api/send", web::post().to(api_send))
                 .route("/api/send/{id}/status", web::get().to(api_send_status))

--- a/src/logic/mod.rs
+++ b/src/logic/mod.rs
@@ -449,6 +449,89 @@ impl Logic {
         }
     }
 
+    pub async fn move_email_to_mailbox(
+        &self,
+        username: &str,
+        email_id: &str,
+        mailbox: &str,
+    ) -> Result<bool> {
+        #[cfg(not(test))]
+        {
+            let database_name =
+                std::env::var("MONGODB_DATABASE").expect("MONGODB_DATABASE must be set");
+            let collection = self
+                .client
+                .database(&database_name)
+                .collection::<Email>("emails");
+            let filter = doc! { "user_id": username, "id": email_id };
+            let update = doc! { "$set": { "mailbox": mailbox.to_ascii_lowercase() } };
+            let res = collection.update_one(filter, update).await?;
+            Ok(res.matched_count > 0)
+        }
+        #[cfg(test)]
+        {
+            Ok(true)
+        }
+    }
+
+    pub async fn set_email_read(
+        &self,
+        username: &str,
+        email_id: &str,
+        is_read: bool,
+    ) -> Result<bool> {
+        #[cfg(not(test))]
+        {
+            let database_name =
+                std::env::var("MONGODB_DATABASE").expect("MONGODB_DATABASE must be set");
+            let collection = self
+                .client
+                .database(&database_name)
+                .collection::<Email>("emails");
+            let filter = doc! { "user_id": username, "id": email_id };
+            let update = if is_read {
+                doc! { "$addToSet": { "flags": "\\Seen" } }
+            } else {
+                doc! { "$pull": { "flags": { "$in": ["\\Seen", "Seen", "seen"] } } }
+            };
+            let res = collection.update_one(filter, update).await?;
+            Ok(res.matched_count > 0)
+        }
+        #[cfg(test)]
+        {
+            Ok(true)
+        }
+    }
+
+    pub async fn set_email_starred(
+        &self,
+        username: &str,
+        email_id: &str,
+        is_starred: bool,
+    ) -> Result<bool> {
+        #[cfg(not(test))]
+        {
+            let database_name =
+                std::env::var("MONGODB_DATABASE").expect("MONGODB_DATABASE must be set");
+            let collection = self
+                .client
+                .database(&database_name)
+                .collection::<Email>("emails");
+            let filter = doc! { "user_id": username, "id": email_id };
+            let update = if is_starred {
+                doc! { "$addToSet": { "flags": "\\Flagged" } }
+            } else {
+                doc! { "$pull": { "flags": { "$in": ["\\Flagged", "Flagged", "flagged", "starred"] } } }
+            };
+            let res = collection.update_one(filter, update).await?;
+            Ok(res.matched_count > 0)
+        }
+        #[cfg(test)]
+        {
+            Ok(true)
+        }
+    }
+
     pub async fn delete_email(&self, username: &str, email_id: &str) -> Result<()> {
         #[cfg(not(test))]
         {


### PR DESCRIPTION
## Summary
- add backend mailbox action endpoint `POST /api/emails/{id}/action`
- support actions: `move`, `archive`, `trash`/`delete`, `restore`, `markRead`, `markUnread`, `star`, `unstar`
- persist actions in Mongo via new logic helpers:
  - `move_email_to_mailbox`
  - `set_email_read`
  - `set_email_starred`
- add folder canonicalization guard for `targetFolder`

## Why
Current frontend mailbox state can diverge from server because key actions are local-only. This adds a server source-of-truth API for mailbox state transitions.

## Validation
- static diff review completed
- local compile check is blocked in this environment (missing `pkg-config`/OpenSSL dev stack for Rust build)
- CI should validate compile/tests on runner

## Next
- wire misfits-web hooks to this endpoint (m2)
