### PR TITLE
fix(monitoring): persist smtp_server delivery events in dkim handoff path

### DIFF
--- a/src/bin/smtp_server.rs
+++ b/src/bin/smtp_server.rs
@@ -65,6 +65,7 @@ use tokio_rustls::server::TlsStream;
 
 use simple_smtp_server::entities::Email;
 use simple_smtp_server::logic::Logic;
+use simple_smtp_server::monitoring;
 use simple_smtp_server::session::SessionManager;
 use simple_smtp_server::smtp_client::{extract_email_address, send_outgoing_email};
 
@@ -856,8 +857,18 @@ async fn main() -> Result<(), MainError> {
             info!("MongoDB connection ready.");
         }
     }
-    let logic = Arc::new(Logic::new(client));
+    let logic = Arc::new(Logic::new(client.clone()));
     let session_manager = Arc::new(SessionManager::new());
+
+    if monitoring::monitoring_enabled() {
+        monitoring::init_bus();
+        monitoring::storage::start_persistence_task(client.clone());
+        let monitor_idx_client = client.clone();
+        tokio::spawn(async move {
+            monitoring::storage::ensure_indexes(&monitor_idx_client).await;
+        });
+        info!("SMTP monitoring bus initialized in smtp_server");
+    }
 
     loop {
         tokio::select! {


### PR DESCRIPTION
## Problem
Messages sent via DKIM-service handoff stay forever:
`{"sent":true, ..., "deliveryState":"queued"}`

Observed for:
- `d3c80f44-0b94-e3c7-66d4-fb61ed233067@misfits.ai`
- `78c2a525-24e9-4011-be76-dd54987a9228@misfits.ai`

`/api/send/{id}/status` shows only one `queued` event on internal hop (`mx_host=smtp-server`, `remote_ip=172.18.x.x`, `smtp_reply=250 OK`) and never gets Delivered/Bounced updates.

## Root cause
`smtp_server` calls `send_outgoing_email(...)`, which emits monitoring events, but the SMTP monitoring bus/persistence was initialized only in `email_api`, not in `smtp_server`.

Result: when outbound delivery is performed by `smtp_server` (DKIM handoff path), downstream events are dropped and API status remains stuck on queued.

## Fix
In `src/bin/smtp_server.rs`:
- import `simple_smtp_server::monitoring`
- initialize monitoring bus in `main()` when monitoring is enabled
- start persistence task + ensure indexes from `smtp_server`

## Verification (ad-hoc)
Script: `/tmp/hermes-verify-smtp-monitoring-bus-pass.XXXXXX.sh`
- `monitoring_bus_assertions=ok`
- `compile_contract=ok` (`cargo check --bin smtp_server` + `cargo check --bin email_api`)
- `verify_script_cleanup=ok`
