### PR TITLE
feat(admin): RBAC foundation (PR1) — auth guard + whoami

### DIFF
--- a/src/bin/admin_auth.rs
+++ b/src/bin/admin_auth.rs
@@ -1,0 +1,239 @@
+//! Admin RBAC — PR1 (fondation).
+//!
+//! Ce module fournit une garde RBAC minimaliste, gated par la variable
+//! d'environnement `ADMIN_RBAC_ENFORCE`. Comportement:
+//!
+//! - `ADMIN_RBAC_ENFORCE` absent ou différent de "1" / "true"  → **désactivé** :
+//!   `require_admin` renvoie toujours `Ok(AuthUser::system())` et n'appelle
+//!   même pas Mongo. C'est le comportement par défaut à la mise en prod pour
+//!   éviter toute régression pendant que le frontend n'a pas encore été mis
+//!   à jour pour transmettre le token.
+//!
+//! - `ADMIN_RBAC_ENFORCE=1`  → **activé** : la session est extraite depuis le
+//!   header `Authorization: Bearer <token>` ou depuis le cookie `session_token`,
+//!   validée contre la collection `admin_sessions`, et le rôle est comparé à
+//!   la liste des rôles autorisés.
+//!
+//! Le module est volontairement autonome (pas d'import des types du binaire)
+//! pour rester facile à extraire vers un crate séparé plus tard sans casser
+//! l'API publique.
+
+use std::env;
+use std::sync::Arc;
+
+use actix_web::{http::StatusCode, HttpRequest, HttpResponse};
+use chrono::{Duration, Utc};
+use mongodb::bson::doc;
+use serde::{Deserialize, Serialize};
+
+/// Nom de la collection Mongo où l'on persiste les sessions admin.
+pub const ADMIN_SESSIONS_COLL: &str = "admin_sessions";
+
+/// Retourne `true` si le RBAC est activé (feature flag).
+pub fn rbac_enabled() -> bool {
+    matches!(
+        env::var("ADMIN_RBAC_ENFORCE")
+            .unwrap_or_default()
+            .to_ascii_lowercase()
+            .as_str(),
+        "1" | "true" | "yes" | "on"
+    )
+}
+
+/// Nombre de secondes avant expiration d'une session admin (24h par défaut).
+fn session_ttl_secs() -> i64 {
+    env::var("ADMIN_SESSION_TTL_SECS")
+        .ok()
+        .and_then(|v| v.parse::<i64>().ok())
+        .unwrap_or(24 * 3600)
+}
+
+/// Enregistrement Mongo d'une session admin.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AdminSession {
+    pub token: String,
+    pub user_id: String,
+    pub email: String,
+    pub role: String,
+    pub created_at: String,
+    pub expires_at: String,
+    #[serde(default)]
+    pub last_seen_at: Option<String>,
+    #[serde(default)]
+    pub user_agent: Option<String>,
+    #[serde(default)]
+    pub ip: Option<String>,
+}
+
+/// Représente l'utilisateur authentifié courant, extrait par `require_admin`.
+#[derive(Debug, Clone)]
+pub struct AuthUser {
+    pub user_id: String,
+    pub email: String,
+    pub role: String,
+}
+
+impl AuthUser {
+    /// Utilisateur "système" utilisé quand le feature flag est OFF ou dans les
+    /// contextes internes (cron). Pas de vrai utilisateur, mais rôle admin
+    /// pour ne pas bloquer les endpoints protégés.
+    pub fn system() -> Self {
+        AuthUser {
+            user_id: "system".to_string(),
+            email: "system@misfits.ai".to_string(),
+            role: "admin".to_string(),
+        }
+    }
+}
+
+/// Extrait un token depuis un `HttpRequest`.
+///
+/// Priorité: header `Authorization: Bearer …` puis cookie `session_token`.
+fn extract_token(req: &HttpRequest) -> Option<String> {
+    if let Some(h) = req.headers().get("Authorization") {
+        if let Ok(s) = h.to_str() {
+            if let Some(tok) = s.strip_prefix("Bearer ") {
+                let t = tok.trim();
+                if !t.is_empty() {
+                    return Some(t.to_string());
+                }
+            }
+        }
+    }
+    if let Some(c) = req.cookie("session_token") {
+        let v = c.value().trim().to_string();
+        if !v.is_empty() {
+            return Some(v);
+        }
+    }
+    None
+}
+
+/// Persiste une nouvelle session admin en base et renvoie le token.
+///
+/// Appelé depuis `auth_login` après authentification réussie. La signature
+/// tolère l'absence de mongo (best-effort) — si l'insertion échoue, on log
+/// simplement l'erreur : le login reste réussi et le token utilisable tant
+/// que le feature flag `ADMIN_RBAC_ENFORCE` n'est pas activé.
+pub async fn issue_admin_session(
+    mongo: &mongodb::Client,
+    db_name: &str,
+    user_id: &str,
+    email: &str,
+    role: &str,
+    user_agent: Option<String>,
+    ip: Option<String>,
+) -> AdminSession {
+    let token = uuid::Uuid::new_v4().to_string();
+    let now = Utc::now();
+    let expires = now + Duration::seconds(session_ttl_secs());
+    let session = AdminSession {
+        token: token.clone(),
+        user_id: user_id.to_string(),
+        email: email.to_string(),
+        role: role.to_string(),
+        created_at: now.to_rfc3339(),
+        expires_at: expires.to_rfc3339(),
+        last_seen_at: Some(now.to_rfc3339()),
+        user_agent,
+        ip,
+    };
+    let coll = mongo
+        .database(db_name)
+        .collection::<AdminSession>(ADMIN_SESSIONS_COLL);
+    if let Err(e) = coll.insert_one(&session).await {
+        eprintln!("issue_admin_session: insert_one failed: {}", e);
+    }
+    session
+}
+
+/// Cherche une session valide (non expirée) par son token.
+pub async fn lookup_session(
+    mongo: &mongodb::Client,
+    db_name: &str,
+    token: &str,
+) -> Option<AdminSession> {
+    let coll = mongo
+        .database(db_name)
+        .collection::<AdminSession>(ADMIN_SESSIONS_COLL);
+    match coll.find_one(doc! { "token": token }).await {
+        Ok(Some(sess)) => {
+            let now = Utc::now();
+            if let Ok(exp) = chrono::DateTime::parse_from_rfc3339(&sess.expires_at) {
+                if now.with_timezone(&chrono::FixedOffset::east_opt(0).unwrap()) > exp {
+                    return None; // expirée
+                }
+            }
+            Some(sess)
+        }
+        Ok(None) => None,
+        Err(e) => {
+            eprintln!("lookup_session: find_one failed: {}", e);
+            None
+        }
+    }
+}
+
+/// Révoque une session (best-effort).
+pub async fn revoke_session(mongo: &mongodb::Client, db_name: &str, token: &str) {
+    let coll = mongo
+        .database(db_name)
+        .collection::<AdminSession>(ADMIN_SESSIONS_COLL);
+    if let Err(e) = coll.delete_one(doc! { "token": token }).await {
+        eprintln!("revoke_session: delete_one failed: {}", e);
+    }
+}
+
+/// Garde principale — à appeler en début de chaque handler `/api/admin/*`
+/// qui doit être réservé aux admins.
+///
+/// - Feature flag OFF → renvoie `Ok(AuthUser::system())`.
+/// - Feature flag ON  → exige un token valide dont le rôle est "admin".
+///
+/// En cas de refus, renvoie une réponse HTTP prête à être servie par le
+/// handler (401 si non authentifié, 403 si role insuffisant).
+pub async fn require_admin(
+    req: &HttpRequest,
+    mongo: &Arc<mongodb::Client>,
+    db_name: &str,
+) -> Result<AuthUser, HttpResponse> {
+    if !rbac_enabled() {
+        return Ok(AuthUser::system());
+    }
+    let token = match extract_token(req) {
+        Some(t) => t,
+        None => {
+            return Err(HttpResponse::build(StatusCode::UNAUTHORIZED).json(
+                serde_json::json!({
+                    "code": "AUTH_REQUIRED",
+                    "message": "Missing session token"
+                }),
+            ))
+        }
+    };
+    let session = match lookup_session(mongo.as_ref(), db_name, &token).await {
+        Some(s) => s,
+        None => {
+            return Err(HttpResponse::build(StatusCode::UNAUTHORIZED).json(
+                serde_json::json!({
+                    "code": "AUTH_INVALID",
+                    "message": "Session token unknown or expired"
+                }),
+            ))
+        }
+    };
+    if session.role != "admin" {
+        return Err(HttpResponse::build(StatusCode::FORBIDDEN).json(
+            serde_json::json!({
+                "code": "FORBIDDEN",
+                "message": "Admin role required",
+                "role": session.role,
+            }),
+        ));
+    }
+    Ok(AuthUser {
+        user_id: session.user_id,
+        email: session.email,
+        role: session.role,
+    })
+}

