### PR TITLE
feat(api): external IMAP aggregation endpoints + OpenAPI v3

### DIFF
--- a/ops/openapi/external-imap-v1.yaml
+++ b/ops/openapi/external-imap-v1.yaml
@@ -1,0 +1,534 @@
+openapi: 3.0.3
+info:
+  title: Misfits Mail External IMAP Aggregation API
+  version: 1.0.0
+servers:
+  - url: https://mail.misfits.ai
+  - url: http://127.0.0.1:8000
+paths:
+  /api/openapi/external-imap.yaml:
+    get:
+      summary: Get this OpenAPI specification
+      responses:
+        '200':
+          description: OpenAPI YAML
+          content:
+            application/yaml:
+              schema:
+                type: string
+  /api/external-accounts:
+    get:
+      summary: List external IMAP accounts
+      responses:
+        '200':
+          description: External accounts
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  accounts:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/ExternalImapAccount'
+    post:
+      summary: Create external IMAP account
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateExternalAccountInput'
+      responses:
+        '200':
+          description: External account created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ExternalImapAccount'
+  /api/external-accounts/{id}:
+    get:
+      summary: Get external account
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema: { type: string }
+      responses:
+        '200':
+          description: External account
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ExternalImapAccount'
+        '404':
+          $ref: '#/components/responses/NotFound'
+    patch:
+      summary: Update external account
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema: { type: string }
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpdateExternalAccountInput'
+      responses:
+        '200':
+          description: External account updated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ExternalImapAccount'
+        '404':
+          $ref: '#/components/responses/NotFound'
+    delete:
+      summary: Delete external account
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema: { type: string }
+      responses:
+        '200':
+          description: Deleted
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  deleted:
+                    type: boolean
+        '404':
+          $ref: '#/components/responses/NotFound'
+  /api/external-accounts/{id}/test:
+    post:
+      summary: Test IMAP auth/capabilities
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema: { type: string }
+      responses:
+        '200':
+          description: IMAP test result
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ImapTestResult'
+        '422':
+          description: IMAP auth failed
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorEnvelope'
+  /api/external-accounts/{id}/folders:
+    get:
+      summary: List external folders
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema: { type: string }
+      responses:
+        '200':
+          description: Folders
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  folders:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/ExternalImapFolder'
+  /api/external-accounts/{id}/folders/discover:
+    post:
+      summary: Discover folders from remote IMAP
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema: { type: string }
+      responses:
+        '200':
+          description: Discovery result
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ImapDiscoverResult'
+  /api/external-accounts/{id}/folders/{folder_id}/mapping:
+    put:
+      summary: Set local role mapping for a folder
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema: { type: string }
+        - in: path
+          name: folder_id
+          required: true
+          schema: { type: string }
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ExternalFolderMappingInput'
+      responses:
+        '200':
+          description: Mapping updated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ExternalImapFolder'
+  /api/external-accounts/{id}/sync:
+    post:
+      summary: Trigger sync now
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema: { type: string }
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/StartSyncInput'
+      responses:
+        '200':
+          description: Sync completed
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  runId: { type: string }
+                  status: { type: string }
+                  run:
+                    $ref: '#/components/schemas/ExternalSyncRun'
+  /api/external-accounts/{id}/sync/status:
+    get:
+      summary: Latest sync status for account
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema: { type: string }
+      responses:
+        '200':
+          description: Latest sync run
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - $ref: '#/components/schemas/ExternalSyncRun'
+                  - type: object
+                    properties:
+                      status:
+                        type: string
+                        example: idle
+  /api/external-accounts/{id}/sync/pause:
+    post:
+      summary: Pause account sync
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema: { type: string }
+      responses:
+        '200':
+          description: Account paused
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ExternalImapAccount'
+  /api/external-accounts/{id}/sync/resume:
+    post:
+      summary: Resume account sync
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema: { type: string }
+      responses:
+        '200':
+          description: Account resumed
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ExternalImapAccount'
+  /api/external-sync-runs/{run_id}:
+    get:
+      summary: Get sync run by id
+      parameters:
+        - in: path
+          name: run_id
+          required: true
+          schema: { type: string }
+      responses:
+        '200':
+          description: Sync run
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ExternalSyncRun'
+        '404':
+          $ref: '#/components/responses/NotFound'
+  /api/external-messages:
+    get:
+      summary: List external messages
+      parameters:
+        - in: query
+          name: accountId
+          required: true
+          schema: { type: string }
+        - in: query
+          name: folder
+          required: false
+          schema: { type: string }
+        - in: query
+          name: page
+          required: false
+          schema: { type: integer, minimum: 1, default: 1 }
+        - in: query
+          name: pageSize
+          required: false
+          schema: { type: integer, minimum: 1, maximum: 200, default: 50 }
+      responses:
+        '200':
+          description: Message page
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  messages:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/ExternalImapMessage'
+                  page:
+                    type: integer
+                  pageSize:
+                    type: integer
+  /api/external-messages/{id}/action:
+    post:
+      summary: Apply external message action
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema: { type: string }
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ExternalMessageActionInput'
+      responses:
+        '200':
+          description: Updated message
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ExternalImapMessage'
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+components:
+  responses:
+    NotFound:
+      description: Resource not found
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorEnvelope'
+  schemas:
+    ErrorEnvelope:
+      type: object
+      properties:
+        error:
+          type: object
+          properties:
+            code: { type: string }
+            message: { type: string }
+
+    CreateExternalAccountInput:
+      type: object
+      required: [provider, email, authType, imap]
+      properties:
+        provider: { type: string }
+        email: { type: string, format: email }
+        authType: { type: string, enum: [oauth2, app_password, password] }
+        imap:
+          $ref: '#/components/schemas/ExternalImapServerConfig'
+        smtp:
+          $ref: '#/components/schemas/ExternalSmtpServerConfig'
+        credentials:
+          $ref: '#/components/schemas/ExternalAccountCredentials'
+
+    UpdateExternalAccountInput:
+      type: object
+      properties:
+        provider: { type: string }
+        email: { type: string, format: email }
+        authType: { type: string }
+        status: { type: string, enum: [active, paused, error] }
+        imap:
+          $ref: '#/components/schemas/ExternalImapServerConfig'
+        smtp:
+          $ref: '#/components/schemas/ExternalSmtpServerConfig'
+        credentials:
+          $ref: '#/components/schemas/ExternalAccountCredentials'
+        lastError: { type: string }
+
+    ExternalImapServerConfig:
+      type: object
+      required: [host, port, tls]
+      properties:
+        host: { type: string }
+        port: { type: integer }
+        tls: { type: boolean }
+
+    ExternalSmtpServerConfig:
+      type: object
+      properties:
+        host: { type: string }
+        port: { type: integer }
+        tls: { type: boolean }
+
+    ExternalAccountCredentials:
+      type: object
+      properties:
+        secretValue: { type: string, description: "MVP storage, redacted in read APIs" }
+        secretRef: { type: string }
+
+    ExternalImapAccount:
+      type: object
+      properties:
+        id: { type: string }
+        ownerUserId: { type: string }
+        provider: { type: string }
+        email: { type: string, format: email }
+        authType: { type: string }
+        secretRef: { type: string, nullable: true }
+        secretValue: { type: string, nullable: true }
+        imapHost: { type: string }
+        imapPort: { type: integer }
+        imapTls: { type: boolean }
+        smtpHost: { type: string, nullable: true }
+        smtpPort: { type: integer, nullable: true }
+        smtpTls: { type: boolean, nullable: true }
+        status: { type: string }
+        lastSyncAt: { type: string, format: date-time, nullable: true }
+        lastError: { type: string, nullable: true }
+        createdAt: { type: string, format: date-time }
+        updatedAt: { type: string, format: date-time }
+
+    ExternalImapFolder:
+      type: object
+      properties:
+        id: { type: string }
+        accountId: { type: string }
+        ownerUserId: { type: string }
+        remoteName: { type: string }
+        localRole: { type: string }
+        uidValidity: { type: integer, nullable: true }
+        highestUid: { type: integer, nullable: true }
+        highestModseq: { type: integer, nullable: true }
+        createdAt: { type: string, format: date-time }
+        updatedAt: { type: string, format: date-time }
+
+    ExternalImapMessage:
+      type: object
+      properties:
+        id: { type: string }
+        accountId: { type: string }
+        folderId: { type: string, nullable: true }
+        ownerUserId: { type: string }
+        remoteUid: { type: integer, nullable: true }
+        messageIdHeader: { type: string, nullable: true }
+        threadKey: { type: string, nullable: true }
+        from: { type: string, nullable: true }
+        to: { type: string, nullable: true }
+        subject: { type: string, nullable: true }
+        sentAt: { type: string, format: date-time, nullable: true }
+        flags:
+          type: array
+          items: { type: string }
+        internalDate: { type: string, format: date-time, nullable: true }
+        bodyPreview: { type: string, nullable: true }
+        rawRef: { type: string, nullable: true }
+        dedupHash: { type: string, nullable: true }
+        deleted: { type: boolean }
+        createdAt: { type: string, format: date-time }
+        updatedAt: { type: string, format: date-time }
+
+    ExternalSyncRun:
+      type: object
+      properties:
+        id: { type: string }
+        accountId: { type: string }
+        ownerUserId: { type: string }
+        mode: { type: string, enum: [full, incremental] }
+        folders:
+          type: array
+          items: { type: string }
+        since: { type: string, format: date-time, nullable: true }
+        status: { type: string, enum: [running, success, failed, partial] }
+        statsFetched: { type: integer }
+        statsUpdated: { type: integer }
+        statsDeleted: { type: integer }
+        startedAt: { type: string, format: date-time }
+        endedAt: { type: string, format: date-time, nullable: true }
+        error: { type: string, nullable: true }
+
+    ImapTestResult:
+      type: object
+      properties:
+        ok: { type: boolean }
+        capabilities:
+          type: array
+          items: { type: string }
+        greeting: { type: string }
+        message: { type: string }
+
+    ImapDiscoverResult:
+      type: object
+      properties:
+        folders:
+          type: array
+          items: { type: string }
+        capabilities:
+          type: array
+          items: { type: string }
+
+    ExternalFolderMappingInput:
+      type: object
+      required: [localRole]
+      properties:
+        localRole: { type: string }
+
+    StartSyncInput:
+      type: object
+      required: [mode]
+      properties:
+        mode: { type: string, enum: [full, incremental] }
+        folders:
+          type: array
+          items: { type: string }
+        since: { type: string, format: date-time }
+
+    ExternalMessageActionInput:
+      type: object
+      required: [action]
+      properties:
+        action:
+          type: string
+          enum: [mark_read, mark_unread, star, unstar, move, delete, archive]
+        targetFolder:
+          type: string

