### PR TITLE
feat(dkim): expose DKIM_DOMAINS to dkim-service

### DIFF
--- a/docker-compose.deploy.yml
+++ b/docker-compose.deploy.yml
@@ -147,6 +147,7 @@ services:
       - SMTP_USER=${SMTP_USERNAME}
       - SMTP_PASS=${SMTP_PASSWORD}
       - DOMAIN_NAME=${DOMAIN_NAME}
+      - DKIM_DOMAINS=${DKIM_DOMAINS:-${DOMAIN_NAME}}
       - KEY_SELECTOR=${KEY_SELECTOR:-default}
       - PRIVATE_KEY_PATH=dkim/dkim-private.pem
     healthcheck:


### PR DESCRIPTION
## Contexte

studious-octo-rotary-phone signe désormais avec d= aligné sur le domaine du From, à condition que DKIM_DOMAINS soit exposé au container.

## Changement

- `docker-compose.deploy.yml` : ajout de `DKIM_DOMAINS=${DKIM_DOMAINS:-${DOMAIN_NAME}}` sur le service `dkim-service`
- Fallback vers `DOMAIN_NAME` → non-régression si la variable est absente

## Source de vérité

- Item 1Password `op://hermes/scw-hermes-smtp/texte` contient déjà `DKIM_DOMAINS=misfits.ai,misfits.fr`
- Le workflow existant récupère ce blob tel quel via `1password/load-secrets-action` → aucune modif nécessaire du workflow

## Prérequis DNS (indépendants)

- `default._domainkey.misfits.fr` TXT = clé publique DKIM
- SPF `misfits.fr` inclure `ip4:51.158.114.182`
- DMARC `_dmarc.misfits.fr`

## Validation post-merge

- Nouveau container `dkim-service` recréé sur 51.158.114.182
- Log attendu: `DKIM sign: from=<from-domain> d=<from-domain> s=default`
