### PR TITLE
fix(monitoring): avoid false queued when delivered exists

### DIFF
--- a/src/bin/email_api.rs
+++ b/src/bin/email_api.rs
@@ -566,7 +566,18 @@ async fn api_monitoring_trace(
     }
 
     let status = events
-        .last()
+        .iter()
+        .rev()
+        .find(|e| {
+            matches!(
+                e.status,
+                monitoring::SmtpStatus::Delivered
+                    | monitoring::SmtpStatus::Bounced
+                    | monitoring::SmtpStatus::Failed
+                    | monitoring::SmtpStatus::Deferred
+            )
+        })
+        .or_else(|| events.last())
         .map(|e| format!("{:?}", e.status))
         .unwrap_or_default();
     let total_ms = events.iter().filter_map(|e| e.total_ms).max();
@@ -3587,7 +3598,15 @@ async fn api_send_status(
     });
     let handoff_only = !accepted_by_remote_mx && !bounced_or_failed && saw_internal_handoff;
 
-    let latest = events.first();
+    let latest = events.iter().find(|e| {
+        matches!(
+            e.status,
+            monitoring::SmtpStatus::Delivered
+                | monitoring::SmtpStatus::Bounced
+                | monitoring::SmtpStatus::Failed
+                | monitoring::SmtpStatus::Deferred
+        )
+    }).or_else(|| events.first());
     let delivery_state = if accepted_by_remote_mx {
         "sent"
     } else if bounced_or_failed {


### PR DESCRIPTION
## Problem
A message can have both:
- a conclusive external event (`delivered` on remote MX), and
- a later internal `queued/pending` event (`smtp-server 250 OK` handoff)

Because status selection used the latest timestamp only, `/api/send/{id}/status` and `/api/monitoring/messages/{message_id}/trace` could display `Queued/Pending` even after a real external `delivered` event.

## Fix
`src/bin/email_api.rs`
1. `api_monitoring_trace`:
   - compute top-level `status` from the newest **conclusive** state first (`Delivered|Bounced|Failed|Deferred`), fallback to last event.
2. `api_send_status`:
   - choose `latestEventType/latestStatus/latestSmtp*` from newest conclusive event first, fallback to newest event.

No change to fail-closed delivery logic; this is status-truthfulness and anti-false-queued display.

## Verification
- Runtime reproduction before fix:
  - `/api/send` returned `sent:true` with messageId `ea7a99e8-bcec-275e-efb5-1c810e08394e@misfits.ai`
  - trace contained both `delivered 250 OK reception.mail-tester.com` and a later internal `queued pending smtp-server`
  - displayed top status was incorrectly `Pending/Queued`
- Compile gates:
  - `cargo check --bin email_api`
  - `cargo check --bin smtp_server`
