### PR TITLE
fix(monitoring): preserve Message-ID in smtp_server DATA path

### DIFF
--- a/src/bin/smtp_server.rs
+++ b/src/bin/smtp_server.rs
@@ -167,6 +167,25 @@ fn is_local_recipient(raw_to: &str) -> bool {
     matches!(recipient_domain(raw_to).as_deref(), Some("misfits.ai") | Some("mail.misfits.ai"))
 }
 
+fn parse_message_id_header(raw_line: &str) -> Option<String> {
+    if !raw_line.to_ascii_lowercase().starts_with("message-id:") {
+        return None;
+    }
+
+    let value = raw_line
+        .split_once(':')
+        .map(|(_, v)| v.trim())
+        .unwrap_or("")
+        .trim_matches(|c| c == '<' || c == '>')
+        .trim();
+
+    if value.is_empty() {
+        None
+    } else {
+        Some(value.to_string())
+    }
+}
+
 // Struct to represent the mail server
 struct MailServer {
     mail_dir: String,
@@ -358,6 +377,9 @@ async fn handle_tls_client(
                                             .trim_start_matches("Subject:")
                                             .trim()
                                             .to_string();
+                                    } else if let Some(mid) = parse_message_id_header(trimmed_line)
+                                    {
+                                        current_email.email.id = mid;
                                     }
                                 }
                             }
@@ -570,6 +592,10 @@ async fn handle_plain_client(
                                             .trim_start_matches("Subject:")
                                             .trim()
                                             .to_string();
+                                    } else if let Some(mid) =
+                                        parse_message_id_header(trimmed_buffer)
+                                    {
+                                        current_email.email.id = mid;
                                     }
                                 }
                             }


### PR DESCRIPTION
## Problem
`/api/send/{id}/status` can stay `queued` because handoff and outbound delivery events are recorded under different message IDs.

## Root cause
`smtp_server` did not parse `Message-ID` in DATA headers, so `current_email.email.id` stayed empty and outbound monitoring events were emitted with a different correlation id.

## Fix
- Add `parse_message_id_header(...)`
- Extract `Message-ID:` in both TLS and plain DATA header parsers
- Set `current_email.email.id` from parsed Message-ID

## Verification (ad-hoc)
- `message_id_correlation_assertions=ok`
- `compile_contract=ok` (`cargo check --bin smtp_server` + `cargo check --bin email_api`)
- `verify_script_cleanup=ok`
