### PR TITLE
ci: use self-hosted Scaleway runners

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -19,7 +19,7 @@ jobs:
   # ============================================================
   test:
     name: Compile & Check
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, scw-rust-large]
     steps:
       - uses: actions/checkout@v4
 
@@ -39,7 +39,7 @@ jobs:
   build-push-smtp:
     name: Build & Push SMTP image (SCW Registry)
     needs: test
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, scw-rust-large]
     if: >-
       (github.event_name == 'push' && github.ref == 'refs/heads/master')
       || github.event_name == 'workflow_dispatch'
@@ -77,7 +77,7 @@ jobs:
   deploy:
     name: Deploy to Scaleway VM
     needs: [test, build-push-smtp]
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, scw-rust-large]
     if: >-
       needs.test.result == 'success' &&
       (


### PR DESCRIPTION
Switch CI/CD jobs to self-hosted runner label [self-hosted, linux, x64, scw-rust-large] to avoid GitHub-hosted resource contention for heavy Rust builds.