### PR TITLE
fix(smtp): fail closed when forward to external recipient fails

### DIFF
--- a/src/bin/smtp_server.rs
+++ b/src/bin/smtp_server.rs
@@ -484,7 +484,7 @@ async fn handle_plain_client(
                                     error!("Failed to forward email: {}", e);
                                     write_response(
                                         &mut stream,
-                                        "250 OK (stored locally, forwarding deferred)\r\n",
+                                        "451 4.4.0 Temporary forwarding failure\r\n",
                                     )
                                     .await?;
                                 }


### PR DESCRIPTION
## Problem
`/api/send` can return:
`{"sent":true,...,"deliveryState":"queued"}`
while the message never reaches external recipient.

Root cause:
- `dkim-service` hands off to `smtp-server:8025`.
- On external forward error, `smtp_server` still replied `250 OK (stored locally, forwarding deferred)`.
- Nodemailer interpreted this as accepted handoff, so API reported success/handoff even when external delivery failed.

## Fix
In `src/bin/smtp_server.rs`:
- keep `250 OK` on successful forward,
- return `451 4.4.0 Temporary forwarding failure` when `send_outgoing_email(...)` fails.

This makes the SMTP transaction fail closed so upstream (`dkim-service` -> `/api/send`) gets an error instead of false success.

## Verification (ad-hoc)
- script: `/tmp/hermes-verify-smtp-forward-failclosed.XXXXXX.sh`
  - `forward_fail_closed_contract=ok`
  - `compile_contract=ok`
  - `verify_script_cleanup=ok`