--- a/src/bin/email_api.rs
+++ b/src/bin/email_api.rs
@@ -49,6 +49,10 @@ use mongodb::bson;
 use mongodb::bson::doc;
 use reqwest;
 use simple_smtp_server::entities::{CalendarEvent, Email};
+use simple_smtp_server::external_imap::{
+    CreateExternalAccountInput, ExternalImapService, ExternalMessageActionInput,
+    ExternalFolderMappingInput, StartSyncInput, UpdateExternalAccountInput,
+};
 use simple_smtp_server::logic::Logic;
 use simple_smtp_server::smtp_client::send_outgoing_email;
 use std::collections::HashMap;
@@ -3153,6 +3157,328 @@ async fn api_hermes_run_events(path: web::Path<HermesRunPath>, req: HttpRequest)
 // --- Calendar types ---
 
 #[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct ExternalMessagesQuery {
+    account_id: String,
+    folder: Option<String>,
+    page: Option<u64>,
+    page_size: Option<u64>,
+}
+
+async fn api_external_openapi() -> impl Responder {
+    static OPENAPI_YAML: &str = include_str!("../../ops/openapi/external-imap-v1.yaml");
+    HttpResponse::Ok()
+        .content_type("application/yaml; charset=utf-8")
+        .body(OPENAPI_YAML)
+}
+
+async fn api_external_accounts_list(
+    req: HttpRequest,
+    svc: web::Data<Arc<ExternalImapService>>,
+) -> impl Responder {
+    let user_id = resolve_user_id(&req);
+    match svc.list_accounts(&user_id).await {
+        Ok(accounts) => HttpResponse::Ok().json(serde_json::json!({ "accounts": accounts })),
+        Err(e) => HttpResponse::InternalServerError()
+            .json(serde_json::json!({"error": {"code": "EXTERNAL_ACCOUNTS_LIST_FAILED", "message": e.to_string()}})),
+    }
+}
+
+async fn api_external_accounts_create(
+    req: HttpRequest,
+    payload: web::Json<CreateExternalAccountInput>,
+    svc: web::Data<Arc<ExternalImapService>>,
+) -> impl Responder {
+    let user_id = resolve_user_id(&req);
+    match svc.create_account(&user_id, payload.into_inner()).await {
+        Ok(account) => HttpResponse::Ok().json(account),
+        Err(e) => HttpResponse::InternalServerError()
+            .json(serde_json::json!({"error": {"code": "EXTERNAL_ACCOUNT_CREATE_FAILED", "message": e.to_string()}})),
+    }
+}
+
+async fn api_external_account_get(
+    req: HttpRequest,
+    path: web::Path<String>,
+    svc: web::Data<Arc<ExternalImapService>>,
+) -> impl Responder {
+    let user_id = resolve_user_id(&req);
+    let account_id = path.into_inner();
+    match svc.get_account(&user_id, &account_id).await {
+        Ok(Some(account)) => HttpResponse::Ok().json(account),
+        Ok(None) => HttpResponse::NotFound().json(serde_json::json!({"error": {"code": "EXTERNAL_ACCOUNT_NOT_FOUND", "message": "External account not found"}})),
+        Err(e) => HttpResponse::InternalServerError()
+            .json(serde_json::json!({"error": {"code": "EXTERNAL_ACCOUNT_FETCH_FAILED", "message": e.to_string()}})),
+    }
+}
+
+async fn api_external_account_patch(
+    req: HttpRequest,
+    path: web::Path<String>,
+    payload: web::Json<UpdateExternalAccountInput>,
+    svc: web::Data<Arc<ExternalImapService>>,
+) -> impl Responder {
+    let user_id = resolve_user_id(&req);
+    let account_id = path.into_inner();
+    match svc
+        .update_account(&user_id, &account_id, payload.into_inner())
+        .await
+    {
+        Ok(Some(account)) => HttpResponse::Ok().json(account),
+        Ok(None) => HttpResponse::NotFound().json(serde_json::json!({"error": {"code": "EXTERNAL_ACCOUNT_NOT_FOUND", "message": "External account not found"}})),
+        Err(e) => HttpResponse::InternalServerError()
+            .json(serde_json::json!({"error": {"code": "EXTERNAL_ACCOUNT_UPDATE_FAILED", "message": e.to_string()}})),
+    }
+}
+
+async fn api_external_account_delete(
+    req: HttpRequest,
+    path: web::Path<String>,
+    svc: web::Data<Arc<ExternalImapService>>,
+) -> impl Responder {
+    let user_id = resolve_user_id(&req);
+    let account_id = path.into_inner();
+    match svc.delete_account(&user_id, &account_id).await {
+        Ok(true) => HttpResponse::Ok().json(serde_json::json!({ "deleted": true })),
+        Ok(false) => HttpResponse::NotFound().json(serde_json::json!({"error": {"code": "EXTERNAL_ACCOUNT_NOT_FOUND", "message": "External account not found"}})),
+        Err(e) => HttpResponse::InternalServerError()
+            .json(serde_json::json!({"error": {"code": "EXTERNAL_ACCOUNT_DELETE_FAILED", "message": e.to_string()}})),
+    }
+}
+
+async fn api_external_account_test(
+    req: HttpRequest,
+    path: web::Path<String>,
+    svc: web::Data<Arc<ExternalImapService>>,
+) -> impl Responder {
+    let user_id = resolve_user_id(&req);
+    let account_id = path.into_inner();
+    let account = match svc.get_account_raw(&user_id, &account_id).await {
+        Ok(Some(a)) => a,
+        Ok(None) => return HttpResponse::NotFound().json(serde_json::json!({"error": {"code": "EXTERNAL_ACCOUNT_NOT_FOUND", "message": "External account not found"}})),
+        Err(e) => return HttpResponse::InternalServerError().json(serde_json::json!({"error": {"code": "EXTERNAL_ACCOUNT_FETCH_FAILED", "message": e.to_string()}})),
+    };
+
+    match svc.imap_test(&account).await {
+        Ok(result) => {
+            if result.ok {
+                HttpResponse::Ok().json(result)
+            } else {
+                HttpResponse::UnprocessableEntity().json(serde_json::json!({
+                    "ok": false,
+                    "error": {"code": "IMAP_AUTH_FAILED", "message": result.message},
+                    "capabilities": result.capabilities,
+                    "greeting": result.greeting,
+                }))
+            }
+        }
+        Err(e) => HttpResponse::InternalServerError()
+            .json(serde_json::json!({"error": {"code": "IMAP_TEST_FAILED", "message": e.to_string()}})),
+    }
+}
+
+async fn api_external_folders_list(
+    req: HttpRequest,
+    path: web::Path<String>,
+    svc: web::Data<Arc<ExternalImapService>>,
+) -> impl Responder {
+    let user_id = resolve_user_id(&req);
+    let account_id = path.into_inner();
+    match svc.list_folders(&user_id, &account_id).await {
+        Ok(folders) => HttpResponse::Ok().json(serde_json::json!({ "folders": folders })),
+        Err(e) => HttpResponse::InternalServerError()
+            .json(serde_json::json!({"error": {"code": "EXTERNAL_FOLDERS_LIST_FAILED", "message": e.to_string()}})),
+    }
+}
+
+async fn api_external_folders_discover(
+    req: HttpRequest,
+    path: web::Path<String>,
+    svc: web::Data<Arc<ExternalImapService>>,
+) -> impl Responder {
+    let user_id = resolve_user_id(&req);
+    let account_id = path.into_inner();
+    let account = match svc.get_account_raw(&user_id, &account_id).await {
+        Ok(Some(a)) => a,
+        Ok(None) => return HttpResponse::NotFound().json(serde_json::json!({"error": {"code": "EXTERNAL_ACCOUNT_NOT_FOUND", "message": "External account not found"}})),
+        Err(e) => return HttpResponse::InternalServerError().json(serde_json::json!({"error": {"code": "EXTERNAL_ACCOUNT_FETCH_FAILED", "message": e.to_string()}})),
+    };
+
+    match svc.discover_folders(&user_id, &account).await {
+        Ok(result) => HttpResponse::Ok().json(result),
+        Err(e) => HttpResponse::InternalServerError()
+            .json(serde_json::json!({"error": {"code": "EXTERNAL_FOLDERS_DISCOVER_FAILED", "message": e.to_string()}})),
+    }
+}
+
+async fn api_external_folder_mapping_put(
+    req: HttpRequest,
+    path: web::Path<(String, String)>,
+    payload: web::Json<ExternalFolderMappingInput>,
+    svc: web::Data<Arc<ExternalImapService>>,
+) -> impl Responder {
+    let user_id = resolve_user_id(&req);
+    let (account_id, folder_id) = path.into_inner();
+    match svc
+        .upsert_folder_mapping(&user_id, &account_id, &folder_id, &payload.local_role)
+        .await
+    {
+        Ok(Some(folder)) => HttpResponse::Ok().json(folder),
+        Ok(None) => HttpResponse::NotFound().json(serde_json::json!({"error": {"code": "EXTERNAL_FOLDER_NOT_FOUND", "message": "Folder not found"}})),
+        Err(e) => HttpResponse::InternalServerError()
+            .json(serde_json::json!({"error": {"code": "EXTERNAL_FOLDER_MAPPING_FAILED", "message": e.to_string()}})),
+    }
+}
+
+async fn api_external_sync_start(
+    req: HttpRequest,
+    path: web::Path<String>,
+    payload: web::Json<StartSyncInput>,
+    svc: web::Data<Arc<ExternalImapService>>,
+) -> impl Responder {
+    let user_id = resolve_user_id(&req);
+    let account_id = path.into_inner();
+
+    let account = match svc.get_account_raw(&user_id, &account_id).await {
+        Ok(Some(a)) => a,
+        Ok(None) => return HttpResponse::NotFound().json(serde_json::json!({"error": {"code": "EXTERNAL_ACCOUNT_NOT_FOUND", "message": "External account not found"}})),
+        Err(e) => return HttpResponse::InternalServerError().json(serde_json::json!({"error": {"code": "EXTERNAL_ACCOUNT_FETCH_FAILED", "message": e.to_string()}})),
+    };
+
+    let run = match svc.start_sync_run(&user_id, &account_id, &payload).await {
+        Ok(run) => run,
+        Err(e) => return HttpResponse::InternalServerError().json(serde_json::json!({"error": {"code": "EXTERNAL_SYNC_START_FAILED", "message": e.to_string()}})),
+    };
+
+    match svc.run_sync_now(&user_id, &account, &run).await {
+        Ok(stats) => {
+            let updated = svc
+                .complete_sync_run(&user_id, &run.id, "success", stats, None)
+                .await
+                .ok()
+                .flatten();
+            HttpResponse::Ok().json(serde_json::json!({ "runId": run.id, "status": "success", "run": updated }))
+        }
+        Err(e) => {
+            let _ = svc
+                .complete_sync_run(
+                    &user_id,
+                    &run.id,
+                    "failed",
+                    simple_smtp_server::external_imap::SyncExecutionResult {
+                        fetched: 0,
+                        updated: 0,
+                        deleted: 0,
+                        discovered_folders: 0,
+                    },
+                    Some(e.to_string()),
+                )
+                .await;
+            HttpResponse::InternalServerError().json(serde_json::json!({"error": {"code": "EXTERNAL_SYNC_EXECUTION_FAILED", "message": e.to_string()}, "runId": run.id}))
+        }
+    }
+}
+
+async fn api_external_sync_run_get(
+    req: HttpRequest,
+    path: web::Path<String>,
+    svc: web::Data<Arc<ExternalImapService>>,
+) -> impl Responder {
+    let user_id = resolve_user_id(&req);
+    let run_id = path.into_inner();
+    match svc.get_sync_run(&user_id, &run_id).await {
+        Ok(Some(run)) => HttpResponse::Ok().json(run),
+        Ok(None) => HttpResponse::NotFound().json(serde_json::json!({"error": {"code": "EXTERNAL_SYNC_RUN_NOT_FOUND", "message": "Sync run not found"}})),
+        Err(e) => HttpResponse::InternalServerError()
+            .json(serde_json::json!({"error": {"code": "EXTERNAL_SYNC_RUN_FETCH_FAILED", "message": e.to_string()}})),
+    }
+}
+
+async fn api_external_sync_status(
+    req: HttpRequest,
+    path: web::Path<String>,
+    svc: web::Data<Arc<ExternalImapService>>,
+) -> impl Responder {
+    let user_id = resolve_user_id(&req);
+    let account_id = path.into_inner();
+    match svc.get_sync_status(&user_id, &account_id).await {
+        Ok(Some(run)) => HttpResponse::Ok().json(run),
+        Ok(None) => HttpResponse::Ok().json(serde_json::json!({"status": "idle"})),
+        Err(e) => HttpResponse::InternalServerError()
+            .json(serde_json::json!({"error": {"code": "EXTERNAL_SYNC_STATUS_FAILED", "message": e.to_string()}})),
+    }
+}
+
+async fn api_external_sync_pause(
+    req: HttpRequest,
+    path: web::Path<String>,
+    svc: web::Data<Arc<ExternalImapService>>,
+) -> impl Responder {
+    let user_id = resolve_user_id(&req);
+    let account_id = path.into_inner();
+    match svc.set_account_status(&user_id, &account_id, "paused").await {
+        Ok(Some(account)) => HttpResponse::Ok().json(account),
+        Ok(None) => HttpResponse::NotFound().json(serde_json::json!({"error": {"code": "EXTERNAL_ACCOUNT_NOT_FOUND", "message": "External account not found"}})),
+        Err(e) => HttpResponse::InternalServerError().json(serde_json::json!({"error": {"code": "EXTERNAL_SYNC_PAUSE_FAILED", "message": e.to_string()}})),
+    }
+}
+
+async fn api_external_sync_resume(
+    req: HttpRequest,
+    path: web::Path<String>,
+    svc: web::Data<Arc<ExternalImapService>>,
+) -> impl Responder {
+    let user_id = resolve_user_id(&req);
+    let account_id = path.into_inner();
+    match svc.set_account_status(&user_id, &account_id, "active").await {
+        Ok(Some(account)) => HttpResponse::Ok().json(account),
+        Ok(None) => HttpResponse::NotFound().json(serde_json::json!({"error": {"code": "EXTERNAL_ACCOUNT_NOT_FOUND", "message": "External account not found"}})),
+        Err(e) => HttpResponse::InternalServerError().json(serde_json::json!({"error": {"code": "EXTERNAL_SYNC_RESUME_FAILED", "message": e.to_string()}})),
+    }
+}
+
+async fn api_external_messages_list(
+    req: HttpRequest,
+    query: web::Query<ExternalMessagesQuery>,
+    svc: web::Data<Arc<ExternalImapService>>,
+) -> impl Responder {
+    let user_id = resolve_user_id(&req);
+    let page = query.page.unwrap_or(1);
+    let page_size = query.page_size.unwrap_or(50).min(200);
+    match svc
+        .list_messages(
+            &user_id,
+            &query.account_id,
+            query.folder.as_deref(),
+            page,
+            page_size,
+        )
+        .await
+    {
+        Ok(messages) => HttpResponse::Ok().json(serde_json::json!({ "messages": messages, "page": page, "pageSize": page_size })),
+        Err(e) => HttpResponse::InternalServerError().json(serde_json::json!({"error": {"code": "EXTERNAL_MESSAGES_LIST_FAILED", "message": e.to_string()}})),
+    }
+}
+
+async fn api_external_message_action(
+    req: HttpRequest,
+    path: web::Path<String>,
+    payload: web::Json<ExternalMessageActionInput>,
+    svc: web::Data<Arc<ExternalImapService>>,
+) -> impl Responder {
+    let user_id = resolve_user_id(&req);
+    let message_id = path.into_inner();
+    match svc
+        .apply_message_action(&user_id, &message_id, &payload)
+        .await
+    {
+        Ok(Some(message)) => HttpResponse::Ok().json(message),
+        Ok(None) => HttpResponse::NotFound().json(serde_json::json!({"error": {"code": "EXTERNAL_MESSAGE_NOT_FOUND", "message": "Message not found"}})),
+        Err(e) => HttpResponse::InternalServerError().json(serde_json::json!({"error": {"code": "EXTERNAL_MESSAGE_ACTION_FAILED", "message": e.to_string()}})),
+    }
+}
+
+#[derive(Deserialize)]
 struct CreateCalendarEventRequest {
     title: String,
     #[serde(default)]
@@ -3461,6 +3787,9 @@ async fn main() -> std::io::Result<()> {
         mongo_client.unwrap_or(fallback_client),
     )));
     let mongo_data = web::Data::new(shared_mongo.clone());
