### PR TITLE
fix(smtp): preserve canonical headers to resolve DKIM_INVALID/MISSING_DATE

### DIFF
--- a/src/bin/smtp_server.rs
+++ b/src/bin/smtp_server.rs
@@ -167,15 +167,17 @@ fn is_local_recipient(raw_to: &str) -> bool {
     matches!(recipient_domain(raw_to).as_deref(), Some("misfits.ai") | Some("mail.misfits.ai"))
 }
 
-fn parse_message_id_header(raw_line: &str) -> Option<String> {
-    if !raw_line.to_ascii_lowercase().starts_with("message-id:") {
+fn parse_header_line(raw_line: &str) -> Option<(String, String)> {
+    let (name, value) = raw_line.split_once(':')?;
+    let name = name.trim();
+    if name.is_empty() {
         return None;
     }
+    Some((name.to_string(), value.trim().to_string()))
+}
 
-    let value = raw_line
-        .split_once(':')
-        .map(|(_, v)| v.trim())
-        .unwrap_or("")
+fn parse_message_id_header(value: &str) -> Option<String> {
+    let value = value
         .trim_matches(|c| c == '<' || c == '>')
         .trim();
 
@@ -357,29 +359,29 @@ async fn handle_tls_client(
                                 // Traitez les en-têtes
                                 let trimmed_line = line.trim();
                                 if !trimmed_line.is_empty() {
-                                    let line = trimmed_line.to_string();
-                                    current_email
-                                        .email
-                                        .headers
-                                        .push((line.clone(), line.clone()));
-                                    if trimmed_line.starts_with("DKIM-Signature:") {
-                                        current_email.dkim_signature = Some(line);
-                                    } else if trimmed_line.starts_with("From:") {
-                                        current_email.email.from =
-                                            extract_email_address(trimmed_line, "From:")
-                                                .unwrap_or_default();
-                                    } else if trimmed_line.starts_with("To:") {
-                                        current_email.email.to =
-                                            extract_email_address(trimmed_line, "To:")
-                                                .unwrap_or_default();
-                                    } else if trimmed_line.starts_with("Subject:") {
-                                        current_email.email.subject = trimmed_line
-                                            .trim_start_matches("Subject:")
-                                            .trim()
-                                            .to_string();
-                                    } else if let Some(mid) = parse_message_id_header(trimmed_line)
-                                    {
-                                        current_email.email.id = mid;
+                                    if let Some((name, value)) = parse_header_line(trimmed_line) {
+                                        current_email
+                                            .email
+                                            .headers
+                                            .push((name.clone(), value.clone()));
+
+                                        if name.eq_ignore_ascii_case("DKIM-Signature") {
+                                            current_email.dkim_signature = Some(value);
+                                        } else if name.eq_ignore_ascii_case("From") {
+                                            current_email.email.from =
+                                                extract_email_address(trimmed_line, "From:")
+                                                    .unwrap_or_default();
+                                        } else if name.eq_ignore_ascii_case("To") {
+                                            current_email.email.to =
+                                                extract_email_address(trimmed_line, "To:")
+                                                    .unwrap_or_default();
+                                        } else if name.eq_ignore_ascii_case("Subject") {
+                                            current_email.email.subject = value;
+                                        } else if name.eq_ignore_ascii_case("Message-ID") {
+                                            if let Some(mid) = parse_message_id_header(&value) {
+                                                current_email.email.id = mid;
+                                            }
+                                        }
                                     }
                                 }
                             }
@@ -572,30 +574,29 @@ async fn handle_plain_client(
                                 // Traitez les en-têtes
                                 let trimmed_buffer = buffer.trim();
                                 if !trimmed_buffer.is_empty() {
-                                    let line = trimmed_buffer.to_string();
-                                    current_email
-                                        .email
-                                        .headers
-                                        .push((line.clone(), line.clone()));
-                                    if trimmed_buffer.starts_with("DKIM-Signature:") {
-                                        current_email.dkim_signature = Some(line);
-                                    } else if trimmed_buffer.starts_with("From:") {
-                                        current_email.email.from =
-                                            extract_email_address(trimmed_buffer, "From:")
-                                                .unwrap_or_default();
-                                    } else if trimmed_buffer.starts_with("To:") {
-                                        current_email.email.to =
-                                            extract_email_address(trimmed_buffer, "To:")
-                                                .unwrap_or_default();
-                                    } else if trimmed_buffer.starts_with("Subject:") {
-                                        current_email.email.subject = trimmed_buffer
-                                            .trim_start_matches("Subject:")
-                                            .trim()
-                                            .to_string();
-                                    } else if let Some(mid) =
-                                        parse_message_id_header(trimmed_buffer)
-                                    {
-                                        current_email.email.id = mid;
+                                    if let Some((name, value)) = parse_header_line(trimmed_buffer) {
+                                        current_email
+                                            .email
+                                            .headers
+                                            .push((name.clone(), value.clone()));
+
+                                        if name.eq_ignore_ascii_case("DKIM-Signature") {
+                                            current_email.dkim_signature = Some(value);
+                                        } else if name.eq_ignore_ascii_case("From") {
+                                            current_email.email.from =
+                                                extract_email_address(trimmed_buffer, "From:")
+                                                    .unwrap_or_default();
+                                        } else if name.eq_ignore_ascii_case("To") {
+                                            current_email.email.to =
+                                                extract_email_address(trimmed_buffer, "To:")
+                                                    .unwrap_or_default();
+                                        } else if name.eq_ignore_ascii_case("Subject") {
+                                            current_email.email.subject = value;
+                                        } else if name.eq_ignore_ascii_case("Message-ID") {
+                                            if let Some(mid) = parse_message_id_header(&value) {
+                                                current_email.email.id = mid;
+                                            }
+                                        }
                                     }
                                 }
                             }

--- a/src/smtp_client/mod.rs
+++ b/src/smtp_client/mod.rs
@@ -28,6 +28,7 @@ The client will attempt to connect to the SMTP server, send the email, and repor
 
 use rustls::pki_types::{CertificateDer, ServerName};
 use rustls::{ClientConfig, RootCertStore};
+use chrono::Utc;
 use std::io::{Error as IoError, ErrorKind};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
@@ -111,6 +112,25 @@ fn upsert_content_type(headers: &mut Vec<(String, String)>, value: String) {
 
 fn compose_smtp_payload(email: &Email) -> String {
     let mut headers = email.headers.clone();
+    headers.retain(|(k, _)| {
+        !(k.eq_ignore_ascii_case("from")
+            || k.eq_ignore_ascii_case("to")
+            || k.eq_ignore_ascii_case("subject"))
+    });
+
+    if !headers.iter().any(|(k, _)| k.eq_ignore_ascii_case("date")) {
+        headers.push(("Date".to_string(), Utc::now().to_rfc2822()));
+    }
+    if !headers
+        .iter()
+        .any(|(k, _)| k.eq_ignore_ascii_case("message-id"))
+    {
+        headers.push((
+            "Message-ID".to_string(),
+            format!("<{}@misfits.ai>", Uuid::new_v4()),
+        ));
+    }
+
     let body = email.body.trim();
 
     let has_multipart = headers.iter().any(|(k, v)| {


### PR DESCRIPTION
## Symptom
SpamAssassin reports on prod test mails:
- `DKIM_INVALID`
- `MISSING_DATE`
- `MISSING_MID`

## Root cause
Two issues in SMTP forwarding path:
1. `smtp_server` parsed inbound headers as `(raw_line, raw_line)` tuples instead of `(header_name, header_value)`.
   - This produced malformed outbound headers like `Message-ID: <id>: Message-ID: <id>`.
2. `smtp_client::compose_smtp_payload` could emit messages without `Date` (and without `Message-ID` in fallback paths), and duplicated `From/To/Subject` if already present in parsed headers.

These mutations break header validity and DKIM verification downstream.

## Fix
- `src/bin/smtp_server.rs`
  - add `parse_header_line(...)` and store canonical `(name, value)` pairs.
  - parse `Message-ID` from value only.
  - keep `Subject` from parsed value.
- `src/smtp_client/mod.rs`
  - remove duplicated `From/To/Subject` from extra header list.
  - add fallback headers when absent:
    - `Date: <rfc2822 now>`
    - `Message-ID: <uuid@misfits.ai>`

## Verification
Ad-hoc compile gate:
- `cargo check --bin smtp_server`
- `cargo check --bin email_api`
Both pass.

This targets the exact SpamAssassin findings and should remove `MISSING_DATE` / `MISSING_MID` and reduce `DKIM_INVALID` caused by relay-side header corruption.
