### PR TITLE
feat(admin): add Mongo-backed CRUD APIs for users and change requests

### DIFF
--- a/src/bin/email_api.rs
+++ b/src/bin/email_api.rs
@@ -996,14 +996,21 @@ async fn api_admin_deliverability_diagnostics(
     let mut top_reasons: Vec<(String, u32)> = bounce_reasons.into_iter().collect();
     top_reasons.sort_by(|a, b| b.1.cmp(&a.1));
 
-    let auth_alerts = audit::query_active_alerts(&mongo, 300)
-        .await
-        .into_iter()
-        .filter(|a| {
-            let n = a.rule_name.to_ascii_lowercase();
-            n.contains("spf") || n.contains("dkim") || n.contains("dmarc")
-        })
-        .count();
+    let active_security_alerts = audit::query_active_alerts(&mongo, 300).await;
+    let spf_failures = active_security_alerts
+        .iter()
+        .filter(|a| a.rule_name.to_ascii_lowercase().contains("spf"))
+        .count() as u64;
+    let dkim_failures = active_security_alerts
+        .iter()
+        .filter(|a| a.rule_name.to_ascii_lowercase().contains("dkim"))
+        .count() as u64;
+    let dmarc_failures = active_security_alerts
+        .iter()
+        .filter(|a| a.rule_name.to_ascii_lowercase().contains("dmarc"))
+        .count() as u64;
+
+    let auth_alerts = spf_failures + dkim_failures + dmarc_failures;
 
     let rbl_sources = env::var("RBL_CHECK_HOSTS")
         .unwrap_or_else(|_| "zen.spamhaus.org,bl.spamcop.net".to_string())
@@ -1012,6 +1019,37 @@ async fn api_admin_deliverability_diagnostics(
         .filter(|s| !s.is_empty())
         .collect::<Vec<_>>();
 
+    let rbl_listed_by = env::var("RBL_LISTED_BY")
+        .unwrap_or_default()
+        .split(',')
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+        .collect::<Vec<_>>();
+
+    let risk_docs = storage::aggregate(
+        &mongo,
+        vec![
+            doc! { "$match": filter.clone() },
+            doc! { "$group": {
+                "_id": null,
+                "avg_risk": { "$avg": "$risk_score" },
+                "high_risk_events": { "$sum": { "$cond": { "if": { "$gte": ["$risk_score", 70] }, "then": 1, "else": 0 } } }
+            }},
+        ],
+    )
+    .await;
+
+    let avg_risk_score = risk_docs
+        .first()
+        .and_then(|d| d.get_f64("avg_risk").ok())
+        .unwrap_or(0.0);
+    let high_risk_events = risk_docs
+        .first()
+        .and_then(|d| d.get_i64("high_risk_events").ok())
+        .unwrap_or(0);
+
+    let denom = if total == 0 { 1.0 } else { total as f64 };
+
     HttpResponse::Ok().json(serde_json::json!({
         "window": query.window,
         "since": since,
@@ -1019,6 +1057,23 @@ async fn api_admin_deliverability_diagnostics(
         "total_events": total,
         "bounces_total": bounces.len(),
         "auth_policy_alerts": auth_alerts,
+        "spf": {
+            "failures": spf_failures,
+            "failure_rate": (spf_failures as f64 / denom)
+        },
+        "dkim": {
+            "failures": dkim_failures,
+            "failure_rate": (dkim_failures as f64 / denom)
+        },
+        "dmarc": {
+            "failures": dmarc_failures,
+            "failure_rate": (dmarc_failures as f64 / denom)
+        },
+        "reputation": {
+            "avg_risk_score": (avg_risk_score * 10.0).round() / 10.0,
+            "high_risk_events": high_risk_events,
+            "ip_domain_status": if high_risk_events > 0 { "degraded" } else { "normal" }
+        },
         "top_bounce_reasons": top_reasons.into_iter().take(10).map(|(reason, count)| serde_json::json!({"reason": reason, "count": count})).collect::<Vec<_>>(),
         "recent_delivery_failures": bounces.into_iter().take(15).map(|e| serde_json::json!({
             "ts": e.ts,
@@ -1031,8 +1086,9 @@ async fn api_admin_deliverability_diagnostics(
         })).collect::<Vec<_>>(),
         "rbl": {
             "sources": rbl_sources,
-            "status": "pending_active_probe",
-            "note": "Connecter un probe DNS périodique pour marquer listed/clean par source RBL"
+            "listed_by": rbl_listed_by,
+            "status": if !env::var("RBL_LISTED_BY").unwrap_or_default().trim().is_empty() { "listed" } else { "clean_or_unknown" },
+            "note": "Renseigner RBL_LISTED_BY pour refléter les listes noires détectées par un probe DNS"
         },
         "diagnostics_hints": [
             "Vérifier SPF/DKIM/DMARC alignés pour le domaine expéditeur",
@@ -1049,6 +1105,7 @@ async fn api_admin_observability_overview(
     use simple_smtp_server::security::audit;
 
     let since = since_str(&query.window);
+    let window_minutes = parse_window(&query.window).num_minutes().max(1) as f64;
     let base_filter = doc! { "ts": { "$gte": &since } };
 
     let total = storage::count_events(&mongo, base_filter.clone()).await;
@@ -1062,24 +1119,146 @@ async fn api_admin_observability_overview(
     .await;
 
     let mut by_status = serde_json::Map::new();
-    let mut queued = 0u64;
+    let mut delivered = 0u64;
+    let mut bounced = 0u64;
     let mut failed = 0u64;
+    let mut deferred = 0u64;
+
     for doc in &by_status_docs {
         let status = doc.get_str("_id").unwrap_or("unknown").to_string();
         let count = doc.get_i64("count").unwrap_or(0) as u64;
-        if status == "queued" || status == "pending" || status == "deferred" {
-            queued += count;
-        }
-        if status == "failed" || status == "bounced" {
-            failed += count;
+        match status.as_str() {
+            "delivered" => delivered = count,
+            "bounced" => bounced = count,
+            "failed" => failed = count,
+            "deferred" => deferred = count,
+            _ => {}
         }
         by_status.insert(status, serde_json::json!(count));
     }
 
     let p95 = storage::p95_total_ms(&mongo, base_filter.clone(), 1000).await;
-    let monitoring_alerts =
-        monitoring::alerts::evaluate_alerts(&mongo, parse_window(&query.window).num_minutes(), &AlertConfig::default()).await;
+
+    let outcome_total = delivered + bounced + failed + deferred;
+    let success_rate = if outcome_total == 0 {
+        0.0
+    } else {
+        delivered as f64 / outcome_total as f64
+    };
+
+    // SMTP queue depth + oldest age
+    let db = env::var("MONGODB_DATABASE").unwrap_or_else(|_| "mailserver".to_string());
+    let queue_coll = mongo
+        .database(&db)
+        .collection::<bson::Document>(SEND_QUEUE_COLL);
+    let pending_queue_filter = doc! { "status": { "$in": ["pending", "scheduled", "sending"] } };
+    let queue_depth = queue_coll
+        .count_documents(pending_queue_filter.clone())
+        .await
+        .unwrap_or(0);
+
+    let oldest_pending = queue_coll
+        .find_one(pending_queue_filter.clone())
+        .sort(doc! { "created_at": 1 })
+        .await
+        .ok()
+        .flatten();
+    let queue_oldest_age_seconds = oldest_pending
+        .as_ref()
+        .and_then(|d| d.get_datetime("created_at").ok())
+        .map(|dt| (Utc::now().timestamp_millis() - dt.timestamp_millis()).max(0) as u64 / 1000);
+
+    // Throughput and SMTP response classes
+    let incoming_events = storage::count_events(
+        &mongo,
+        doc! { "ts": { "$gte": &since }, "event_type": { "$in": ["accepted", "received"] } },
+    )
+    .await;
+    let outgoing_events = storage::count_events(
+        &mongo,
+        doc! { "ts": { "$gte": &since }, "status": { "$in": ["delivered", "bounced", "failed", "deferred"] } },
+    )
+    .await;
+
+    let smtp_4xx = storage::count_events(
+        &mongo,
+        doc! { "ts": { "$gte": &since }, "smtp_code": { "$gte": 400, "$lt": 500 } },
+    )
+    .await;
+    let smtp_5xx = storage::count_events(
+        &mongo,
+        doc! { "ts": { "$gte": &since }, "smtp_code": { "$gte": 500, "$lt": 600 } },
+    )
+    .await;
+
+    let monitoring_alerts = monitoring::alerts::evaluate_alerts(
+        &mongo,
+        parse_window(&query.window).num_minutes(),
+        &AlertConfig::default(),
+    )
+    .await;
     let security_alerts = audit::query_active_alerts(&mongo, 300).await;
+
+    let queue_growth_alerts = monitoring_alerts
+        .iter()
+        .filter(|a| a.kind.contains("queue") || a.message.to_ascii_lowercase().contains("queue"))
+        .count();
+    let auth_failure_alerts = security_alerts
+        .iter()
+        .filter(|a| {
+            let n = a.rule_name.to_ascii_lowercase();
+            n.contains("auth") || n.contains("brute") || n.contains("login")
+        })
+        .count();
+    let anomaly_alerts = security_alerts
+        .iter()
+        .filter(|a| {
+            let n = a.rule_name.to_ascii_lowercase();
+            n.contains("volume") || n.contains("spike") || n.contains("anormal") || n.contains("anomaly")
+        })
+        .count();
+
+    let dns_issue_events = storage::count_events(
+        &mongo,
+        doc! { "ts": { "$gte": &since }, "event_type": "dns_lookup", "status": { "$in": ["failed", "deferred"] } },
+    )
+    .await;
+
+    let rbl_sources = env::var("RBL_CHECK_HOSTS")
+        .unwrap_or_else(|_| "zen.spamhaus.org,bl.spamcop.net".to_string())
+        .split(',')
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+        .collect::<Vec<_>>();
+    let rbl_listed_by = env::var("RBL_LISTED_BY")
+        .unwrap_or_default()
+        .split(',')
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+        .collect::<Vec<_>>();
+
+    let auth_events_coll = mongo
+        .database(&db)
+        .collection::<bson::Document>("auth_events");
+    let suspicious_login_docs = match auth_events_coll
+        .aggregate(vec![
+            doc! { "$match": { "ts": { "$gte": &since }, "success": false } },
+            doc! { "$group": { "_id": "$ip", "attempts": { "$sum": 1 } } },
+            doc! { "$sort": { "attempts": -1 } },
+            doc! { "$limit": 10 },
+        ])
+        .await
+    {
+        Ok(cursor) => cursor.try_collect::<Vec<_>>().await.unwrap_or_default(),
+        Err(_) => Vec::new(),
+    };
+    let suspicious_logins_top = suspicious_login_docs
+        .into_iter()
+        .map(|d| serde_json::json!({
+            "ip": d.get_str("_id").unwrap_or("unknown"),
+            "attempts": d.get_i64("attempts").unwrap_or(0)
+        }))
+        .collect::<Vec<_>>();
 
     let by_domain_docs = storage::aggregate(
         &mongo,
@@ -1118,10 +1297,55 @@ async fn api_admin_observability_overview(
         "since": since,
         "smtp": {
             "total_events": total,
-            "queue_depth_estimate": queued,
-            "failure_events": failed,
+            "failure_events": failed + bounced,
             "p95_total_ms": p95,
             "by_status": by_status
+        },
+        "health_realtime": {
+            "queue": {
+                "depth": queue_depth,
+                "oldest_age_seconds": queue_oldest_age_seconds
+            },
+            "throughput": {
+                "incoming_per_min": ((incoming_events as f64 / window_minutes) * 100.0).round() / 100.0,
+                "outgoing_per_min": ((outgoing_events as f64 / window_minutes) * 100.0).round() / 100.0
+            },
+            "delivery": {
+                "success_rate": (success_rate * 10000.0).round() / 10000.0,
+                "smtp_4xx_rate": if total == 0 { 0.0 } else { ((smtp_4xx as f64 / total as f64) * 10000.0).round() / 10000.0 },
+                "smtp_5xx_rate": if total == 0 { 0.0 } else { ((smtp_5xx as f64 / total as f64) * 10000.0).round() / 10000.0 },
+                "p95_total_ms": p95
+            }
+        },
+        "proactive_alerting": {
+            "threshold_alerts": {
+                "queue_growth": queue_growth_alerts,
+                "auth_failures": auth_failure_alerts,
+                "imap_latency_alert": env::var("IMAP_P95_MS").ok().and_then(|v| v.parse::<u64>().ok()).map(|v| v > env::var("IMAP_P95_MS_THRESHOLD").ok().and_then(|t| t.parse::<u64>().ok()).unwrap_or(4000)).unwrap_or(false)
+            },
+            "anomaly_detection": {
+                "anomaly_alerts": anomaly_alerts,
+                "spam_or_volume_spike": anomaly_alerts > 0,
+                "sudden_bounce_signal": monitoring_alerts.iter().any(|a| a.kind == "bounce_rate")
+            },
+            "correlation": {
+                "smtp": { "events": total, "smtp_4xx": smtp_4xx, "smtp_5xx": smtp_5xx },
+                "imap": {
+                    "active_connections": env::var("IMAP_ACTIVE_CONNECTIONS").ok().and_then(|v| v.parse::<u64>().ok()),
+                    "p95_ms": env::var("IMAP_P95_MS").ok().and_then(|v| v.parse::<u64>().ok())
+                },
+                "dns": { "lookup_issue_events": dns_issue_events },
+                "blacklist": {
+                    "sources": rbl_sources,
+                    "listed_by": rbl_listed_by,
+                    "listed": !env::var("RBL_LISTED_BY").unwrap_or_default().trim().is_empty()
+                }
+            }
+        },
+        "security_deliverability": {
+            "suspicious_logins_top": suspicious_logins_top,
+            "active_security_alerts": security_alerts.len(),
+            "active_monitoring_alerts": monitoring_alerts.len()
         },
         "imap": {
             "active_connections": env::var("IMAP_ACTIVE_CONNECTIONS").ok().and_then(|v| v.parse::<u64>().ok()),

--- a/src/bin/email_api.rs
+++ b/src/bin/email_api.rs
@@ -51,7 +51,9 @@ use futures_util::{stream, TryStreamExt};
 use mongodb::bson;
 use mongodb::bson::doc;
 use reqwest;
-use simple_smtp_server::entities::{CalendarEvent, Email};
+use simple_smtp_server::entities::{
+    AdminUserActivity, AdminUserRecord, CalendarEvent, ChangeRequestItem, Email, WorkflowStage,
+};
 use simple_smtp_server::external_imap::{
     CreateExternalAccountInput, ExternalImapService, ExternalMessageActionInput,
     ExternalFolderMappingInput, StartSyncInput, UpdateExternalAccountInput,
@@ -3865,6 +3867,610 @@ async fn api_drafts_delete(
     }
 }
 
+const ADMIN_USERS_COLL: &str = "admin_users";
+const ADMIN_CHANGE_REQUESTS_COLL: &str = "admin_change_requests";
+
+fn now_iso() -> String {
+    Utc::now().to_rfc3339()
+}
+
+fn admin_workflow_order() -> Vec<&'static str> {
+    vec!["submitted", "triaged", "planned", "in_progress", "qa", "released"]
+}
+
+fn compute_priority(urgency: &str, impact: &str) -> String {
+    if urgency == "high" && impact == "high" {
+        "P0".to_string()
+    } else if urgency == "high" || impact == "high" {
+        "P1".to_string()
+    } else {
+        "P2".to_string()
+    }
+}
+
+fn build_initial_stages() -> Vec<WorkflowStage> {
+    vec![
+        WorkflowStage {
+            key: "discovery".to_string(),
+            label: "Discovery produit".to_string(),
+            owner: "product".to_string(),
+            status: "active".to_string(),
+            checklist: vec![
+                "Clarifier le problème utilisateur".to_string(),
+                "Mesurer impact business/ops".to_string(),
+                "Valider la portée UX + Backend".to_string(),
+            ],
+            done_at: None,
+        },
+        WorkflowStage {
+            key: "spec".to_string(),
+            label: "Spécification".to_string(),
+            owner: "backend".to_string(),
+            status: "pending".to_string(),
+            checklist: vec![
+                "Définir contrat API + payload".to_string(),
+                "Définir telemetry & changelog".to_string(),
+            ],
+            done_at: None,
+        },
+        WorkflowStage {
+            key: "build".to_string(),
+            label: "Implémentation".to_string(),
+            owner: "frontend".to_string(),
+            status: "pending".to_string(),
+            checklist: vec![
+                "Implémenter UI/UX".to_string(),
+                "Implémenter endpoint backend".to_string(),
+                "Ajouter tests critiques".to_string(),
+            ],
+            done_at: None,
+        },
+        WorkflowStage {
+            key: "qa".to_string(),
+            label: "Validation".to_string(),
+            owner: "qa".to_string(),
+            status: "pending".to_string(),
+            checklist: vec![
+                "Typecheck + lint + tests".to_string(),
+                "Validation de non-régression admin".to_string(),
+            ],
+            done_at: None,
+        },
+        WorkflowStage {
+            key: "release".to_string(),
+            label: "Rollout".to_string(),
+            owner: "ops".to_string(),
+            status: "pending".to_string(),
+            checklist: vec![
+                "Publier changelog".to_string(),
+                "Surveiller métriques post-release".to_string(),
+                "Préparer rollback playbook".to_string(),
+            ],
+            done_at: None,
+        },
+    ]
+}
+
+fn build_acceptance_criteria(scope: &str) -> Vec<String> {
+    let mut base = vec![
+        "Le flux admin expose un état lisible de la demande".to_string(),
+        "Le backend retourne un état workflow déterministe".to_string(),
+        "Le changement apparaît dans le flux changelog une fois released".to_string(),
+    ];
+
+    if scope == "ux" || scope == "fullstack" {
+        base.push("Parcours UX sans ambiguïté: soumission -> triage -> release".to_string());
+    }
+    if scope == "backend" || scope == "fullstack" {
+        base.push("Contrat API versionné et validé sur payloads invalides".to_string());
+    }
+    if scope == "security" {
+        base.push("Audit trail incluant owner, horodatage et note de transition".to_string());
+    }
+
+    base
+}
+
+fn advance_workflow(stages: &[WorkflowStage]) -> Vec<WorkflowStage> {
+    let now = now_iso();
+    let current_idx = stages.iter().position(|s| s.status == "active");
+    if current_idx.is_none() {
+        return stages.to_vec();
+    }
+    let current_idx = current_idx.unwrap();
+    stages
+        .iter()
+        .enumerate()
+        .map(|(idx, stage)| {
+            if idx == current_idx {
+                let mut done = stage.clone();
+                done.status = "done".to_string();
+                done.done_at = Some(now.clone());
+                done
+            } else if idx == current_idx + 1 {
+                let mut active = stage.clone();
+                active.status = "active".to_string();
+                active
+            } else {
+                stage.clone()
+            }
+        })
+        .collect()
+}
+
+fn status_counts(items: &[ChangeRequestItem]) -> serde_json::Value {
+    let mut map = serde_json::Map::new();
+    for status in [
+        "submitted",
+        "triaged",
+        "planned",
+        "in_progress",
+        "qa",
+        "released",
+        "rejected",
+    ] {
+        map.insert(status.to_string(), serde_json::Value::from(0));
+    }
+    for item in items {
+        if let Some(v) = map.get_mut(&item.status) {
+            let next = v.as_i64().unwrap_or(0) + 1;
+            *v = serde_json::Value::from(next);
+        }
+    }
+    serde_json::Value::Object(map)
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct CreateAdminUserInput {
+    id: Option<String>,
+    email: String,
+    display_name: Option<String>,
+    role: String,
+    status: Option<String>,
+    two_factor_enabled: Option<bool>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct UpdateAdminUserInput {
+    role: Option<String>,
+    status: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct CreateChangeRequestInputApi {
+    title: String,
+    problem: String,
+    desired_outcome: String,
+    scope: String,
+    urgency: String,
+    impact: String,
+    requested_by: String,
+    linked_repo: String,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct PatchChangeRequestInputApi {
+    action: Option<String>,
+    note: Option<String>,
+    title: Option<String>,
+    problem: Option<String>,
+    desired_outcome: Option<String>,
+    status: Option<String>,
+}
+
+async fn api_admin_users_list(mongo: web::Data<Arc<mongodb::Client>>) -> impl Responder {
+    let coll = mongo
+        .database(&mongo_db_name())
+        .collection::<AdminUserRecord>(ADMIN_USERS_COLL);
+
+    match coll.find(doc! {}).sort(doc! { "lastActivityAt": -1 }).limit(500).await {
+        Ok(cursor) => {
+            let users = cursor.try_collect::<Vec<AdminUserRecord>>().await.unwrap_or_default();
+            HttpResponse::Ok().json(serde_json::json!({
+                "generatedAt": now_iso(),
+                "users": users,
+            }))
+        }
+        Err(e) => {
+            eprintln!("api_admin_users_list error: {}", e);
+            HttpResponse::InternalServerError().json(serde_json::json!({ "message": "Failed to load admin users" }))
+        }
+    }
+}
+
+async fn api_admin_user_get(
+    path: web::Path<String>,
+    mongo: web::Data<Arc<mongodb::Client>>,
+) -> impl Responder {
+    let id = path.into_inner();
+    let coll = mongo
+        .database(&mongo_db_name())
+        .collection::<AdminUserRecord>(ADMIN_USERS_COLL);
+
+    match coll.find_one(doc! { "id": &id }).await {
+        Ok(Some(user)) => HttpResponse::Ok().json(serde_json::json!({ "user": user })),
+        Ok(None) => HttpResponse::NotFound().json(serde_json::json!({ "message": "User not found" })),
+        Err(e) => {
+            eprintln!("api_admin_user_get error: {}", e);
+            HttpResponse::InternalServerError().json(serde_json::json!({ "message": "Failed to load user" }))
+        }
+    }
+}
+
+async fn api_admin_user_create(
+    body: web::Json<CreateAdminUserInput>,
+    mongo: web::Data<Arc<mongodb::Client>>,
+) -> impl Responder {
+    let role = body.role.trim().to_ascii_lowercase();
+    if !["user", "admin", "support"].contains(&role.as_str()) {
+        return HttpResponse::BadRequest().json(serde_json::json!({ "message": "role must be user|admin|support" }));
+    }
+
+    let status = body
+        .status
+        .as_deref()
+        .unwrap_or("active")
+        .trim()
+        .to_ascii_lowercase();
+    if !["active", "restricted"].contains(&status.as_str()) {
+        return HttpResponse::BadRequest().json(serde_json::json!({ "message": "status must be active|restricted" }));
+    }
+
+    let id = body
+        .id
+        .clone()
+        .unwrap_or_else(|| format!("u_{}", Uuid::new_v4().simple()));
+    let now = now_iso();
+
+    let user = AdminUserRecord {
+        id: id.clone(),
+        email: body.email.trim().to_string(),
+        display_name: body.display_name.clone(),
+        role,
+        status,
+        two_factor_enabled: body.two_factor_enabled.unwrap_or(false),
+        last_login_at: None,
+        last_activity_at: Some(now.clone()),
+        sessions24h: 0,
+        actions7d: 0,
+        change_requests30d: 0,
+        recent_activity: vec![AdminUserActivity {
+            at: now.clone(),
+            label: "User created".to_string(),
+            kind: "admin_action".to_string(),
+        }],
+        created_at: now.clone(),
+        updated_at: now,
+    };
+
+    let coll = mongo
+        .database(&mongo_db_name())
+        .collection::<AdminUserRecord>(ADMIN_USERS_COLL);
+
+    match coll.insert_one(&user).await {
+        Ok(_) => HttpResponse::Created().json(serde_json::json!({ "user": user })),
+        Err(e) => {
+            eprintln!("api_admin_user_create error: {}", e);
+            HttpResponse::InternalServerError().json(serde_json::json!({ "message": "Failed to create user" }))
+        }
+    }
+}
+
+async fn api_admin_user_patch(
+    path: web::Path<String>,
+    body: web::Json<UpdateAdminUserInput>,
+    mongo: web::Data<Arc<mongodb::Client>>,
+) -> impl Responder {
+    let id = path.into_inner();
+    let coll = mongo
+        .database(&mongo_db_name())
+        .collection::<AdminUserRecord>(ADMIN_USERS_COLL);
+
+    let current = match coll.find_one(doc! { "id": &id }).await {
+        Ok(Some(v)) => v,
+        Ok(None) => {
+            return HttpResponse::NotFound().json(serde_json::json!({ "message": "User not found" }))
+        }
+        Err(e) => {
+            eprintln!("api_admin_user_patch read error: {}", e);
+            return HttpResponse::InternalServerError().json(serde_json::json!({ "message": "Failed to load user" }));
+        }
+    };
+
+    let now = now_iso();
+    let mut updated = current.clone();
+
+    if let Some(role) = &body.role {
+        let role = role.trim().to_ascii_lowercase();
+        if !["user", "admin", "support"].contains(&role.as_str()) {
+            return HttpResponse::BadRequest().json(serde_json::json!({ "message": "role must be user|admin|support" }));
+        }
+        updated.role = role;
+    }
+
+    if let Some(status) = &body.status {
+        let status = status.trim().to_ascii_lowercase();
+        if !["active", "restricted"].contains(&status.as_str()) {
+            return HttpResponse::BadRequest().json(serde_json::json!({ "message": "status must be active|restricted" }));
+        }
+        updated.status = status;
+    }
+
+    updated.updated_at = now.clone();
+    updated.last_activity_at = Some(now.clone());
+    updated.actions7d += 1;
+    let note = body
+        .role
+        .as_ref()
+        .map(|r| format!("Role changed to {}", r))
+        .unwrap_or_else(|| "User updated".to_string());
+    let mut recent = updated.recent_activity;
+    recent.insert(
+        0,
+        AdminUserActivity {
+            at: now,
+            label: note,
+            kind: "role_change".to_string(),
+        },
+    );
+    recent.truncate(8);
+    updated.recent_activity = recent;
+
+    match coll
+        .replace_one(doc! { "id": &id }, &updated)
+        .upsert(false)
+        .await
+    {
+        Ok(_) => HttpResponse::Ok().json(serde_json::json!({ "user": updated })),
+        Err(e) => {
+            eprintln!("api_admin_user_patch write error: {}", e);
+            HttpResponse::InternalServerError().json(serde_json::json!({ "message": "Failed to update user" }))
+        }
+    }
+}
+
+async fn api_admin_user_delete(
+    path: web::Path<String>,
+    mongo: web::Data<Arc<mongodb::Client>>,
+) -> impl Responder {
+    let id = path.into_inner();
+    let coll = mongo
+        .database(&mongo_db_name())
+        .collection::<AdminUserRecord>(ADMIN_USERS_COLL);
+
+    match coll.delete_one(doc! { "id": &id }).await {
+        Ok(res) if res.deleted_count > 0 => HttpResponse::Ok().json(serde_json::json!({ "deleted": true, "id": id })),
+        Ok(_) => HttpResponse::NotFound().json(serde_json::json!({ "deleted": false, "message": "User not found" })),
+        Err(e) => {
+            eprintln!("api_admin_user_delete error: {}", e);
+            HttpResponse::InternalServerError().json(serde_json::json!({ "message": "Failed to delete user" }))
+        }
+    }
+}
+
+async fn api_admin_change_requests_list(
+    mongo: web::Data<Arc<mongodb::Client>>,
+) -> impl Responder {
+    let coll = mongo
+        .database(&mongo_db_name())
+        .collection::<ChangeRequestItem>(ADMIN_CHANGE_REQUESTS_COLL);
+
+    match coll.find(doc! {}).sort(doc! { "updatedAt": -1 }).limit(500).await {
+        Ok(cursor) => {
+            let items = cursor
+                .try_collect::<Vec<ChangeRequestItem>>()
+                .await
+                .unwrap_or_default();
+            HttpResponse::Ok().json(serde_json::json!({
+                "generatedAt": now_iso(),
+                "counts": status_counts(&items),
+                "items": items,
+            }))
+        }
+        Err(e) => {
+            eprintln!("api_admin_change_requests_list error: {}", e);
+            HttpResponse::InternalServerError().json(serde_json::json!({ "message": "Failed to load change requests" }))
+        }
+    }
+}
+
+async fn api_admin_change_request_get(
+    path: web::Path<String>,
+    mongo: web::Data<Arc<mongodb::Client>>,
+) -> impl Responder {
+    let id = path.into_inner();
+    let coll = mongo
+        .database(&mongo_db_name())
+        .collection::<ChangeRequestItem>(ADMIN_CHANGE_REQUESTS_COLL);
+
+    match coll.find_one(doc! { "id": &id }).await {
+        Ok(Some(item)) => HttpResponse::Ok().json(serde_json::json!({ "item": item })),
+        Ok(None) => HttpResponse::NotFound().json(serde_json::json!({ "message": "Change request not found" })),
+        Err(e) => {
+            eprintln!("api_admin_change_request_get error: {}", e);
+            HttpResponse::InternalServerError().json(serde_json::json!({ "message": "Failed to load change request" }))
+        }
+    }
+}
+
+async fn api_admin_change_request_create(
+    body: web::Json<CreateChangeRequestInputApi>,
+    mongo: web::Data<Arc<mongodb::Client>>,
+) -> impl Responder {
+    let scope = body.scope.trim().to_ascii_lowercase();
+    let urgency = body.urgency.trim().to_ascii_lowercase();
+    let impact = body.impact.trim().to_ascii_lowercase();
+    let linked_repo = body.linked_repo.trim().to_ascii_lowercase();
+
+    if !["ux", "backend", "fullstack", "security"].contains(&scope.as_str()) {
+        return HttpResponse::BadRequest().json(serde_json::json!({ "message": "scope must be ux|backend|fullstack|security" }));
+    }
+    if !["low", "medium", "high"].contains(&urgency.as_str()) {
+        return HttpResponse::BadRequest().json(serde_json::json!({ "message": "urgency must be low|medium|high" }));
+    }
+    if !["small", "medium", "high"].contains(&impact.as_str()) {
+        return HttpResponse::BadRequest().json(serde_json::json!({ "message": "impact must be small|medium|high" }));
+    }
+    if !["misfits-web", "reimagined-guide", "cross-repo"].contains(&linked_repo.as_str()) {
+        return HttpResponse::BadRequest().json(serde_json::json!({ "message": "linkedRepo must be misfits-web|reimagined-guide|cross-repo" }));
+    }
+
+    let now = now_iso();
+    let item = ChangeRequestItem {
+        id: format!("cr_{}", Uuid::new_v4().simple()),
+        title: body.title.trim().to_string(),
+        problem: body.problem.trim().to_string(),
+        desired_outcome: body.desired_outcome.trim().to_string(),
+        scope: scope.clone(),
+        priority: compute_priority(&urgency, &impact),
+        status: "submitted".to_string(),
+        requested_by: body.requested_by.trim().to_string(),
+        linked_repo,
+        created_at: now.clone(),
+        updated_at: now,
+        target_release_window: if urgency == "high" {
+            "next-24h".to_string()
+        } else if urgency == "medium" {
+            "next-72h".to_string()
+        } else {
+            "next-sprint".to_string()
+        },
+        acceptance_criteria: build_acceptance_criteria(&scope),
+        workflow: build_initial_stages(),
+        changelog_entry: None,
+    };
+
+    let coll = mongo
+        .database(&mongo_db_name())
+        .collection::<ChangeRequestItem>(ADMIN_CHANGE_REQUESTS_COLL);
+
+    match coll.insert_one(&item).await {
+        Ok(_) => HttpResponse::Created().json(serde_json::json!({ "item": item })),
+        Err(e) => {
+            eprintln!("api_admin_change_request_create error: {}", e);
+            HttpResponse::InternalServerError().json(serde_json::json!({ "message": "Failed to create change request" }))
+        }
+    }
+}
+
+async fn api_admin_change_request_patch(
+    path: web::Path<String>,
+    body: web::Json<PatchChangeRequestInputApi>,
+    mongo: web::Data<Arc<mongodb::Client>>,
+) -> impl Responder {
+    let id = path.into_inner();
+    let coll = mongo
+        .database(&mongo_db_name())
+        .collection::<ChangeRequestItem>(ADMIN_CHANGE_REQUESTS_COLL);
+
+    let mut item = match coll.find_one(doc! { "id": &id }).await {
+        Ok(Some(v)) => v,
+        Ok(None) => {
+            return HttpResponse::NotFound().json(serde_json::json!({ "message": "Change request not found" }))
+        }
+        Err(e) => {
+            eprintln!("api_admin_change_request_patch read error: {}", e);
+            return HttpResponse::InternalServerError().json(serde_json::json!({ "message": "Failed to load change request" }));
+        }
+    };
+
+    if let Some(action) = &body.action {
+        let action = action.trim().to_ascii_lowercase();
+        if action == "reject" {
+            item.status = "rejected".to_string();
+            item.workflow = item
+                .workflow
+                .iter()
+                .map(|stage| {
+                    if stage.status == "active" {
+                        let mut s = stage.clone();
+                        s.status = "done".to_string();
+                        s.done_at = Some(now_iso());
+                        s
+                    } else {
+                        stage.clone()
+                    }
+                })
+                .collect();
+        } else if action == "advance" {
+            let order = admin_workflow_order();
+            let idx = order.iter().position(|x| *x == item.status).unwrap_or(0);
+            if idx < order.len() - 1 {
+                item.status = order[idx + 1].to_string();
+                item.workflow = advance_workflow(&item.workflow);
+                if item.status == "released" {
+                    item.changelog_entry = Some(serde_json::json!({
+                        "title": item.title,
+                        "summary": body.note.clone().unwrap_or_else(|| item.desired_outcome.clone()),
+                        "releasedAt": now_iso(),
+                    }));
+                }
+            }
+        } else {
+            return HttpResponse::BadRequest().json(serde_json::json!({ "message": "action must be advance|reject" }));
+        }
+    }
+
+    if let Some(title) = &body.title {
+        item.title = title.trim().to_string();
+    }
+    if let Some(problem) = &body.problem {
+        item.problem = problem.trim().to_string();
+    }
+    if let Some(desired) = &body.desired_outcome {
+        item.desired_outcome = desired.trim().to_string();
+    }
+    if let Some(status) = &body.status {
+        let status = status.trim().to_ascii_lowercase();
+        if [
+            "submitted",
+            "triaged",
+            "planned",
+            "in_progress",
+            "qa",
+            "released",
+            "rejected",
+        ]
+        .contains(&status.as_str())
+        {
+            item.status = status;
+        }
+    }
+
+    item.updated_at = now_iso();
+
+    match coll.replace_one(doc! { "id": &id }, &item).upsert(false).await {
+        Ok(_) => HttpResponse::Ok().json(serde_json::json!({ "item": item })),
+        Err(e) => {
+            eprintln!("api_admin_change_request_patch write error: {}", e);
+            HttpResponse::InternalServerError().json(serde_json::json!({ "message": "Failed to update change request" }))
+        }
+    }
+}
+
+async fn api_admin_change_request_delete(
+    path: web::Path<String>,
+    mongo: web::Data<Arc<mongodb::Client>>,
+) -> impl Responder {
+    let id = path.into_inner();
+    let coll = mongo
+        .database(&mongo_db_name())
+        .collection::<ChangeRequestItem>(ADMIN_CHANGE_REQUESTS_COLL);
+
+    match coll.delete_one(doc! { "id": &id }).await {
+        Ok(res) if res.deleted_count > 0 => HttpResponse::Ok().json(serde_json::json!({ "deleted": true, "id": id })),
+        Ok(_) => HttpResponse::NotFound().json(serde_json::json!({ "deleted": false, "message": "Change request not found" })),
+        Err(e) => {
+            eprintln!("api_admin_change_request_delete error: {}", e);
+            HttpResponse::InternalServerError().json(serde_json::json!({ "message": "Failed to delete change request" }))
+        }
+    }
+}
+
 // --- AI settings (Phase B1, issue #173) ----------------------------------------
 
 const AI_SETTINGS_ID: &str = "global";
@@ -5295,6 +5901,31 @@ async fn main() -> std::io::Result<()> {
                 .route(
                     "/api/security/remediation/{alert_id}/rollback",
                     web::post().to(api_security_rollback),
+                )
+                .route("/api/admin/users", web::get().to(api_admin_users_list))
+                .route("/api/admin/users", web::post().to(api_admin_user_create))
+                .route("/api/admin/users/{id}", web::get().to(api_admin_user_get))
+                .route("/api/admin/users/{id}", web::patch().to(api_admin_user_patch))
+                .route("/api/admin/users/{id}", web::delete().to(api_admin_user_delete))
+                .route(
+                    "/api/admin/change-requests",
+                    web::get().to(api_admin_change_requests_list),
+                )
+                .route(
+                    "/api/admin/change-requests",
+                    web::post().to(api_admin_change_request_create),
+                )
+                .route(
+                    "/api/admin/change-requests/{id}",
+                    web::get().to(api_admin_change_request_get),
+                )
+                .route(
+                    "/api/admin/change-requests/{id}",
+                    web::patch().to(api_admin_change_request_patch),
+                )
+                .route(
+                    "/api/admin/change-requests/{id}",
+                    web::delete().to(api_admin_change_request_delete),
                 )
                 .route(
                     "/api/admin/security/posture",

--- a/src/entities.rs
+++ b/src/entities.rs
@@ -167,3 +167,61 @@ impl Email {
         }
     }
 }
+
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct AdminUserActivity {
+    pub at: String,
+    pub label: String,
+    pub kind: String,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct AdminUserRecord {
+    pub id: String,
+    pub email: String,
+    pub display_name: Option<String>,
+    pub role: String,
+    pub status: String,
+    pub two_factor_enabled: bool,
+    pub last_login_at: Option<String>,
+    pub last_activity_at: Option<String>,
+    pub sessions24h: i64,
+    pub actions7d: i64,
+    pub change_requests30d: i64,
+    pub recent_activity: Vec<AdminUserActivity>,
+    pub created_at: String,
+    pub updated_at: String,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct WorkflowStage {
+    pub key: String,
+    pub label: String,
+    pub owner: String,
+    pub status: String,
+    pub checklist: Vec<String>,
+    pub done_at: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct ChangeRequestItem {
+    pub id: String,
+    pub title: String,
+    pub problem: String,
+    pub desired_outcome: String,
+    pub scope: String,
+    pub priority: String,
+    pub status: String,
+    pub requested_by: String,
+    pub linked_repo: String,
+    pub created_at: String,
+    pub updated_at: String,
+    pub target_release_window: String,
+    pub acceptance_criteria: Vec<String>,
+    pub workflow: Vec<WorkflowStage>,
+    pub changelog_entry: Option<serde_json::Value>,
+}


### PR DESCRIPTION
## Summary
- add persistent models for admin users/activity and change requests/workflow
- add Mongo-backed CRUD endpoints:
  - `GET/POST /api/admin/users`
  - `GET/PATCH/DELETE /api/admin/users/{id}`
  - `GET/POST /api/admin/change-requests`
  - `GET/PATCH/DELETE /api/admin/change-requests/{id}`
- add workflow transition behavior (`advance`/`reject`) and release metadata at status `released`

## Why
Provide real backend source-of-truth for admin operations and remove frontend in-memory mocks.

## Validation
- cargo check --bin email_api
