### PR TITLE
fix(dkim): keep folded header whitespace in DATA parsing

### DIFF
--- a/src/bin/smtp_server.rs
+++ b/src/bin/smtp_server.rs
@@ -406,7 +406,7 @@ async fn handle_tls_client(
                                 in_body = true; // Ligne vide détectée, commencez à capturer le corps
                             } else {
                                 // Traitez les en-têtes
-                                let trimmed_line = line.trim();
+                                let trimmed_line = line.trim_end_matches(|c| c == '\r' || c == '\n');
                                 if !trimmed_line.is_empty() {
                                     apply_parsed_header(&mut current_email, trimmed_line);
                                 }
@@ -598,7 +598,7 @@ async fn handle_plain_client(
                                 in_body = true; // Ligne vide détectée, commencez à capturer le corps
                             } else {
                                 // Traitez les en-têtes
-                                let trimmed_buffer = buffer.trim();
+                                let trimmed_buffer = buffer.trim_end_matches(|c| c == '\r' || c == '\n');
                                 if !trimmed_buffer.is_empty() {
                                     apply_parsed_header(&mut current_email, trimmed_buffer);
                                 }


### PR DESCRIPTION
## Symptom
After #239, DKIM still invalid on mail-tester.

## Root cause
In SMTP DATA parsing we still did `line.trim()` before header processing.
That removed leading whitespace on folded header continuation lines.

For DKIM-Signature, continuation lines (starting with SP/HTAB) were turned into new pseudo-headers (e.g. `h=...`) instead of being appended to `DKIM-Signature`, so the signature remained truncated/invalid.

## Fix
`src/bin/smtp_server.rs`
- In both TLS/plain DATA header paths, replace `trim()` with `trim_end_matches("\r|\n")` before `apply_parsed_header(...)`.
- This preserves leading whitespace so folded DKIM headers are correctly unfolded and retained.

## Verification
- `cargo check --bin smtp_server`
- `cargo check --bin email_api`

Both pass.
