### PR TITLE
feat(monitoring): realtime flow health, proactive alerts and correlation

### DIFF
--- a/src/bin/email_api.rs
+++ b/src/bin/email_api.rs
@@ -354,6 +354,16 @@ fn since_str(window: &str) -> String {
     (Utc::now() - dur).to_rfc3339()
 }
 
+fn env_bool(name: &str, default: bool) -> bool {
+    match env::var(name) {
+        Ok(v) => matches!(
+            v.trim().to_ascii_lowercase().as_str(),
+            "1" | "true" | "yes" | "on"
+        ),
+        Err(_) => default,
+    }
+}
+
 #[derive(Deserialize)]
 struct MonitoringWindowQuery {
     #[serde(default = "default_monitoring_window")]
@@ -392,6 +402,19 @@ fn default_mon_page_size() -> u32 {
 #[derive(Deserialize)]
 struct MonitoringLiveQuery {
     message_id: Option<String>,
+}
+
+#[derive(Deserialize)]
+struct AdminWindowQuery {
+    #[serde(default = "default_window")]
+    window: String,
+}
+
+#[derive(Deserialize)]
+struct DeliverabilityDiagnosticsQuery {
+    #[serde(default = "default_window")]
+    window: String,
+    domain: Option<String>,
 }
 
 /// GET /api/monitoring/summary?window=15m
@@ -872,6 +895,249 @@ async fn api_security_live(mongo: web::Data<Arc<mongodb::Client>>) -> impl Respo
         .insert_header(("Cache-Control", "no-cache"))
         .insert_header(("X-Accel-Buffering", "no"))
         .streaming(stream)
+}
+
+async fn api_admin_security_posture(
+    query: web::Query<AdminWindowQuery>,
+    mongo: web::Data<Arc<mongodb::Client>>,
+) -> impl Responder {
+    use simple_smtp_server::security::audit;
+
+    let active_alerts = audit::query_active_alerts(&mongo, 300).await;
+
+    let brute_force_alerts = active_alerts
+        .iter()
+        .filter(|a| {
+            let n = a.rule_name.to_ascii_lowercase();
+            n.contains("bruteforce") || n.contains("brute") || n.contains("rate")
+        })
+        .count();
+
+    let auth_fail_alerts = active_alerts
+        .iter()
+        .filter(|a| {
+            let n = a.rule_name.to_ascii_lowercase();
+            n.contains("spf") || n.contains("dkim") || n.contains("dmarc")
+        })
+        .count();
+
+    let domain = env::var("DOMAIN_NAME")
+        .or_else(|_| env::var("MAIL_DOMAIN"))
+        .unwrap_or_else(|_| "misfits.ai".to_string());
+    let smtp_public_ip =
+        env::var("SMTP_PUBLIC_IP").unwrap_or_else(|_| "51.158.114.182".to_string());
+    let dkim_selector = env::var("KEY_SELECTOR").unwrap_or_else(|_| "default".to_string());
+
+    HttpResponse::Ok().json(serde_json::json!({
+        "window": query.window,
+        "security": {
+            "tls": {
+                "smtp_starttls_required": env_bool("SMTP_REQUIRE_STARTTLS", true),
+                "smtps_listener": env::var("SMTP_TLS_ADDR").unwrap_or_else(|_| "0.0.0.0:8465".to_string()),
+                "imaps_listener": env::var("IMAP_TLS_ADDR").unwrap_or_else(|_| "0.0.0.0:8993".to_string()),
+                "imap_starttls_required": env_bool("IMAP_REQUIRE_STARTTLS", true)
+            },
+            "authentication": {
+                "sasl_mechanisms": ["PLAIN", "LOGIN"],
+                "oauth2_enabled": env::var("GITHUB_CLIENT_ID").map(|v| !v.trim().is_empty()).unwrap_or(false),
+                "admin_mfa_required": env_bool("ADMIN_MFA_REQUIRED", true)
+            },
+            "anti_abuse": {
+                "rate_limit_enabled": env_bool("RATE_LIMIT_ENABLED", true),
+                "rate_limit_per_minute": env::var("RATE_LIMIT_PER_MINUTE").ok().and_then(|v| v.parse::<u32>().ok()).unwrap_or(120),
+                "fail2ban_enabled": env_bool("FAIL2BAN_ENABLED", true),
+                "bruteforce_signals_24h": brute_force_alerts,
+                "auth_policy_signals_24h": auth_fail_alerts
+            },
+            "mail_auth_dns": {
+                "domain": domain,
+                "spf_expected": format!("v=spf1 ip4:{} -all", smtp_public_ip),
+                "dkim_selector": dkim_selector,
+                "dmarc_expected": "v=DMARC1; p=quarantine; adkim=s; aspf=s; pct=100",
+                "ptr_rdns_note": "Configurer PTR/rDNS de l'IP publique vers un host mail stable (ex: mail.<domain>)"
+            }
+        }
+    }))
+}
+
+async fn api_admin_deliverability_diagnostics(
+    query: web::Query<DeliverabilityDiagnosticsQuery>,
+    mongo: web::Data<Arc<mongodb::Client>>,
+) -> impl Responder {
+    use simple_smtp_server::security::audit;
+
+    let since = since_str(&query.window);
+    let mut filter = doc! { "ts": { "$gte": &since } };
+
+    if let Some(domain) = query.domain.as_ref().map(|d| d.trim()).filter(|d| !d.is_empty()) {
+        let safe_domain = domain.replace('.', "\\.");
+        filter.insert("to", doc! { "$regex": format!("@{}$", safe_domain), "$options": "i" });
+    }
+
+    let total = storage::count_events(&mongo, filter.clone()).await;
+    let bounces = storage::query_events(
+        &mongo,
+        doc! { "ts": { "$gte": &since }, "status": "bounced" },
+        1,
+        200,
+    )
+    .await;
+
+    let mut bounce_reasons: HashMap<String, u32> = HashMap::new();
+    for evt in &bounces {
+        let key = evt
+            .bounce_reason
+            .clone()
+            .or_else(|| evt.smtp_reply.clone())
+            .unwrap_or_else(|| "unknown".to_string());
+        *bounce_reasons.entry(key).or_insert(0) += 1;
+    }
+
+    let mut top_reasons: Vec<(String, u32)> = bounce_reasons.into_iter().collect();
+    top_reasons.sort_by(|a, b| b.1.cmp(&a.1));
+
+    let auth_alerts = audit::query_active_alerts(&mongo, 300)
+        .await
+        .into_iter()
+        .filter(|a| {
+            let n = a.rule_name.to_ascii_lowercase();
+            n.contains("spf") || n.contains("dkim") || n.contains("dmarc")
+        })
+        .count();
+
+    let rbl_sources = env::var("RBL_CHECK_HOSTS")
+        .unwrap_or_else(|_| "zen.spamhaus.org,bl.spamcop.net".to_string())
+        .split(',')
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+        .collect::<Vec<_>>();
+
+    HttpResponse::Ok().json(serde_json::json!({
+        "window": query.window,
+        "since": since,
+        "scope_domain": query.domain,
+        "total_events": total,
+        "bounces_total": bounces.len(),
+        "auth_policy_alerts": auth_alerts,
+        "top_bounce_reasons": top_reasons.into_iter().take(10).map(|(reason, count)| serde_json::json!({"reason": reason, "count": count})).collect::<Vec<_>>(),
+        "recent_delivery_failures": bounces.into_iter().take(15).map(|e| serde_json::json!({
+            "ts": e.ts,
+            "to": e.to,
+            "mx_host": e.mx_host,
+            "smtp_code": e.smtp_code,
+            "smtp_reply": e.smtp_reply,
+            "bounce_reason": e.bounce_reason,
+            "risk_score": e.risk_score
+        })).collect::<Vec<_>>(),
+        "rbl": {
+            "sources": rbl_sources,
+            "status": "pending_active_probe",
+            "note": "Connecter un probe DNS périodique pour marquer listed/clean par source RBL"
+        },
+        "diagnostics_hints": [
+            "Vérifier SPF/DKIM/DMARC alignés pour le domaine expéditeur",
+            "Comparer smtp_code/smtp_reply des bounces pour isoler policy vs reputation",
+            "Analyser la latence DNS/TLS avant DATA pour détecter throttling provider"
+        ]
+    }))
+}
+
+async fn api_admin_observability_overview(
+    query: web::Query<AdminWindowQuery>,
+    mongo: web::Data<Arc<mongodb::Client>>,
+) -> impl Responder {
+    use simple_smtp_server::security::audit;
+
+    let since = since_str(&query.window);
+    let base_filter = doc! { "ts": { "$gte": &since } };
+
+    let total = storage::count_events(&mongo, base_filter.clone()).await;
+    let by_status_docs = storage::aggregate(
+        &mongo,
+        vec![
+            doc! { "$match": base_filter.clone() },
+            doc! { "$group": { "_id": "$status", "count": { "$sum": 1 }, "avg_ms": { "$avg": "$total_ms" } } },
+        ],
+    )
+    .await;
+
+    let mut by_status = serde_json::Map::new();
+    let mut queued = 0u64;
+    let mut failed = 0u64;
+    for doc in &by_status_docs {
+        let status = doc.get_str("_id").unwrap_or("unknown").to_string();
+        let count = doc.get_i64("count").unwrap_or(0) as u64;
+        if status == "queued" || status == "pending" || status == "deferred" {
+            queued += count;
+        }
+        if status == "failed" || status == "bounced" {
+            failed += count;
+        }
+        by_status.insert(status, serde_json::json!(count));
+    }
+
+    let p95 = storage::p95_total_ms(&mongo, base_filter.clone(), 1000).await;
+    let monitoring_alerts =
+        monitoring::alerts::evaluate_alerts(&mongo, parse_window(&query.window).num_minutes(), &AlertConfig::default()).await;
+    let security_alerts = audit::query_active_alerts(&mongo, 300).await;
+
+    let by_domain_docs = storage::aggregate(
+        &mongo,
+        vec![
+            doc! { "$match": base_filter.clone() },
+            doc! { "$project": {
+                "recipient_domain": { "$arrayElemAt": [ { "$split": ["$to", "@"] }, 1 ] },
+                "status": "$status"
+            }},
+            doc! { "$group": {
+                "_id": "$recipient_domain",
+                "count": { "$sum": 1 },
+                "delivered": { "$sum": { "$cond": { "if": { "$eq": ["$status", "delivered"] }, "then": 1, "else": 0 } } },
+                "bounced": { "$sum": { "$cond": { "if": { "$eq": ["$status", "bounced"] }, "then": 1, "else": 0 } } }
+            }},
+            doc! { "$sort": { "count": -1 } },
+            doc! { "$limit": 20 }
+        ],
+    )
+    .await;
+
+    let per_domain = by_domain_docs
+        .into_iter()
+        .map(|d| {
+            serde_json::json!({
+                "domain": d.get_str("_id").unwrap_or("unknown"),
+                "count": d.get_i64("count").unwrap_or(0),
+                "delivered": d.get_i64("delivered").unwrap_or(0),
+                "bounced": d.get_i64("bounced").unwrap_or(0)
+            })
+        })
+        .collect::<Vec<_>>();
+
+    HttpResponse::Ok().json(serde_json::json!({
+        "window": query.window,
+        "since": since,
+        "smtp": {
+            "total_events": total,
+            "queue_depth_estimate": queued,
+            "failure_events": failed,
+            "p95_total_ms": p95,
+            "by_status": by_status
+        },
+        "imap": {
+            "active_connections": env::var("IMAP_ACTIVE_CONNECTIONS").ok().and_then(|v| v.parse::<u64>().ok()),
+            "note": "Connecter un compteur runtime IMAP pour une métrique live fiable"
+        },
+        "realtime_alerts": {
+            "monitoring_active": monitoring_alerts.len(),
+            "security_active": security_alerts.len()
+        },
+        "per_domain": per_domain,
+        "exports": {
+            "prometheus_enabled": env_bool("PROMETHEUS_EXPORT_ENABLED", true),
+            "prometheus_path": env::var("PROMETHEUS_EXPORT_PATH").unwrap_or_else(|_| "/metrics".to_string()),
+            "siem_webhook_configured": env::var("SIEM_WEBHOOK_URL").map(|v| !v.trim().is_empty()).unwrap_or(false)
+        }
+    }))
 }
 
 /// Accents → ASCII, non-alphanumériques supprimés, minuscules.
@@ -4805,6 +5071,18 @@ async fn main() -> std::io::Result<()> {
                 .route(
                     "/api/security/remediation/{alert_id}/rollback",
                     web::post().to(api_security_rollback),
+                )
+                .route(
+                    "/api/admin/security/posture",
+                    web::get().to(api_admin_security_posture),
+                )
+                .route(
+                    "/api/admin/deliverability/diagnostics",
+                    web::get().to(api_admin_deliverability_diagnostics),
+                )
+                .route(
+                    "/api/admin/observability/overview",
+                    web::get().to(api_admin_observability_overview),
                 )
         })
         .bind(http_addr)