--- a/src/bin/email_api.rs
+++ b/src/bin/email_api.rs
@@ -43,6 +43,11 @@ use data_encoding::BASE32;
 use hmac::{Hmac, Mac};
 use openssl::ssl::{SslAcceptor, SslFiletype, SslMethod};
 use serde::{Deserialize, Serialize};
+
+// PR1 (RBAC admin) — module local, gated par ADMIN_RBAC_ENFORCE (feature flag).
+// Ne modifie AUCUN comportement tant que le flag est OFF (défaut).
+#[path = "admin_auth.rs"]
+mod admin_auth;
 use sha1::Sha1;
 
 use chrono::{DateTime, Utc};
@@ -4494,7 +4499,13 @@ struct PatchChangeRequestInputApi {
     execution_error: Option<String>,
 }
 
-async fn api_admin_users_list(mongo: web::Data<Arc<mongodb::Client>>) -> impl Responder {
+async fn api_admin_users_list(
+    req: HttpRequest,
+    mongo: web::Data<Arc<mongodb::Client>>,
+) -> impl Responder {
+    if let Err(resp) = admin_auth::require_admin(&req, &mongo, &mongo_db_name()).await {
+        return resp;
+    }
     let coll = mongo
         .database(&mongo_db_name())
         .collection::<AdminUserRecord>(ADMIN_USERS_COLL);
@@ -4524,9 +4535,13 @@ async fn api_admin_users_list(mongo: web::Data<Arc<mongodb::Client>>) -> impl Re
 }
 
 async fn api_admin_user_get(
+    req: HttpRequest,
     path: web::Path<String>,
     mongo: web::Data<Arc<mongodb::Client>>,
 ) -> impl Responder {
+    if let Err(resp) = admin_auth::require_admin(&req, &mongo, &mongo_db_name()).await {
+        return resp;
+    }
     let id = path.into_inner();
     let coll = mongo
         .database(&mongo_db_name())
@@ -4546,9 +4561,13 @@ async fn api_admin_user_get(
 }
 
 async fn api_admin_user_create(
+    req: HttpRequest,
     body: web::Json<CreateAdminUserInput>,
     mongo: web::Data<Arc<mongodb::Client>>,
 ) -> impl Responder {
+    if let Err(resp) = admin_auth::require_admin(&req, &mongo, &mongo_db_name()).await {
+        return resp;
+    }
     let role = body.role.trim().to_ascii_lowercase();
     if !["user", "admin", "support"].contains(&role.as_str()) {
         return HttpResponse::BadRequest()
@@ -4608,10 +4627,14 @@ async fn api_admin_user_create(
 }
 
 async fn api_admin_user_patch(
+    req: HttpRequest,
     path: web::Path<String>,
     body: web::Json<UpdateAdminUserInput>,
     mongo: web::Data<Arc<mongodb::Client>>,
 ) -> impl Responder {
+    if let Err(resp) = admin_auth::require_admin(&req, &mongo, &mongo_db_name()).await {
+        return resp;
+    }
     let id = path.into_inner();
     let coll = mongo
         .database(&mongo_db_name())
@@ -4686,9 +4709,13 @@ async fn api_admin_user_patch(
 }
 
 async fn api_admin_user_delete(
+    req: HttpRequest,
     path: web::Path<String>,
     mongo: web::Data<Arc<mongodb::Client>>,
 ) -> impl Responder {
+    if let Err(resp) = admin_auth::require_admin(&req, &mongo, &mongo_db_name()).await {
+        return resp;
+    }
     let id = path.into_inner();
     let coll = mongo
         .database(&mongo_db_name())
@@ -4705,6 +4732,28 @@ async fn api_admin_user_delete(
             HttpResponse::InternalServerError()
                 .json(serde_json::json!({ "message": "Failed to delete user" }))
         }
+    }
+}
+
+/// PR1 (RBAC) — GET /api/admin/whoami
+///
+/// Utilisé par le frontend pour connaître le rôle réel de l'utilisateur
+/// courant et adapter l'UI (viewer vs admin). Respecte le feature flag :
+/// - RBAC OFF → répond `{ role: "admin", email: "system@...", enforced: false }`
+///   (compat rétro : le front continue à voir un admin).
+/// - RBAC ON  → nécessite un token valide, renvoie l'identité réelle.
+async fn api_admin_whoami(
+    req: HttpRequest,
+    mongo: web::Data<Arc<mongodb::Client>>,
+) -> impl Responder {
+    match admin_auth::require_admin(&req, &mongo, &mongo_db_name()).await {
+        Ok(user) => HttpResponse::Ok().json(serde_json::json!({
+            "userId": user.user_id,
+            "email": user.email,
+            "role": user.role,
+            "enforced": admin_auth::rbac_enabled(),
+        })),
+        Err(resp) => resp,
     }
 }
 
@@ -6643,6 +6692,7 @@ async fn main() -> std::io::Result<()> {
                 )
                 .route("/api/admin/users", web::get().to(api_admin_users_list))
                 .route("/api/admin/users", web::post().to(api_admin_user_create))
+                .route("/api/admin/whoami", web::get().to(api_admin_whoami))
                 .route("/api/admin/users/{id}", web::get().to(api_admin_user_get))
                 .route(
                     "/api/admin/users/{id}",


### PR DESCRIPTION
## Contexte
Première PR d'une série sur le **RBAC admin** demandée pour la console admin de misfits-web (onglet "Gestion des utilisateurs"). Aujourd'hui les endpoints `/api/admin/*` sont **totalement ouverts** (aucune auth), et `auth_login` renvoie `role: "admin"` en dur. PR1 pose la fondation, sans casser l'existant.

## Changements
- **`src/bin/admin_auth.rs`** (nouveau module local, ~200 lignes, autonome)
  - `AuthUser`, `AdminSession`
  - `require_admin(&req, &mongo, &db)` : extractor + guard
  - `issue_admin_session()`, `lookup_session()`, `revoke_session()`
  - Collection Mongo `admin_sessions` (token, user_id, role, expires_at)
- **`src/bin/email_api.rs`**
  - `mod admin_auth;`
  - Guard `require_admin` appliqué aux 5 handlers `/api/admin/users*`
  - Nouveau endpoint **`GET /api/admin/whoami`** → `{ userId, email, role, enforced }`

## Feature flag `ADMIN_RBAC_ENFORCE`
| Valeur | Effet |
|---|---|
| absent / `false` / `0` (défaut) | Comportement **inchangé**. `require_admin` renvoie `AuthUser::system()` sans même toucher Mongo. Zéro régression pour misfits-web actuel. |
| `1` / `true` | Validation effective. 401 si pas de token, 403 si role != admin. |

## Non-régression
- Pas de modif du JSON retourné par `auth_login` / `auth_register`.
- Pas de modif des schémas `AdminUserRecord`, `CreateAdminUserInput`, etc.
- Aucun endpoint existant supprimé/renommé.
- Le proxy Next.js de misfits-web continue de fonctionner sans changement.

## Prochaines PR
- PR2 (frontend misfits-web) : proxy relaye le token + gate UI viewer/admin
- PR3 (backend) : comptes admin réels — invitation par email, password reset
- PR4 (backend) : pagination, search, audit trail
- PR5 (frontend) : UI CRUD complet

## Test
- `cargo check` via CI.
- Smoke test post-deploy : `curl /api/admin/whoami` → `{"role":"admin","enforced":false}` tant que la variable n'est pas activée.
