### PR TITLE
fix(api): surface DKIM upstream error details on /api/send

### DIFF
--- a/src/bin/email_api.rs
+++ b/src/bin/email_api.rs
@@ -3068,7 +3068,7 @@ async fn api_send(
                 eprintln!("DKIM service error on /api/send: {}", e);
                 return HttpResponse::InternalServerError().json(serde_json::json!({
                     "sent": false,
-                    "message": "Failed to generate DKIM signature",
+                    "message": format!("Failed to generate DKIM signature: {}", e),
                 }));
             }
         };
@@ -6336,15 +6336,20 @@ impl DkimService for RealDkimService {
             .await
             .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?;
 
-        if response.status().is_success() {
-            response
-                .json()
-                .await
+        let status = response.status();
+        let body = response
+            .text()
+            .await
+            .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?;
+
+        if status.is_success() {
+            serde_json::from_str::<serde_json::Value>(&body)
                 .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))
         } else {
+            let snippet = if body.len() > 1200 { &body[..1200] } else { &body };
             Err(std::io::Error::new(
                 std::io::ErrorKind::Other,
-                "Failed to sign email",
+                format!("DKIM service HTTP {}: {}", status.as_u16(), snippet),
             ))
         }
     }


### PR DESCRIPTION
## Problem
`/api/send` returns a generic:
- `{"sent":false,"message":"Failed to generate DKIM signature"}`

This hides the true upstream cause (e.g. DKIM service HTTP code/body), slowing prod incident triage.

## Fix
In `src/bin/email_api.rs`:
1. `RealDkimService::sign_email`
   - read response body for both success/error paths
   - on non-2xx, return `DKIM service HTTP <code>: <body-snippet>`
2. `/api/send` DKIM error branch
   - include error detail in API message:
   - `Failed to generate DKIM signature: <details>`

## Verification (ad-hoc)
Script: `/tmp/hermes-verify-dkim-error-surface-pass.XXXXXX.sh`
- `dkim_error_surface_assertions=ok`
- `compile_contract=ok` (`cargo check --bin email_api` + `cargo check --bin smtp_server`)
- `verify_script_cleanup=ok`
