### PR TITLE
fix(mail): accept DKIM-service handoff proof for signer-owned delivery

### DIFF
--- a/src/bin/email_api.rs
+++ b/src/bin/email_api.rs
@@ -3041,14 +3041,15 @@ async fn api_send(
                 );
                 let effective_remote_accept = accepted_by_remote_mx && !internal_hop;
 
-                // No DKIM signature means the Node service likely already performed
-                // SMTP handoff/delivery itself. Only skip direct SMTP relay when
-                // acceptance is on a non-internal remote MX hop.
-                let delivered = sig.is_empty() && effective_remote_accept;
+                // No DKIM signature means dkim-service likely performed SMTP itself.
+                // Accept this path only with explicit SMTP handoff proof (`accepted*`).
+                // We still keep `effective_remote_accept` separate so status can tell
+                // true remote MX acceptance from internal relay handoff.
+                let delivered = sig.is_empty() && accepted_by_remote_mx;
                 if sig.is_empty() && !delivered {
                     return HttpResponse::InternalServerError().json(serde_json::json!({
                         "sent": false,
-                        "message": "DKIM signer returned success without signature and without remote delivery proof; refusing unsigned send",
+                        "message": "DKIM signer returned success without signature and without SMTP handoff proof; refusing unsigned send",
                     }));
                 }
                 (


### PR DESCRIPTION
## Why
Observed API response:
`{"sent":false,"message":"DKIM signer returned success without signature and without remote delivery proof; refusing unsigned send"}`

`dkim-service` currently owns SMTP handoff and returns `accepted*` proof, but does not return `dkimSignature`.

## Change
In `/api/send` (`src/bin/email_api.rs`):
- still fail-closed when signer returns success with no signature and no handoff proof;
- allow signer-owned path when success has SMTP handoff proof (`acceptedByRemoteMx` or non-empty `accepted[]`), even if the hop is internal;
- keep `effective_remote_accept` logic unchanged for observability classification (public MX vs internal relay).

This prevents unsigned fallback SMTP send while unblocking valid signer-owned delivery.

## Verification (ad-hoc)
- `/tmp/hermes-verify-dkim-handoff-clean.XXXXXX.sh`
  - `handoff_contract=ok`
  - `compile_contract=ok`
  - `verify_script_cleanup=ok`
