### PR TITLE
fix(dkim): preserve folded headers and signed payload on relay

### DIFF
--- a/src/bin/smtp_server.rs
+++ b/src/bin/smtp_server.rs
@@ -188,6 +188,55 @@ fn parse_message_id_header(value: &str) -> Option<String> {
     }
 }
 
+fn apply_parsed_header(current_email: &mut CustomEmail, raw_line: &str) {
+    if raw_line.starts_with(' ') || raw_line.starts_with('\t') {
+        if let Some((last_name, last_value)) = current_email.email.headers.last_mut() {
+            let continuation = raw_line.trim();
+            if !continuation.is_empty() {
+                if !last_value.is_empty() {
+                    last_value.push(' ');
+                }
+                last_value.push_str(continuation);
+
+                if last_name.eq_ignore_ascii_case("DKIM-Signature") {
+                    current_email.dkim_signature = Some(last_value.clone());
+                } else if last_name.eq_ignore_ascii_case("Subject") {
+                    current_email.email.subject = last_value.clone();
+                } else if last_name.eq_ignore_ascii_case("Message-ID") {
+                    if let Some(mid) = parse_message_id_header(last_value) {
+                        current_email.email.id = mid;
+                    }
+                }
+            }
+        }
+        return;
+    }
+
+    if let Some((name, value)) = parse_header_line(raw_line) {
+        current_email
+            .email
+            .headers
+            .push((name.clone(), value.clone()));
+
+        if name.eq_ignore_ascii_case("DKIM-Signature") {
+            current_email.dkim_signature = Some(value.clone());
+        } else if name.eq_ignore_ascii_case("From") {
+            let canonical = format!("From: {}", value);
+            current_email.email.from =
+                extract_email_address(&canonical, "From:").unwrap_or_default();
+        } else if name.eq_ignore_ascii_case("To") {
+            let canonical = format!("To: {}", value);
+            current_email.email.to = extract_email_address(&canonical, "To:").unwrap_or_default();
+        } else if name.eq_ignore_ascii_case("Subject") {
+            current_email.email.subject = value;
+        } else if name.eq_ignore_ascii_case("Message-ID") {
+            if let Some(mid) = parse_message_id_header(&value) {
+                current_email.email.id = mid;
+            }
+        }
+    }
+}
+
 // Struct to represent the mail server
 struct MailServer {
     mail_dir: String,
@@ -359,30 +408,7 @@ async fn handle_tls_client(
                                 // Traitez les en-têtes
                                 let trimmed_line = line.trim();
                                 if !trimmed_line.is_empty() {
-                                    if let Some((name, value)) = parse_header_line(trimmed_line) {
-                                        current_email
-                                            .email
-                                            .headers
-                                            .push((name.clone(), value.clone()));
-
-                                        if name.eq_ignore_ascii_case("DKIM-Signature") {
-                                            current_email.dkim_signature = Some(value);
-                                        } else if name.eq_ignore_ascii_case("From") {
-                                            current_email.email.from =
-                                                extract_email_address(trimmed_line, "From:")
-                                                    .unwrap_or_default();
-                                        } else if name.eq_ignore_ascii_case("To") {
-                                            current_email.email.to =
-                                                extract_email_address(trimmed_line, "To:")
-                                                    .unwrap_or_default();
-                                        } else if name.eq_ignore_ascii_case("Subject") {
-                                            current_email.email.subject = value;
-                                        } else if name.eq_ignore_ascii_case("Message-ID") {
-                                            if let Some(mid) = parse_message_id_header(&value) {
-                                                current_email.email.id = mid;
-                                            }
-                                        }
-                                    }
+                                    apply_parsed_header(&mut current_email, trimmed_line);
                                 }
                             }
                         } else {
@@ -574,30 +600,7 @@ async fn handle_plain_client(
                                 // Traitez les en-têtes
                                 let trimmed_buffer = buffer.trim();
                                 if !trimmed_buffer.is_empty() {
-                                    if let Some((name, value)) = parse_header_line(trimmed_buffer) {
-                                        current_email
-                                            .email
-                                            .headers
-                                            .push((name.clone(), value.clone()));
-
-                                        if name.eq_ignore_ascii_case("DKIM-Signature") {
-                                            current_email.dkim_signature = Some(value);
-                                        } else if name.eq_ignore_ascii_case("From") {
-                                            current_email.email.from =
-                                                extract_email_address(trimmed_buffer, "From:")
-                                                    .unwrap_or_default();
-                                        } else if name.eq_ignore_ascii_case("To") {
-                                            current_email.email.to =
-                                                extract_email_address(trimmed_buffer, "To:")
-                                                    .unwrap_or_default();
-                                        } else if name.eq_ignore_ascii_case("Subject") {
-                                            current_email.email.subject = value;
-                                        } else if name.eq_ignore_ascii_case("Message-ID") {
-                                            if let Some(mid) = parse_message_id_header(&value) {
-                                                current_email.email.id = mid;
-                                            }
-                                        }
-                                    }
+                                    apply_parsed_header(&mut current_email, trimmed_buffer);
                                 }
                             }
                         } else {

--- a/src/smtp_client/mod.rs
+++ b/src/smtp_client/mod.rs
@@ -112,11 +112,6 @@ fn upsert_content_type(headers: &mut Vec<(String, String)>, value: String) {
 
 fn compose_smtp_payload(email: &Email) -> String {
     let mut headers = email.headers.clone();
-    headers.retain(|(k, _)| {
-        !(k.eq_ignore_ascii_case("from")
-            || k.eq_ignore_ascii_case("to")
-            || k.eq_ignore_ascii_case("subject"))
-    });
 
     if !headers.iter().any(|(k, _)| k.eq_ignore_ascii_case("date")) {
         headers.push(("Date".to_string(), Utc::now().to_rfc2822()));
@@ -131,14 +126,50 @@ fn compose_smtp_payload(email: &Email) -> String {
         ));
     }
 
-    let body = email.body.trim();
+    let has_dkim_signature = headers
+        .iter()
+        .any(|(k, _)| k.eq_ignore_ascii_case("dkim-signature"));
+
+    if has_dkim_signature {
+        let mut email_content = String::new();
+
+        let has_from = headers.iter().any(|(k, _)| k.eq_ignore_ascii_case("from"));
+        let has_to = headers.iter().any(|(k, _)| k.eq_ignore_ascii_case("to"));
+        let has_subject = headers.iter().any(|(k, _)| k.eq_ignore_ascii_case("subject"));
+
+        if !has_from {
+            email_content.push_str(&format!("From: {}\r\n", email.from));
+        }
+        if !has_to {
+            email_content.push_str(&format!("To: {}\r\n", email.to));
+        }
+        if !has_subject {
+            email_content.push_str(&format!("Subject: {}\r\n", email.subject));
+        }
+
+        for (key, value) in &headers {
+            email_content.push_str(&format!("{}: {}\r\n", key, value));
+        }
+
+        email_content.push_str("\r\n");
+        email_content.push_str(&normalize_crlf(&email.body));
+        return email_content;
+    }
+
+    headers.retain(|(k, _)| {
+        !(k.eq_ignore_ascii_case("from")
+            || k.eq_ignore_ascii_case("to")
+            || k.eq_ignore_ascii_case("subject"))
+    });
+
+    let body = email.body.as_str();
 
     let has_multipart = headers.iter().any(|(k, v)| {
         k.eq_ignore_ascii_case("content-type") && v.to_ascii_lowercase().contains("multipart/")
     });
 
     let payload_body = if has_multipart {
-        body.to_string()
+        normalize_crlf(body)
     } else if body_looks_like_html(body) {
         let html = normalize_crlf(&ensure_html_document(body));
         let mut plain = strip_tags_simple(&html);


### PR DESCRIPTION
## Symptom
Still seeing on SpamAssassin after #238:
- DKIM_INVALID
- DKIM_SIGNED
- MIME_NO_TEXT (intermittent depending content)

## Root cause
Two DKIM-breakers remained in the SMTP relay path:

1) Folded header lines were not preserved
- `smtp_server` parsed only `name:value` lines and ignored continuation lines starting with whitespace.
- DKIM-Signature is often folded across multiple lines; we kept only the first fragment, producing invalid signatures.

2) Signed payload rewrite at relay
- `smtp_client::compose_smtp_payload` transformed payload/body (trim, html multipart rewrite, canonical From/To/Subject regeneration) even when a DKIM-Signature already existed.
- Any such rewrite invalidates upstream DKIM body/header hashes.

## Fix
### `src/bin/smtp_server.rs`
- Added `apply_parsed_header(...)`:
  - stores canonical headers,
  - appends folded continuation lines (`SP/HTAB`) to previous header value,
  - updates DKIM-Signature / Subject / Message-ID after unfolding.
- Replaced duplicated header parse blocks in TLS/plain DATA handlers with `apply_parsed_header`.

### `src/smtp_client/mod.rs`
- In `compose_smtp_payload`:
  - detect existing `DKIM-Signature` header,
  - preserve signed message structure (no HTML/body rewrite, no trim-based mutation),
  - emit stored headers as-is, only adding fallback Date/Message-ID when absent.
- Keep prior non-signed fallback behavior for non-DKIM payloads.

## Verification
Ad-hoc compile gates:
- `cargo check --bin smtp_server`
- `cargo check --bin email_api`

Both pass.

Expected impact: remove relay-induced DKIM corruption so `DKIM_SIGNED` can become valid verification instead of `DKIM_INVALID` for upstream-signed messages.
