### PR TITLE
fix(mail): refuse unsigned fallback when DKIM signature is missing

### DIFF
--- a/src/bin/email_api.rs
+++ b/src/bin/email_api.rs
@@ -1553,6 +1553,19 @@ async fn send_email_handler(
             let message_id = dkim_result["messageId"].as_str().unwrap_or("");
             match dkim_result["status"].as_str() {
                 Some("success") => {
+                    let sig = dkim_result["dkimSignature"]
+                        .as_str()
+                        .or_else(|| dkim_result["dkim_signature"].as_str())
+                        .unwrap_or("")
+                        .trim()
+                        .to_string();
+                    if sig.is_empty() {
+                        return HttpResponse::InternalServerError().json(serde_json::json!({
+                            "status": "error",
+                            "message": "DKIM service returned success without a DKIM signature",
+                        }));
+                    }
+
                     // Construct the email with DKIM signature
                     let email = Email {
                         id: Uuid::new_v4().to_string(),
@@ -1560,25 +1573,14 @@ async fn send_email_handler(
                         to: email_req.to.clone(),
                         subject: email_req.subject.clone(),
                         body: email_req.body.clone(),
-                        headers: vec![(
-                            "DKIM-Signature".to_string(),
-                            dkim_result["dkimSignature"]
-                                .as_str()
-                                .unwrap_or("")
-                                .to_string(),
-                        )],
+                        headers: vec![("DKIM-Signature".to_string(), sig.clone())],
                         flags: vec![],
                         sequence_number: 0,
                         uid: 0,
                         internal_date: mongodb::bson::DateTime::from_millis(
                             Utc::now().timestamp_millis(),
                         ),
-                        dkim_signature: Some(
-                            dkim_result["dkimSignature"]
-                                .as_str()
-                                .unwrap_or("")
-                                .to_string(),
-                        ),
+                        dkim_signature: Some(sig),
                     };
 
                     // Send the email
@@ -3043,6 +3045,12 @@ async fn api_send(
                 // SMTP handoff/delivery itself. Only skip direct SMTP relay when
                 // acceptance is on a non-internal remote MX hop.
                 let delivered = sig.is_empty() && effective_remote_accept;
+                if sig.is_empty() && !delivered {
+                    return HttpResponse::InternalServerError().json(serde_json::json!({
+                        "sent": false,
+                        "message": "DKIM signer returned success without signature and without remote delivery proof; refusing unsigned send",
+                    }));
+                }
                 (
                     sig,
                     mid,


### PR DESCRIPTION
## Problem
User report: emails can arrive without DKIM signature.

Root cause in backend (`/api/send` path): when DKIM service returned `status=success` but no `dkimSignature`, the API could still continue with direct SMTP send in some flows, resulting in unsigned mail.

## Fix
- `send_email_handler` now fails closed if DKIM service returns success without a signature.
- `/api/send` now fails closed when signer returns success **without DKIM signature** and **without valid remote-delivery proof**.
- This blocks unsigned fallback sends and surfaces a clear error to caller.

## Verification
- ad-hoc script `/tmp/hermes-verify-dkim-signed-only.XXXXXX.sh`:
  - `dkim_fail_closed_contract=ok`
  - `compile_contract=ok`
  - `verify_script_cleanup=ok`
- `cargo check --bin email_api` ✅
- `cargo check --bin smtp_server` ✅

## Expected impact
- No more silent unsigned sends from these API flows.
- If DKIM signer is misconfigured, send now fails explicitly instead of degrading deliverability.