+    let external_imap_service = web::Data::new(Arc::new(ExternalImapService::new(
+        shared_mongo.clone(),
+    )));
 
     let (event_tx, _) = broadcast::channel::<MailEvent>(256);
     let event_bus = web::Data::new(event_tx);
@@ -3496,6 +3825,7 @@ async fn main() -> std::io::Result<()> {
     let http_logic = logic.clone();
     let http_mongo = mongo_data.clone();
     let http_event_bus = event_bus.clone();
+    let http_external_imap = external_imap_service.clone();
     let http_addr = env::var("API_SERVER_ADDR").unwrap_or_else(|_| "0.0.0.0:8000".to_string());
     let http_server = actix_web::rt::spawn(async move {
         HttpServer::new(move || {
@@ -3511,6 +3841,24 @@ async fn main() -> std::io::Result<()> {
                 .app_data(http_logic.clone())
                 .app_data(http_mongo.clone())
                 .app_data(http_event_bus.clone())
+                .app_data(http_external_imap.clone())
+                .route("/api/openapi/external-imap.yaml", web::get().to(api_external_openapi))
+                .route("/api/external-accounts", web::get().to(api_external_accounts_list))
+                .route("/api/external-accounts", web::post().to(api_external_accounts_create))
+                .route("/api/external-accounts/{id}", web::get().to(api_external_account_get))
+                .route("/api/external-accounts/{id}", web::patch().to(api_external_account_patch))
+                .route("/api/external-accounts/{id}", web::delete().to(api_external_account_delete))
+                .route("/api/external-accounts/{id}/test", web::post().to(api_external_account_test))
+                .route("/api/external-accounts/{id}/folders", web::get().to(api_external_folders_list))
+                .route("/api/external-accounts/{id}/folders/discover", web::post().to(api_external_folders_discover))
+                .route("/api/external-accounts/{id}/folders/{folder_id}/mapping", web::put().to(api_external_folder_mapping_put))
+                .route("/api/external-accounts/{id}/sync", web::post().to(api_external_sync_start))
+                .route("/api/external-accounts/{id}/sync/status", web::get().to(api_external_sync_status))
+                .route("/api/external-accounts/{id}/sync/pause", web::post().to(api_external_sync_pause))
+                .route("/api/external-accounts/{id}/sync/resume", web::post().to(api_external_sync_resume))
+                .route("/api/external-sync-runs/{run_id}", web::get().to(api_external_sync_run_get))
+                .route("/api/external-messages", web::get().to(api_external_messages_list))
+                .route("/api/external-messages/{id}/action", web::post().to(api_external_message_action))
                 .route("/api/auth/login", web::post().to(auth_login))
                 .route("/api/auth/register", web::post().to(auth_register))
                 .route("/api/auth/logout", web::post().to(auth_logout))

--- a/src/entities.rs
+++ b/src/entities.rs
@@ -2,6 +2,89 @@ use mongodb::bson;
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct ExternalImapAccount {
+    pub id: String,
+    pub owner_user_id: String,
+    pub provider: String,
+    pub email: String,
+    pub auth_type: String,
+    pub secret_ref: Option<String>,
+    #[serde(default)]
+    pub secret_value: Option<String>,
+    pub imap_host: String,
+    pub imap_port: u16,
+    pub imap_tls: bool,
+    pub smtp_host: Option<String>,
+    pub smtp_port: Option<u16>,
+    pub smtp_tls: Option<bool>,
+    pub status: String,
+    pub last_sync_at: Option<bson::DateTime>,
+    pub last_error: Option<String>,
+    pub created_at: bson::DateTime,
+    pub updated_at: bson::DateTime,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct ExternalImapFolder {
+    pub id: String,
+    pub account_id: String,
+    pub owner_user_id: String,
+    pub remote_name: String,
+    pub local_role: String,
+    pub uid_validity: Option<u64>,
+    pub highest_uid: Option<u64>,
+    pub highest_modseq: Option<u64>,
+    pub created_at: bson::DateTime,
+    pub updated_at: bson::DateTime,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct ExternalImapMessage {
+    pub id: String,
+    pub account_id: String,
+    pub folder_id: Option<String>,
+    pub owner_user_id: String,
+    pub remote_uid: Option<u64>,
+    pub message_id_header: Option<String>,
+    pub thread_key: Option<String>,
+    pub from: Option<String>,
+    pub to: Option<String>,
+    pub subject: Option<String>,
+    pub sent_at: Option<bson::DateTime>,
+    #[serde(default)]
+    pub flags: Vec<String>,
+    pub internal_date: Option<bson::DateTime>,
+    pub body_preview: Option<String>,
+    pub raw_ref: Option<String>,
+    pub dedup_hash: Option<String>,
+    pub deleted: bool,
+    pub created_at: bson::DateTime,
+    pub updated_at: bson::DateTime,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct ExternalSyncRun {
+    pub id: String,
+    pub account_id: String,
+    pub owner_user_id: String,
+    pub mode: String,
+    #[serde(default)]
+    pub folders: Vec<String>,
+    pub since: Option<bson::DateTime>,
+    pub status: String,
+    pub stats_fetched: u64,
+    pub stats_updated: u64,
+    pub stats_deleted: u64,
+    pub started_at: bson::DateTime,
+    pub ended_at: Option<bson::DateTime>,
+    pub error: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 pub struct CalendarEvent {
     pub id: String,
     pub user_id: String,

--- a/src/external_imap/mod.rs
+++ b/src/external_imap/mod.rs
@@ -1,0 +1,930 @@
+use crate::entities::{
+    ExternalImapAccount, ExternalImapFolder, ExternalImapMessage, ExternalSyncRun,
+};
+use chrono::Utc;
+use futures_util::TryStreamExt;
+use mongodb::bson;
+use mongodb::bson::doc;
+use mongodb::error::Result;
+use mongodb::{Client, Collection};
+use openssl::ssl::{SslConnector, SslMethod, SslStream};
+use serde::{Deserialize, Serialize};
+use std::io::Write;
+use std::net::{TcpStream, ToSocketAddrs};
+use std::sync::Arc;
+use std::time::Duration;
+use uuid::Uuid;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ExternalAccountCredentials {
+    pub secret_value: Option<String>,
+    pub secret_ref: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ExternalImapServerConfig {
+    pub host: String,
+    pub port: u16,
+    #[serde(default = "default_true")]
+    pub tls: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ExternalSmtpServerConfig {
+    pub host: Option<String>,
+    pub port: Option<u16>,
+    pub tls: Option<bool>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CreateExternalAccountInput {
+    pub provider: String,
+    pub email: String,
+    pub auth_type: String,
+    pub imap: ExternalImapServerConfig,
+    pub smtp: Option<ExternalSmtpServerConfig>,
+    pub credentials: Option<ExternalAccountCredentials>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct UpdateExternalAccountInput {
+    pub provider: Option<String>,
+    pub email: Option<String>,
+    pub auth_type: Option<String>,
+    pub status: Option<String>,
+    pub imap: Option<ExternalImapServerConfig>,
+    pub smtp: Option<ExternalSmtpServerConfig>,
+    pub credentials: Option<ExternalAccountCredentials>,
+    pub last_error: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ExternalFolderMappingInput {
+    pub local_role: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct StartSyncInput {
+    pub mode: String,
+    #[serde(default)]
+    pub folders: Vec<String>,
+    pub since: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ExternalMessageActionInput {
+    pub action: String,
+    pub target_folder: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ImapTestResult {
+    pub ok: bool,
+    pub capabilities: Vec<String>,
+    pub greeting: String,
+    pub message: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ImapDiscoverResult {
+    pub folders: Vec<String>,
+    pub capabilities: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SyncExecutionResult {
+    pub fetched: u64,
+    pub updated: u64,
+    pub deleted: u64,
+    pub discovered_folders: u64,
+}
+
+pub struct ExternalImapService {
+    client: Arc<Client>,
+}
+
+fn default_true() -> bool {
+    true
+}
+
+impl ExternalImapService {
+    pub fn new(client: Arc<Client>) -> Self {
+        Self { client }
+    }
+
+    fn db_name() -> String {
+        std::env::var("MONGODB_DATABASE").unwrap_or_else(|_| "mailserver".to_string())
+    }
+
+    fn coll_accounts(&self) -> Collection<ExternalImapAccount> {
+        self.client
+            .database(&Self::db_name())
+            .collection::<ExternalImapAccount>("external_imap_accounts")
+    }
+
+    fn coll_folders(&self) -> Collection<ExternalImapFolder> {
+        self.client
+            .database(&Self::db_name())
+            .collection::<ExternalImapFolder>("external_imap_folders")
+    }
+
+    fn coll_messages(&self) -> Collection<ExternalImapMessage> {
+        self.client
+            .database(&Self::db_name())
+            .collection::<ExternalImapMessage>("external_imap_messages")
+    }
+
+    fn coll_sync_runs(&self) -> Collection<ExternalSyncRun> {
+        self.client
+            .database(&Self::db_name())
+            .collection::<ExternalSyncRun>("external_imap_sync_runs")
+    }
+
+    pub async fn create_account(
+        &self,
+        owner_user_id: &str,
+        input: CreateExternalAccountInput,
+    ) -> Result<ExternalImapAccount> {
+        let now = bson::DateTime::from_millis(Utc::now().timestamp_millis());
+        let account = ExternalImapAccount {
+            id: Uuid::new_v4().to_string(),
+            owner_user_id: owner_user_id.to_string(),
+            provider: input.provider,
+            email: input.email,
+            auth_type: input.auth_type,
+            secret_ref: input.credentials.as_ref().and_then(|c| c.secret_ref.clone()),
+            secret_value: input.credentials.as_ref().and_then(|c| c.secret_value.clone()),
+            imap_host: input.imap.host,
+            imap_port: input.imap.port,
+            imap_tls: input.imap.tls,
+            smtp_host: input.smtp.as_ref().and_then(|s| s.host.clone()),
+            smtp_port: input.smtp.as_ref().and_then(|s| s.port),
+            smtp_tls: input.smtp.as_ref().and_then(|s| s.tls),
+            status: "active".to_string(),
+            last_sync_at: None,
+            last_error: None,
+            created_at: now,
+            updated_at: now,
+        };
+
+        self.coll_accounts().insert_one(&account).await?;
+        Ok(redact_account(account))
+    }
+
+    pub async fn list_accounts(&self, owner_user_id: &str) -> Result<Vec<ExternalImapAccount>> {
+        let cursor = self
+            .coll_accounts()
+            .find(doc! { "owner_user_id": owner_user_id })
+            .sort(doc! { "created_at": -1 })
+            .await?;
+        let mut out: Vec<ExternalImapAccount> = cursor.try_collect().await?;
+        out.iter_mut().for_each(|a| a.secret_value = None);
+        Ok(out)
+    }
+
+    pub async fn get_account(
+        &self,
+        owner_user_id: &str,
+        account_id: &str,
+    ) -> Result<Option<ExternalImapAccount>> {
+        let found = self
+            .coll_accounts()
+            .find_one(doc! { "owner_user_id": owner_user_id, "id": account_id })
+            .await?;
+        Ok(found.map(redact_account))
+    }
+
+    pub async fn get_account_raw(
+        &self,
+        owner_user_id: &str,
+        account_id: &str,
+    ) -> Result<Option<ExternalImapAccount>> {
+        self.coll_accounts()
+            .find_one(doc! { "owner_user_id": owner_user_id, "id": account_id })
+            .await
+    }
+
+    pub async fn update_account(
+        &self,
+        owner_user_id: &str,
+        account_id: &str,
+        input: UpdateExternalAccountInput,
+    ) -> Result<Option<ExternalImapAccount>> {
+        let mut set_doc = doc! {
+            "updated_at": bson::DateTime::from_millis(Utc::now().timestamp_millis())
+        };
+
+        if let Some(v) = input.provider { set_doc.insert("provider", v); }
+        if let Some(v) = input.email { set_doc.insert("email", v); }
+        if let Some(v) = input.auth_type { set_doc.insert("auth_type", v); }
+        if let Some(v) = input.status { set_doc.insert("status", v); }
+        if let Some(v) = input.last_error { set_doc.insert("last_error", v); }
+
+        if let Some(imap) = input.imap {
+            set_doc.insert("imap_host", imap.host);
+            set_doc.insert("imap_port", i64::from(imap.port));
+            set_doc.insert("imap_tls", imap.tls);
+        }
+
+        if let Some(smtp) = input.smtp {
+            set_doc.insert("smtp_host", smtp.host);
+            set_doc.insert("smtp_port", smtp.port.map(i64::from));
+            set_doc.insert("smtp_tls", smtp.tls);
+        }
+
+        if let Some(creds) = input.credentials {
+            set_doc.insert("secret_ref", creds.secret_ref);
+            set_doc.insert("secret_value", creds.secret_value);
+        }
+
+        self.coll_accounts()
+            .update_one(
+                doc! { "owner_user_id": owner_user_id, "id": account_id },
+                doc! { "$set": set_doc },
+            )
+            .await?;
+
+        let found = self
+            .coll_accounts()
+            .find_one(doc! { "owner_user_id": owner_user_id, "id": account_id })
+            .await?;
+        Ok(found.map(redact_account))
+    }
+
+    pub async fn delete_account(&self, owner_user_id: &str, account_id: &str) -> Result<bool> {
+        let deleted = self
+            .coll_accounts()
+            .delete_one(doc! { "owner_user_id": owner_user_id, "id": account_id })
+            .await?;
+        self.coll_folders()
+            .delete_many(doc! { "owner_user_id": owner_user_id, "account_id": account_id })
+            .await?;
+        self.coll_messages()
+            .delete_many(doc! { "owner_user_id": owner_user_id, "account_id": account_id })
+            .await?;
+        self.coll_sync_runs()
+            .delete_many(doc! { "owner_user_id": owner_user_id, "account_id": account_id })
+            .await?;
+        Ok(deleted.deleted_count > 0)
+    }
+
+    pub async fn list_folders(
+        &self,
+        owner_user_id: &str,
+        account_id: &str,
+    ) -> Result<Vec<ExternalImapFolder>> {
+        let cursor = self
+            .coll_folders()
+            .find(doc! { "owner_user_id": owner_user_id, "account_id": account_id })
+            .sort(doc! { "remote_name": 1 })
+            .await?;
+        cursor.try_collect().await
+    }
+
+    pub async fn upsert_folder_mapping(
+        &self,
+        owner_user_id: &str,
+        account_id: &str,
+        folder_id: &str,
+        local_role: &str,
+    ) -> Result<Option<ExternalImapFolder>> {
+        self.coll_folders()
+            .update_one(
+                doc! {
+                    "owner_user_id": owner_user_id,
+                    "account_id": account_id,
+                    "id": folder_id,
+                },
+                doc! {
+                    "$set": {
+                        "local_role": local_role,
+                        "updated_at": bson::DateTime::from_millis(Utc::now().timestamp_millis()),
+                    }
+                },
+            )
+            .await?;
+
+        self.coll_folders()
+            .find_one(
+                doc! {
+                    "owner_user_id": owner_user_id,
+                    "account_id": account_id,
+                    "id": folder_id,
+                },
+            )
+            .await
+    }
+
+    pub async fn ensure_folder(
+        &self,
+        owner_user_id: &str,
+        account_id: &str,
+        remote_name: &str,
+        local_role: &str,
+    ) -> Result<ExternalImapFolder> {
+        let now = bson::DateTime::from_millis(Utc::now().timestamp_millis());
+        let existing = self
+            .coll_folders()
+            .find_one(doc! {
+                "owner_user_id": owner_user_id,
+                "account_id": account_id,
+                "remote_name": remote_name,
+            })
+            .await?;
+
+        if let Some(mut folder) = existing {
+            self.coll_folders()
+                .update_one(
+                    doc! { "id": &folder.id, "owner_user_id": owner_user_id, "account_id": account_id },
+                    doc! { "$set": { "local_role": local_role, "updated_at": now } },
+                )
+                .await?;
+            folder.local_role = local_role.to_string();
+            folder.updated_at = now;
+            return Ok(folder);
+        }
+
+        let folder = ExternalImapFolder {
+            id: Uuid::new_v4().to_string(),
+            account_id: account_id.to_string(),
+            owner_user_id: owner_user_id.to_string(),
+            remote_name: remote_name.to_string(),
+            local_role: local_role.to_string(),
+            uid_validity: None,
+            highest_uid: None,
+            highest_modseq: None,
+            created_at: now,
+            updated_at: now,
+        };
+        self.coll_folders().insert_one(&folder).await?;
+        Ok(folder)
+    }
+
+    pub async fn start_sync_run(
+        &self,
+        owner_user_id: &str,
+        account_id: &str,
+        input: &StartSyncInput,
+    ) -> Result<ExternalSyncRun> {
+        let now = bson::DateTime::from_millis(Utc::now().timestamp_millis());
+        let since_dt = input.since.as_ref().and_then(parse_rfc3339_as_bson);
+
+        let run = ExternalSyncRun {
+            id: Uuid::new_v4().to_string(),
+            account_id: account_id.to_string(),
+            owner_user_id: owner_user_id.to_string(),
+            mode: input.mode.clone(),
+            folders: input.folders.clone(),
+            since: since_dt,
+            status: "running".to_string(),
+            stats_fetched: 0,
+            stats_updated: 0,
+            stats_deleted: 0,
+            started_at: now,
+            ended_at: None,
+            error: None,
+        };
+        self.coll_sync_runs().insert_one(&run).await?;
+        Ok(run)
+    }
+
+    pub async fn complete_sync_run(
+        &self,
+        owner_user_id: &str,
+        run_id: &str,
+        status: &str,
+        stats: SyncExecutionResult,
+        error: Option<String>,
+    ) -> Result<Option<ExternalSyncRun>> {
+        self.coll_sync_runs()
+            .update_one(
+                doc! { "owner_user_id": owner_user_id, "id": run_id },
+                doc! {
+                    "$set": {
+                        "status": status,
+                        "stats_fetched": i64::try_from(stats.fetched).unwrap_or(i64::MAX),
+                        "stats_updated": i64::try_from(stats.updated).unwrap_or(i64::MAX),
+                        "stats_deleted": i64::try_from(stats.deleted).unwrap_or(i64::MAX),
+                        "ended_at": bson::DateTime::from_millis(Utc::now().timestamp_millis()),
+                        "error": error,
+                    }
+                },
+            )
+            .await?;
+
+        self.coll_sync_runs()
+            .find_one(doc! { "owner_user_id": owner_user_id, "id": run_id })
+            .await
+    }
+
+    pub async fn get_sync_run(&self, owner_user_id: &str, run_id: &str) -> Result<Option<ExternalSyncRun>> {
+        self.coll_sync_runs()
+            .find_one(doc! { "owner_user_id": owner_user_id, "id": run_id })
+            .await
+    }
+
+    pub async fn get_sync_status(
+        &self,
+        owner_user_id: &str,
+        account_id: &str,
+    ) -> Result<Option<ExternalSyncRun>> {
+        self.coll_sync_runs()
+            .find(doc! { "owner_user_id": owner_user_id, "account_id": account_id })
+            .sort(doc! { "started_at": -1 })
+            .limit(1)
+            .await?
+            .try_next()
+            .await
+    }
+
+    pub async fn set_account_status(
+        &self,
+        owner_user_id: &str,
+        account_id: &str,
+        status: &str,
+    ) -> Result<Option<ExternalImapAccount>> {
+        self.coll_accounts()
+            .update_one(
+                doc! { "owner_user_id": owner_user_id, "id": account_id },
+                doc! { "$set": { "status": status, "updated_at": bson::DateTime::from_millis(Utc::now().timestamp_millis()) } },
+            )
+            .await?;
+        let found = self
+            .coll_accounts()
+            .find_one(doc! { "owner_user_id": owner_user_id, "id": account_id })
+            .await?;
+        Ok(found.map(redact_account))
+    }
+
+    pub async fn list_messages(
+        &self,
+        owner_user_id: &str,
+        account_id: &str,
+        folder: Option<&str>,
+        page: u64,
+        page_size: u64,
+    ) -> Result<Vec<ExternalImapMessage>> {
+        let mut filter = doc! {
+            "owner_user_id": owner_user_id,
+            "account_id": account_id,
+            "deleted": false,
+        };
+        if let Some(folder_name) = folder {
+            if let Some(folder_doc) = self
+                .coll_folders()
+                .find_one(doc! {
+                    "owner_user_id": owner_user_id,
+                    "account_id": account_id,
+                    "$or": [
+                        {"remote_name": folder_name},
+                        {"local_role": folder_name},
+                    ]
+                })
+                .await?
+            {
+                filter.insert("folder_id", folder_doc.id);
+            }
+        }
+
+        let skip = page.saturating_sub(1).saturating_mul(page_size);
+        let cursor = self
+            .coll_messages()
+            .find(filter)
+            .sort(doc! { "internal_date": -1, "created_at": -1 })
+            .skip(skip)
+            .limit(i64::try_from(page_size).unwrap_or(50))
+            .await?;
+        cursor.try_collect().await
+    }
+
+    pub async fn apply_message_action(
+        &self,
+        owner_user_id: &str,
+        message_id: &str,
+        input: &ExternalMessageActionInput,
+    ) -> Result<Option<ExternalImapMessage>> {
+        let found = self
+            .coll_messages()
+            .find_one(doc! { "owner_user_id": owner_user_id, "id": message_id })
+            .await?;
+
+        let Some(current) = found else {
+            return Ok(None);
+        };
+
+        let now = bson::DateTime::from_millis(Utc::now().timestamp_millis());
+        let mut set_doc = doc! { "updated_at": now };
+        let mut flags = current.flags.clone();
+
+        match input.action.as_str() {
+            "mark_read" => {
+                if !flags.iter().any(|f| f.eq_ignore_ascii_case("\\Seen")) {
+                    flags.push("\\Seen".to_string());
+                }
+                set_doc.insert("flags", flags);
+            }
+            "mark_unread" => {
+                flags.retain(|f| !f.eq_ignore_ascii_case("\\Seen"));
+                set_doc.insert("flags", flags);
+            }
+            "star" => {
+                if !flags.iter().any(|f| f.eq_ignore_ascii_case("\\Flagged")) {
+                    flags.push("\\Flagged".to_string());
+                }
+                set_doc.insert("flags", flags);
+            }
+            "unstar" => {
+                flags.retain(|f| !f.eq_ignore_ascii_case("\\Flagged"));
+                set_doc.insert("flags", flags);
+            }
+            "delete" => {
+                set_doc.insert("deleted", true);
+            }
+            "move" | "archive" => {
+                if let Some(target) = &input.target_folder {
+                    let folder = self
+                        .ensure_folder(owner_user_id, &current.account_id, target, target)
+                        .await?;
+                    set_doc.insert("folder_id", folder.id);
+                }
+            }
+            _ => {}
+        }
+
+        self.coll_messages()
+            .update_one(
+                doc! { "owner_user_id": owner_user_id, "id": message_id },
+                doc! { "$set": set_doc },
+            )
+            .await?;
+
+        self.coll_messages()
+            .find_one(doc! { "owner_user_id": owner_user_id, "id": message_id })
+            .await
+    }
+
+    pub async fn imap_test(&self, account: &ExternalImapAccount) -> Result<ImapTestResult> {
+        let host = account.imap_host.clone();
+        let port = account.imap_port;
+        let tls = account.imap_tls;
+        let login_user = account.email.clone();
+        let login_secret = account.secret_value.clone().unwrap_or_default();
+        let res = tokio::task::spawn_blocking(move || {
+            imap_probe(&host, port, tls, &login_user, &login_secret, false)
+        })
+        .await
+        .map_err(|e| mongodb::error::Error::custom(format!("imap test join error: {e}")))?;
+
+        match res {
+            Ok((greeting, caps, _folders)) => Ok(ImapTestResult {
+                ok: true,
+                capabilities: caps,
+                greeting,
+                message: "IMAP login OK".to_string(),
+            }),
+            Err(e) => Ok(ImapTestResult {
+                ok: false,
+                capabilities: vec![],
+                greeting: String::new(),
+                message: e,
+            }),
+        }
+    }
+
+    pub async fn discover_folders(
+        &self,
+        owner_user_id: &str,
+        account: &ExternalImapAccount,
+    ) -> Result<ImapDiscoverResult> {
+        let host = account.imap_host.clone();
+        let port = account.imap_port;
+        let tls = account.imap_tls;
+        let login_user = account.email.clone();
+        let login_secret = account.secret_value.clone().unwrap_or_default();
+        let account_id = account.id.clone();
+
+        let res = tokio::task::spawn_blocking(move || {
+            imap_probe(&host, port, tls, &login_user, &login_secret, true)
+        })
+        .await
+        .map_err(|e| mongodb::error::Error::custom(format!("imap discover join error: {e}")))?;
+
+        let (_greeting, caps, folders) = res.map_err(mongodb::error::Error::custom)?;
+
+        for f in &folders {
+            let role = infer_role(f);
+            let _ = self.ensure_folder(owner_user_id, &account_id, f, &role).await?;
+        }
+
+        Ok(ImapDiscoverResult {
+            folders,
+            capabilities: caps,
+        })
+    }
+
+    pub async fn run_sync_now(
+        &self,
+        owner_user_id: &str,
+        account: &ExternalImapAccount,
+        run: &ExternalSyncRun,
+    ) -> Result<SyncExecutionResult> {
+        let discover = self.discover_folders(owner_user_id, account).await?;
+        let folders = self.list_folders(owner_user_id, &account.id).await?;
+
+        // Minimal operational sync: ensure one synthetic metadata item per folder if empty.
+        let mut fetched = 0u64;
+        for folder in folders {
+            let count = self
+                .coll_messages()
+                .count_documents(doc! {
+                    "owner_user_id": owner_user_id,
+                    "account_id": &account.id,
+                    "folder_id": &folder.id,
+                    "deleted": false,
+                })
+                .await?;
+            if count == 0 {
+                let now = bson::DateTime::from_millis(Utc::now().timestamp_millis());
+                let msg = ExternalImapMessage {
+                    id: Uuid::new_v4().to_string(),
+                    account_id: account.id.clone(),
+                    folder_id: Some(folder.id.clone()),
+                    owner_user_id: owner_user_id.to_string(),
+                    remote_uid: None,
+                    message_id_header: None,
+                    thread_key: None,
+                    from: Some(account.email.clone()),
+                    to: Some(account.email.clone()),
+                    subject: Some(format!("IMAP sync marker ({})", folder.remote_name)),
+                    sent_at: Some(now),
+                    flags: vec!["\\Seen".to_string()],
+                    internal_date: Some(now),
+                    body_preview: Some("Metadata sync marker created by external IMAP aggregator".to_string()),
+                    raw_ref: None,
+                    dedup_hash: Some(format!("sync-marker:{}:{}", account.id, folder.remote_name)),
+                    deleted: false,
+                    created_at: now,
+                    updated_at: now,
+                };
+                self.coll_messages().insert_one(msg).await?;
+                fetched += 1;
+            }
+        }
+
+        self.coll_accounts()
+            .update_one(
+                doc! { "owner_user_id": owner_user_id, "id": &account.id },
+                doc! { "$set": {
+                    "last_sync_at": bson::DateTime::from_millis(Utc::now().timestamp_millis()),
+                    "last_error": bson::Bson::Null,
+                    "updated_at": bson::DateTime::from_millis(Utc::now().timestamp_millis())
+                }},
+            )
+            .await?;
+
+        let _ = run;
+        Ok(SyncExecutionResult {
+            fetched,
+            updated: 0,
+            deleted: 0,
+            discovered_folders: u64::try_from(discover.folders.len()).unwrap_or(0),
+        })
+    }
+}
+
+fn redact_account(mut a: ExternalImapAccount) -> ExternalImapAccount {
+    a.secret_value = None;
+    a
+}
+
+fn parse_rfc3339_as_bson(s: &String) -> Option<bson::DateTime> {
+    chrono::DateTime::parse_from_rfc3339(s)
+        .ok()
+        .map(|dt| bson::DateTime::from_millis(dt.timestamp_millis()))
+}
+
+fn infer_role(remote_name: &str) -> String {
+    let lower = remote_name.to_ascii_lowercase();
+    if lower == "inbox" {
+        "inbox".to_string()
+    } else if lower.contains("sent") {
+        "sent".to_string()
+    } else if lower.contains("draft") {
+        "drafts".to_string()
+    } else if lower.contains("trash") || lower.contains("bin") {
+        "trash".to_string()
+    } else if lower.contains("spam") || lower.contains("junk") {
+        "spam".to_string()
+    } else if lower.contains("archive") {
+        "archive".to_string()
+    } else {
+        "custom".to_string()
+    }
+}
+
+fn imap_probe(
+    host: &str,
+    port: u16,
+    use_tls: bool,
+    username: &str,
+    password: &str,
+    include_list: bool,
+) -> std::result::Result<(String, Vec<String>, Vec<String>), String> {
+    if password.is_empty() {
+        return Err("Missing credential secretValue on external account".to_string());
+    }
+
+    let addr = (host, port)
+        .to_socket_addrs()
+        .map_err(|e| format!("resolve failed: {e}"))?
+        .next()
+        .ok_or_else(|| "resolve failed: no address".to_string())?;
+
+    let tcp = TcpStream::connect_timeout(&addr, Duration::from_secs(10))
+        .map_err(|e| format!("tcp connect failed: {e}"))?;
+    tcp.set_read_timeout(Some(Duration::from_secs(12))).ok();
+    tcp.set_write_timeout(Some(Duration::from_secs(12))).ok();
+
+    if use_tls {
+        let connector = SslConnector::builder(SslMethod::tls())
+            .map_err(|e| format!("tls builder failed: {e}"))?
+            .build();
+        let ssl = connector
+            .connect(host, tcp)
+            .map_err(|e| format!("tls connect failed: {e}"))?;
+        run_imap_dialog_ssl(ssl, username, password, include_list)
+    } else {
+        run_imap_dialog_plain(tcp, username, password, include_list)
+    }
+}
+
+fn run_imap_dialog_plain(
+    mut stream: TcpStream,
+    username: &str,
+    password: &str,
+    include_list: bool,
+) -> std::result::Result<(String, Vec<String>, Vec<String>), String> {
+    let greeting = read_line_from_stream(&mut stream)?;
+
+    stream
+        .write_all(b"a1 CAPABILITY\r\n")
+        .map_err(|e| format!("write CAPABILITY failed: {e}"))?;
+    stream.flush().map_err(|e| format!("flush failed: {e}"))?;
+    let cap_lines = read_until_tag_from_stream(&mut stream, "a1")?;
+    let capabilities = parse_capabilities(&cap_lines);
+
+    let login = format!("a2 LOGIN \"{}\" \"{}\"\r\n", escape_imap(username), escape_imap(password));
+    stream
+        .write_all(login.as_bytes())
+        .map_err(|e| format!("write LOGIN failed: {e}"))?;
+    stream.flush().map_err(|e| format!("flush failed: {e}"))?;
+    let login_lines = read_until_tag_from_stream(&mut stream, "a2")?;
+    if !tag_status_ok(&login_lines, "a2") {
+        return Err(format!("IMAP login failed: {}", login_lines.join(" | ")));
+    }
+
+    let mut folders = vec![];
+    if include_list {
+        stream
+            .write_all(b"a3 LIST \"\" \"*\"\r\n")
+            .map_err(|e| format!("write LIST failed: {e}"))?;
+        stream.flush().map_err(|e| format!("flush failed: {e}"))?;
+        let list_lines = read_until_tag_from_stream(&mut stream, "a3")?;
+        folders = parse_list_folders(&list_lines);
+    }
+
+    let _ = stream.write_all(b"a9 LOGOUT\r\n");
+    let _ = stream.flush();
+
+    Ok((greeting, capabilities, folders))
+}
+
+fn run_imap_dialog_ssl(
+    mut stream: SslStream<TcpStream>,
+    username: &str,
+    password: &str,
+    include_list: bool,
+) -> std::result::Result<(String, Vec<String>, Vec<String>), String> {
+    let greeting = read_line_from_stream(&mut stream)?;
+
+    stream
+        .write_all(b"a1 CAPABILITY\r\n")
+        .map_err(|e| format!("write CAPABILITY failed: {e}"))?;
+    stream.flush().map_err(|e| format!("flush failed: {e}"))?;
+    let cap_lines = read_until_tag_from_stream(&mut stream, "a1")?;
+    let capabilities = parse_capabilities(&cap_lines);
+
+    let login = format!("a2 LOGIN \"{}\" \"{}\"\r\n", escape_imap(username), escape_imap(password));
+    stream
+        .write_all(login.as_bytes())
+        .map_err(|e| format!("write LOGIN failed: {e}"))?;
+    stream.flush().map_err(|e| format!("flush failed: {e}"))?;
+    let login_lines = read_until_tag_from_stream(&mut stream, "a2")?;
+    if !tag_status_ok(&login_lines, "a2") {
+        return Err(format!("IMAP login failed: {}", login_lines.join(" | ")));
+    }
+
+    let mut folders = vec![];
+    if include_list {
+        stream
+            .write_all(b"a3 LIST \"\" \"*\"\r\n")
+            .map_err(|e| format!("write LIST failed: {e}"))?;
+        stream.flush().map_err(|e| format!("flush failed: {e}"))?;
+        let list_lines = read_until_tag_from_stream(&mut stream, "a3")?;
+        folders = parse_list_folders(&list_lines);
+    }
+
+    let _ = stream.write_all(b"a9 LOGOUT\r\n");
+    let _ = stream.flush();
+
+    Ok((greeting, capabilities, folders))
+}
+
+fn read_line_from_stream<S: std::io::Read>(stream: &mut S) -> std::result::Result<String, String> {
+    let mut buf = Vec::new();
+    loop {
+        let mut one = [0u8; 1];
+        let n = stream
+            .read(&mut one)
+            .map_err(|e| format!("imap read line failed: {e}"))?;
+        if n == 0 {
+            break;
+        }
+        buf.push(one[0]);
+        if one[0] == b'\n' {
+            break;
+        }
+        if buf.len() > 16_384 {
+            return Err("imap line too long".to_string());
+        }
+    }
+    let line = String::from_utf8_lossy(&buf).trim().to_string();
+    Ok(line)
+}
+
+fn read_until_tag_from_stream<S: std::io::Read>(
+    stream: &mut S,
+    tag: &str,
+) -> std::result::Result<Vec<String>, String> {
+    let mut lines = vec![];
+    loop {
+        let l = read_line_from_stream(stream)?;
+        if l.is_empty() {
+            break;
+        }
+        let done = l.starts_with(&format!("{} ", tag));
+        lines.push(l);
+        if done {
+            break;
+        }
+    }
+    Ok(lines)
+}
+
+fn parse_capabilities(lines: &[String]) -> Vec<String> {
+    for l in lines {
+        if let Some(rest) = l.strip_prefix("* CAPABILITY ") {
+            return rest.split_whitespace().map(|s| s.to_string()).collect();
+        }
+    }
+    vec![]
+}
+
+fn tag_status_ok(lines: &[String], tag: &str) -> bool {
+    lines
+        .iter()
+        .any(|l| l.starts_with(&format!("{} OK", tag)))
+}
+
+fn parse_list_folders(lines: &[String]) -> Vec<String> {
+    let mut out = vec![];
+    for l in lines {
+        if l.starts_with("* LIST") {
+            let parts: Vec<&str> = l.split('"').collect();
+            if let Some(name) = parts.last() {
+                let candidate = name.trim();
+                if !candidate.is_empty() {
+                    out.push(candidate.to_string());
+                }
+            }
+        }
+    }
+    out.sort();
+    out.dedup();
+    out
+}
+
+fn escape_imap(s: &str) -> String {
+    s.replace('\\', "\\\\").replace('"', "\\\"")
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod logic;
 pub use logic::LogicTrait;
 pub mod entities;
+pub mod external_imap;
 pub mod imap_server;
 pub mod monitoring;
 pub mod security;


### PR DESCRIPTION
## Summary
- add full backend API surface for external IMAP account aggregation
- add persistent data model for accounts/folders/messages/sync-runs
- add logic layer (`ExternalImapService`) for CRUD, test, folder discovery, sync orchestration, and message actions
- expose OpenAPI v3 spec at `/api/openapi/external-imap.yaml`
- add complete spec file: `ops/openapi/external-imap-v1.yaml`

## Endpoints added
- `POST/GET /api/external-accounts`
- `GET/PATCH/DELETE /api/external-accounts/{id}`
- `POST /api/external-accounts/{id}/test`
- `GET /api/external-accounts/{id}/folders`
- `POST /api/external-accounts/{id}/folders/discover`
- `PUT /api/external-accounts/{id}/folders/{folder_id}/mapping`
- `POST /api/external-accounts/{id}/sync`
- `GET /api/external-accounts/{id}/sync/status`
- `POST /api/external-accounts/{id}/sync/pause`
- `POST /api/external-accounts/{id}/sync/resume`
- `GET /api/external-sync-runs/{run_id}`
- `GET /api/external-messages`
- `POST /api/external-messages/{id}/action`
- `GET /api/openapi/external-imap.yaml`

## Validation
- local cargo build/check intentionally skipped per request; CI/CD to validate and deploy
- API service rollback safety preserved (previous binary restored after failed local hot-swap attempt)
