### PR TITLE
fix(smtp): forward authenticated external recipients

### DIFF
--- a/src/bin/smtp_server.rs
+++ b/src/bin/smtp_server.rs
@@ -148,6 +148,25 @@ fn env_bool(key: &str, default: bool) -> bool {
     }
 }
 
+fn recipient_domain(raw_to: &str) -> Option<String> {
+    let trimmed = raw_to.trim();
+    let addr = if let (Some(start), Some(end)) = (trimmed.rfind('<'), trimmed.rfind('>')) {
+        if start < end {
+            &trimmed[start + 1..end]
+        } else {
+            trimmed
+        }
+    } else {
+        trimmed.trim_matches(|c| c == '<' || c == '>')
+    };
+
+    addr.split('@').nth(1).map(|d| d.trim().trim_end_matches('.').to_ascii_lowercase())
+}
+
+fn is_local_recipient(raw_to: &str) -> bool {
+    matches!(recipient_domain(raw_to).as_deref(), Some("misfits.ai") | Some("mail.misfits.ai"))
+}
+
 // Struct to represent the mail server
 struct MailServer {
     mail_dir: String,
@@ -270,7 +289,23 @@ async fn handle_tls_client(
                                             &email_to_store.from,
                                             &email_to_store.to,
                                         ).await;
-                                        write_response(&mut stream, "250 OK\r\n").await?;
+                                        if is_local_recipient(&email_to_store.to) {
+                                            write_response(&mut stream, "250 OK\r\n").await?;
+                                        } else {
+                                            match send_outgoing_email(&email_to_store).await {
+                                                Ok(_) => {
+                                                    write_response(&mut stream, "250 OK\r\n").await?;
+                                                }
+                                                Err(e) => {
+                                                    error!("Failed to forward authenticated email: {}", e);
+                                                    write_response(
+                                                        &mut stream,
+                                                        "451 4.4.0 Temporary forwarding failure\r\n",
+                                                    )
+                                                    .await?;
+                                                }
+                                            }
+                                        }
                                     }
                                 } else {
                                     eprintln!(
@@ -463,7 +498,23 @@ async fn handle_plain_client(
                                             &email_to_store.from,
                                             &email_to_store.to,
                                         ).await;
-                                        write_response(&mut stream, "250 OK\r\n").await?;
+                                        if is_local_recipient(&email_to_store.to) {
+                                            write_response(&mut stream, "250 OK\r\n").await?;
+                                        } else {
+                                            match send_outgoing_email(&email_to_store).await {
+                                                Ok(_) => {
+                                                    write_response(&mut stream, "250 OK\r\n").await?;
+                                                }
+                                                Err(e) => {
+                                                    error!("Failed to forward authenticated email: {}", e);
+                                                    write_response(
+                                                        &mut stream,
+                                                        "451 4.4.0 Temporary forwarding failure\r\n",
+                                                    )
+                                                    .await?;
+                                                }
+                                            }
+                                        }
                                     }
                                 } else {
                                     eprintln!("Mailbox or username not found for session");


### PR DESCRIPTION
## Problem
Still seeing `sent:true` + `deliveryState:"queued"` after DKIM handoff for external recipients.

Latest example:
- `301641a7-20a6-457e-9822-a98494941328`
- `d3c80f44-0b94-e3c7-66d4-fb61ed233067@misfits.ai`
- trace only shows internal hop: `mx_host=smtp-server`, `remote_ip=172.18.0.2`, `smtp_reply=250 OK`

## Root cause
`smtp_server` authenticated path (`session_id` present) only stored mail to mailbox and returned `250 OK`, but did not call outbound forward.

`dkim-service` is configured with SMTP auth, so it always uses this authenticated path.
Result: accepted internally, never sent to external MX.

## Fix
In `src/bin/smtp_server.rs`:
- add recipient domain helpers (`recipient_domain`, `is_local_recipient`)
- for authenticated path, after store success:
  - if local recipient (`misfits.ai`/`mail.misfits.ai`): keep local-only `250 OK`
  - else call `send_outgoing_email(&email_to_store)`
  - on forward failure, return `451 4.4.0 Temporary forwarding failure`

## Verification (ad-hoc)
Script: `/tmp/hermes-verify-smtp-auth-forward-pass.XXXXXX.sh`
- `smtp_auth_forward_assertions=ok`
- `compile_contract=ok` (`cargo check --bin smtp_server` + `cargo check --bin email_api`)
- `verify_script_cleanup=ok`