--- a/src/bin/email_api.rs
+++ b/src/bin/email_api.rs
@@ -996,14 +996,21 @@ async fn api_admin_deliverability_diagnostics(
     let mut top_reasons: Vec<(String, u32)> = bounce_reasons.into_iter().collect();
     top_reasons.sort_by(|a, b| b.1.cmp(&a.1));
 
-    let auth_alerts = audit::query_active_alerts(&mongo, 300)
-        .await
-        .into_iter()
-        .filter(|a| {
-            let n = a.rule_name.to_ascii_lowercase();
-            n.contains("spf") || n.contains("dkim") || n.contains("dmarc")
-        })
-        .count();
+    let active_security_alerts = audit::query_active_alerts(&mongo, 300).await;
+    let spf_failures = active_security_alerts
+        .iter()
+        .filter(|a| a.rule_name.to_ascii_lowercase().contains("spf"))
+        .count() as u64;
+    let dkim_failures = active_security_alerts
+        .iter()
+        .filter(|a| a.rule_name.to_ascii_lowercase().contains("dkim"))
+        .count() as u64;
+    let dmarc_failures = active_security_alerts
+        .iter()
+        .filter(|a| a.rule_name.to_ascii_lowercase().contains("dmarc"))
+        .count() as u64;
+
+    let auth_alerts = spf_failures + dkim_failures + dmarc_failures;
 
     let rbl_sources = env::var("RBL_CHECK_HOSTS")
         .unwrap_or_else(|_| "zen.spamhaus.org,bl.spamcop.net".to_string())
@@ -1012,6 +1019,37 @@ async fn api_admin_deliverability_diagnostics(
         .filter(|s| !s.is_empty())
         .collect::<Vec<_>>();
 
+    let rbl_listed_by = env::var("RBL_LISTED_BY")
+        .unwrap_or_default()
+        .split(',')
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+        .collect::<Vec<_>>();
+
+    let risk_docs = storage::aggregate(
+        &mongo,
+        vec![
+            doc! { "$match": filter.clone() },
+            doc! { "$group": {
+                "_id": null,
+                "avg_risk": { "$avg": "$risk_score" },
+                "high_risk_events": { "$sum": { "$cond": { "if": { "$gte": ["$risk_score", 70] }, "then": 1, "else": 0 } } }
+            }},
+        ],
+    )
+    .await;
+
+    let avg_risk_score = risk_docs
+        .first()
+        .and_then(|d| d.get_f64("avg_risk").ok())
+        .unwrap_or(0.0);
+    let high_risk_events = risk_docs
+        .first()
+        .and_then(|d| d.get_i64("high_risk_events").ok())
+        .unwrap_or(0);
+
+    let denom = if total == 0 { 1.0 } else { total as f64 };
+
     HttpResponse::Ok().json(serde_json::json!({
         "window": query.window,
         "since": since,
@@ -1019,6 +1057,23 @@ async fn api_admin_deliverability_diagnostics(
         "total_events": total,
         "bounces_total": bounces.len(),
         "auth_policy_alerts": auth_alerts,
+        "spf": {
+            "failures": spf_failures,
+            "failure_rate": (spf_failures as f64 / denom)
+        },
+        "dkim": {
+            "failures": dkim_failures,
+            "failure_rate": (dkim_failures as f64 / denom)
+        },
+        "dmarc": {
+            "failures": dmarc_failures,
+            "failure_rate": (dmarc_failures as f64 / denom)
+        },
+        "reputation": {
+            "avg_risk_score": (avg_risk_score * 10.0).round() / 10.0,
+            "high_risk_events": high_risk_events,
+            "ip_domain_status": if high_risk_events > 0 { "degraded" } else { "normal" }
+        },
         "top_bounce_reasons": top_reasons.into_iter().take(10).map(|(reason, count)| serde_json::json!({"reason": reason, "count": count})).collect::<Vec<_>>(),
         "recent_delivery_failures": bounces.into_iter().take(15).map(|e| serde_json::json!({
             "ts": e.ts,
@@ -1031,8 +1086,9 @@ async fn api_admin_deliverability_diagnostics(
         })).collect::<Vec<_>>(),
         "rbl": {
             "sources": rbl_sources,
-            "status": "pending_active_probe",
-            "note": "Connecter un probe DNS périodique pour marquer listed/clean par source RBL"
+            "listed_by": rbl_listed_by,
+            "status": if !env::var("RBL_LISTED_BY").unwrap_or_default().trim().is_empty() { "listed" } else { "clean_or_unknown" },
+            "note": "Renseigner RBL_LISTED_BY pour refléter les listes noires détectées par un probe DNS"
         },
         "diagnostics_hints": [
             "Vérifier SPF/DKIM/DMARC alignés pour le domaine expéditeur",
@@ -1049,6 +1105,7 @@ async fn api_admin_observability_overview(
     use simple_smtp_server::security::audit;
 
     let since = since_str(&query.window);
+    let window_minutes = parse_window(&query.window).num_minutes().max(1) as f64;
     let base_filter = doc! { "ts": { "$gte": &since } };
 
     let total = storage::count_events(&mongo, base_filter.clone()).await;
@@ -1062,24 +1119,146 @@ async fn api_admin_observability_overview(
     .await;
 
     let mut by_status = serde_json::Map::new();
-    let mut queued = 0u64;
+    let mut delivered = 0u64;
+    let mut bounced = 0u64;
     let mut failed = 0u64;
+    let mut deferred = 0u64;
+
     for doc in &by_status_docs {
         let status = doc.get_str("_id").unwrap_or("unknown").to_string();
         let count = doc.get_i64("count").unwrap_or(0) as u64;
-        if status == "queued" || status == "pending" || status == "deferred" {
-            queued += count;
-        }
-        if status == "failed" || status == "bounced" {
-            failed += count;
+        match status.as_str() {
+            "delivered" => delivered = count,
+            "bounced" => bounced = count,
+            "failed" => failed = count,
+            "deferred" => deferred = count,
+            _ => {}
         }
         by_status.insert(status, serde_json::json!(count));
     }
 
     let p95 = storage::p95_total_ms(&mongo, base_filter.clone(), 1000).await;
-    let monitoring_alerts =
-        monitoring::alerts::evaluate_alerts(&mongo, parse_window(&query.window).num_minutes(), &AlertConfig::default()).await;
+
+    let outcome_total = delivered + bounced + failed + deferred;
+    let success_rate = if outcome_total == 0 {
+        0.0
+    } else {
+        delivered as f64 / outcome_total as f64
+    };
+
+    // SMTP queue depth + oldest age
+    let db = env::var("MONGODB_DATABASE").unwrap_or_else(|_| "mailserver".to_string());
+    let queue_coll = mongo
+        .database(&db)
+        .collection::<bson::Document>(SEND_QUEUE_COLL);
+    let pending_queue_filter = doc! { "status": { "$in": ["pending", "scheduled", "sending"] } };
+    let queue_depth = queue_coll
+        .count_documents(pending_queue_filter.clone())
+        .await
+        .unwrap_or(0);
+
+    let oldest_pending = queue_coll
+        .find_one(pending_queue_filter.clone())
+        .sort(doc! { "created_at": 1 })
+        .await
+        .ok()
+        .flatten();
+    let queue_oldest_age_seconds = oldest_pending
+        .as_ref()
+        .and_then(|d| d.get_datetime("created_at").ok())
+        .map(|dt| (Utc::now().timestamp_millis() - dt.timestamp_millis()).max(0) as u64 / 1000);
+
+    // Throughput and SMTP response classes
+    let incoming_events = storage::count_events(
+        &mongo,
+        doc! { "ts": { "$gte": &since }, "event_type": { "$in": ["accepted", "received"] } },
+    )
+    .await;
+    let outgoing_events = storage::count_events(
+        &mongo,
+        doc! { "ts": { "$gte": &since }, "status": { "$in": ["delivered", "bounced", "failed", "deferred"] } },
+    )
+    .await;
+
+    let smtp_4xx = storage::count_events(
+        &mongo,
+        doc! { "ts": { "$gte": &since }, "smtp_code": { "$gte": 400, "$lt": 500 } },
+    )
+    .await;
+    let smtp_5xx = storage::count_events(
+        &mongo,
+        doc! { "ts": { "$gte": &since }, "smtp_code": { "$gte": 500, "$lt": 600 } },
+    )
+    .await;
+
+    let monitoring_alerts = monitoring::alerts::evaluate_alerts(
+        &mongo,
+        parse_window(&query.window).num_minutes(),
+        &AlertConfig::default(),
+    )
+    .await;
     let security_alerts = audit::query_active_alerts(&mongo, 300).await;
+
+    let queue_growth_alerts = monitoring_alerts
+        .iter()
+        .filter(|a| a.kind.contains("queue") || a.message.to_ascii_lowercase().contains("queue"))
+        .count();
+    let auth_failure_alerts = security_alerts
+        .iter()
+        .filter(|a| {
+            let n = a.rule_name.to_ascii_lowercase();
+            n.contains("auth") || n.contains("brute") || n.contains("login")
+        })
+        .count();
+    let anomaly_alerts = security_alerts
+        .iter()
+        .filter(|a| {
+            let n = a.rule_name.to_ascii_lowercase();
+            n.contains("volume") || n.contains("spike") || n.contains("anormal") || n.contains("anomaly")
+        })
+        .count();
+
+    let dns_issue_events = storage::count_events(
+        &mongo,
+        doc! { "ts": { "$gte": &since }, "event_type": "dns_lookup", "status": { "$in": ["failed", "deferred"] } },
+    )
+    .await;
+
+    let rbl_sources = env::var("RBL_CHECK_HOSTS")
+        .unwrap_or_else(|_| "zen.spamhaus.org,bl.spamcop.net".to_string())
+        .split(',')
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+        .collect::<Vec<_>>();
+    let rbl_listed_by = env::var("RBL_LISTED_BY")
+        .unwrap_or_default()
+        .split(',')
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+        .collect::<Vec<_>>();
+
+    let auth_events_coll = mongo
+        .database(&db)
+        .collection::<bson::Document>("auth_events");
+    let suspicious_login_docs = match auth_events_coll
+        .aggregate(vec![
+            doc! { "$match": { "ts": { "$gte": &since }, "success": false } },
+            doc! { "$group": { "_id": "$ip", "attempts": { "$sum": 1 } } },
+            doc! { "$sort": { "attempts": -1 } },
+            doc! { "$limit": 10 },
+        ])
+        .await
+    {
+        Ok(cursor) => cursor.try_collect::<Vec<_>>().await.unwrap_or_default(),
+        Err(_) => Vec::new(),
+    };
+    let suspicious_logins_top = suspicious_login_docs
+        .into_iter()
+        .map(|d| serde_json::json!({
+            "ip": d.get_str("_id").unwrap_or("unknown"),
+            "attempts": d.get_i64("attempts").unwrap_or(0)
+        }))
+        .collect::<Vec<_>>();
 
     let by_domain_docs = storage::aggregate(
         &mongo,
@@ -1118,10 +1297,55 @@ async fn api_admin_observability_overview(
         "since": since,
         "smtp": {
             "total_events": total,
-            "queue_depth_estimate": queued,
-            "failure_events": failed,
+            "failure_events": failed + bounced,
             "p95_total_ms": p95,
             "by_status": by_status
+        },
+        "health_realtime": {
+            "queue": {
+                "depth": queue_depth,
+                "oldest_age_seconds": queue_oldest_age_seconds
+            },
+            "throughput": {
+                "incoming_per_min": ((incoming_events as f64 / window_minutes) * 100.0).round() / 100.0,
+                "outgoing_per_min": ((outgoing_events as f64 / window_minutes) * 100.0).round() / 100.0
+            },
+            "delivery": {
+                "success_rate": (success_rate * 10000.0).round() / 10000.0,
+                "smtp_4xx_rate": if total == 0 { 0.0 } else { ((smtp_4xx as f64 / total as f64) * 10000.0).round() / 10000.0 },
+                "smtp_5xx_rate": if total == 0 { 0.0 } else { ((smtp_5xx as f64 / total as f64) * 10000.0).round() / 10000.0 },
+                "p95_total_ms": p95
+            }
+        },
+        "proactive_alerting": {
+            "threshold_alerts": {
+                "queue_growth": queue_growth_alerts,
+                "auth_failures": auth_failure_alerts,
+                "imap_latency_alert": env::var("IMAP_P95_MS").ok().and_then(|v| v.parse::<u64>().ok()).map(|v| v > env::var("IMAP_P95_MS_THRESHOLD").ok().and_then(|t| t.parse::<u64>().ok()).unwrap_or(4000)).unwrap_or(false)
+            },
+            "anomaly_detection": {
+                "anomaly_alerts": anomaly_alerts,
+                "spam_or_volume_spike": anomaly_alerts > 0,
+                "sudden_bounce_signal": monitoring_alerts.iter().any(|a| a.kind == "bounce_rate")
+            },
+            "correlation": {
+                "smtp": { "events": total, "smtp_4xx": smtp_4xx, "smtp_5xx": smtp_5xx },
+                "imap": {
+                    "active_connections": env::var("IMAP_ACTIVE_CONNECTIONS").ok().and_then(|v| v.parse::<u64>().ok()),
+                    "p95_ms": env::var("IMAP_P95_MS").ok().and_then(|v| v.parse::<u64>().ok())
+                },
+                "dns": { "lookup_issue_events": dns_issue_events },
+                "blacklist": {
+                    "sources": rbl_sources,
+                    "listed_by": rbl_listed_by,
+                    "listed": !env::var("RBL_LISTED_BY").unwrap_or_default().trim().is_empty()
+                }
+            }
+        },
+        "security_deliverability": {
+            "suspicious_logins_top": suspicious_logins_top,
+            "active_security_alerts": security_alerts.len(),
+            "active_monitoring_alerts": monitoring_alerts.len()
         },
         "imap": {
             "active_connections": env::var("IMAP_ACTIVE_CONNECTIONS").ok().and_then(|v| v.parse::<u64>().ok()),


### PR DESCRIPTION
## Summary
- add realtime SMTP flow health metrics to `/api/admin/observability/overview`
- expose queue depth + oldest age, throughput in/out, success rate and 4xx/5xx rates
- add proactive alerting snapshot (threshold/anomaly) and correlation block (SMTP + IMAP + DNS + RBL)
- extend `/api/admin/deliverability/diagnostics` with SPF/DKIM/DMARC failure rates and reputation summary

## Validation
- `cargo check --bin email_api`

## Notes
- RBL listed sources are read from `RBL_LISTED_BY` when available.
- IMAP latency alert uses `IMAP_P95_MS` compared to `IMAP_P95_MS_THRESHOLD` (default 4000ms).
