### PR TITLE
fix(send): prevent /api/send panic on STARTTLS

### DIFF
--- a/src/bin/email_api.rs
+++ b/src/bin/email_api.rs
@@ -3389,6 +3389,11 @@ async fn calendar_delete_event(
 async fn main() -> std::io::Result<()> {
     dotenv().ok();
 
+    // rustls 0.23 requires an explicit process-level CryptoProvider.
+    rustls::crypto::aws_lc_rs::default_provider()
+        .install_default()
+        .expect("failed to install rustls CryptoProvider");
+
     // Connect to MongoDB for auth
     let mongo_user = env::var("MONGODB_USERNAME").unwrap_or_default();
     let mongo_pass = env::var("MONGODB_PASSWORD").unwrap_or_default();


### PR DESCRIPTION
## Summary
- install rustls aws-lc CryptoProvider at email_api startup
- fixes panic during STARTTLS in direct-MX send path

## Symptom fixed
-  returned 502 (Caddy EOF)
- email-api logs showed rustls panic: CryptoProvider not installed
