### PR TITLE
docs: sync install/usage/data-dictionary/sequence with code

### DIFF
--- a/docs/DATA-DICTIONARY.md
+++ b/docs/DATA-DICTIONARY.md
@@ -1,0 +1,96 @@
+# DATA DICTIONARY — MongoDB `mailserver`
+
+Extrait des `collection::<T>("…")` de :
+- [`src/bin/email_api.rs`](../src/bin/email_api.rs)
+- [`src/logic/mod.rs`](../src/logic/mod.rs)
+- [`src/external_imap/mod.rs`](../src/external_imap/mod.rs)
+- [`src/entities.rs`](../src/entities.rs)
+
+Base : `${MONGODB_DATABASE}` (def. `mailserver`).
+
+## Collections
+
+| Collection                    | Type sérialisé              | Source                                    | Usage                                             |
+|-------------------------------|-----------------------------|-------------------------------------------|---------------------------------------------------|
+| `users`                       | `User` / bson::Document     | `logic/mod.rs:128`, `email_api.rs:2732`   | Comptes utilisateurs, mot de passe (bcrypt)       |
+| `mailboxes`                   | `Mailbox`                   | `logic/mod.rs:138,626,800,839,866`        | Boîtes IMAP par user                              |
+| `emails`                      | `Email` / bson::Document    | `logic/mod.rs:205,411…757`                | Messages stockés (in/out)                         |
+| `archive`                     | `Email`                     | `logic/mod.rs:598`                        | Emails archivés                                   |
+| `aliases`                     | bson::Document              | `logic/mod.rs:178`                        | Alias d'adresses                                  |
+| `subscriptions`               | `User`                      | `logic/mod.rs:888`                        | Abonnements mailing-list                          |
+| `mail_events`                 | bson::Document              | `email_api.rs:264,285`, `logic/mod.rs:247`| Audit trail mail (in/out, statuts)                |
+| `smtp_events`                 | bson::Document              | `email_api.rs:3936`                       | Événements SMTP bruts (monitoring)                |
+| `auth_events`                 | bson::Document              | `email_api.rs:1614`                       | Login/logout/2FA                                  |
+| `two_factor_codes`            | bson::Document              | `email_api.rs:2772`                       | Codes 2FA temporaires                             |
+| `password_reset_tokens`       | bson::Document              | `email_api.rs:2844,2912`                  | Jetons de reset                                   |
+| `drafts`                      | bson::Document              | `email_api.rs:4150,4233,4273,4510`        | Brouillons                                        |
+| `send_queue`                  | bson::Document              | `email_api.rs:1522…3775` (const `SEND_QUEUE_COLL`) | File d'envoi (schedule, undo)             |
+| `tenant_state`                | bson::Document              | `email_api.rs:891`                        | État tenant / feature flags                       |
+| `admin_runbooks`              | bson::Document              | `email_api.rs:1226,1421`                  | Runbooks admin                                    |
+| `ai_settings`                 | bson::Document              | grep global                               | Réglages IA par user                              |
+| `calendar_events`             | `CalendarEvent`             | `entities.rs` + email_api.rs              | Événements calendrier                             |
+| `external_imap_accounts`      | `ExternalImapAccount`       | `external_imap/mod.rs:133`                | Comptes IMAP externes                             |
+| `external_imap_folders`       | `ExternalImapFolder`        | `external_imap/mod.rs:139`                | Dossiers distants + mapping local                 |
+| `external_imap_messages`      | `ExternalImapMessage`       | `external_imap/mod.rs:145`                | Messages synchronisés                             |
+| `external_imap_sync_runs`     | `ExternalSyncRun`           | `external_imap/mod.rs:151`                | Runs de sync (statut, stats)                      |
+
+## Structs Rust (extraits de `src/entities.rs`)
+
+### `Email`
+| Champ            | Type BSON       | Notes                             |
+|------------------|-----------------|-----------------------------------|
+| id               | String          | UUID                              |
+| from             | String          |                                   |
+| to               | String          |                                   |
+| subject          | String          |                                   |
+| body             | String          |                                   |
+| headers          | Array<Tuple>    | `Vec<(String,String)>`            |
+| flags            | Array<String>   | IMAP flags                        |
+| sequence_number  | u32             | IMAP MSN                          |
+| uid              | u32             | IMAP UID                          |
+| internal_date    | Date            | `bson::DateTime`                  |
+| dkim_signature   | String?         |                                   |
+
+### `CalendarEvent`
+`id`, `user_id`, `title`, `description`, `start`, `end`, `event_type`
+(def. `"default"`), `color` (def. `"#3788d8"`), `location`, `created_at`,
+`updated_at`.
+
+### `ExternalImapAccount` (camelCase JSON)
+`id`, `ownerUserId`, `provider`, `email`, `authType`, `secretRef?`,
+`secretValue?`, `imapHost`, `imapPort` (u16), `imapTls` (bool), `smtpHost?`,
+`smtpPort?`, `smtpTls?`, `status`, `lastSyncAt?`, `lastError?`, `createdAt`,
+`updatedAt`.
+
+### `ExternalImapFolder`
+`id`, `accountId`, `ownerUserId`, `remoteName`, `localRole`, `uidValidity?`,
+`highestUid?`, `highestModseq?`, `createdAt`, `updatedAt`.
+
+### `ExternalImapMessage`
+`id`, `accountId`, `folderId?`, `ownerUserId`, `remoteUid?`, `messageIdHeader?`,
+`threadKey?`, `from?`, `to?`, `subject?`, `sentAt?`, `flags[]`, `internalDate?`,
+`bodyPreview?`, `rawRef?`, `dedupHash?`, `deleted` (bool), `createdAt`,
+`updatedAt`.
+
+### `ExternalSyncRun`
+`id`, `accountId`, `ownerUserId`, `mode`, `folders[]`, `since?`, `status`,
+`statsFetched`, `statsUpdated`, `statsDeleted`, `startedAt`, `endedAt?`,
+`error?`.
+
+### `AdminUserRecord` / `AdminUserActivity`
+Cf. `entities.rs` — dashboards admin (sessions24h, actions7d, activity feed).
+
+### `ChangeRequestItem` / `WorkflowStage` / `WorkflowEvent`
+Modèle "change requests" (workflow multi-étapes, checklists, execution state).
+
+## Index
+
+Le code n'utilise pas `create_index` de manière visible ; les index sont
+gérés hors code (opération MongoDB manuelle). Index recommandés :
+
+- `users.email` unique
+- `emails.{to,internal_date}`, `emails.uid`, `emails.id` unique
+- `external_imap_messages.{accountId,remoteUid}` unique
+- `external_imap_messages.dedupHash`
+- `send_queue.{status,scheduledAt}`
+- `mail_events.at`, `auth_events.at`

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -1,0 +1,161 @@
+# INSTALL — misfits.ai Mail (reimagined-guide)
+
+Ce document est extrait du code réel du dépôt. Chaque affirmation renvoie à un
+fichier source.
+
+## 1. Prérequis
+
+- Rust stable (image builder = `rust:1.88`, cf. [`Dockerfile`](../Dockerfile) ligne 2).
+- MongoDB 4+ (natif systemd sur la VM Scaleway — **pas** dans un container ;
+  cf. commentaire d'en-tête de [`docker-compose.deploy.yml`](../docker-compose.deploy.yml)).
+- Docker + Docker Compose v2 pour l'exécution en production.
+- OpenSSL / `libssl-dev` en build (Dockerfile étape builder).
+
+## 2. Binaires produits
+
+Déclarés dans [`Cargo.toml`](../Cargo.toml) (`autobins = false`) :
+
+| Binaire       | Chemin                        | Rôle                                  |
+|---------------|-------------------------------|---------------------------------------|
+| `smtp_server` | `src/bin/smtp_server.rs`      | Serveur SMTP entrant/sortant + STARTTLS |
+| `email_api`   | `src/bin/email_api.rs`        | API HTTP (actix-web) : inbox, send, admin, external IMAP, calendar, OAuth, Hermes |
+| `imap_server` | `src/bin/imap_server.rs`      | Serveur IMAP4rev1 minimal             |
+| `client`      | `src/bin/client.rs`           | Client SMTP de test                   |
+
+(Aussi présent : `admin_auth.rs`, `api.rs`, `imap_runner.rs` — modules utilitaires.)
+
+## 3. Variables d'environnement
+
+Source de vérité : [`env.example`](../env.example). Extrait par domaine :
+
+### SMTP
+- `SMTP_TLS_ADDR` (def. `0.0.0.0:8465`)
+- `SMTP_PLAIN_ADDR` (def. `0.0.0.0:8025`)
+- `SMTP_REQUIRE_STARTTLS` (`true`/`false`)
+- `SMTP_HOSTNAME` (ex. `mail.misfits.ai`)
+- `SMTP_USERNAME` / `SMTP_PASSWORD`
+- `CERT_PATH` / `KEY_PATH` (en prod, injectés depuis le volume `caddy_data`, cf.
+  `docker-compose.deploy.yml`)
+
+### SMTP Relay (optionnel — port 25 sortant bloqué)
+`SMTP_RELAY_HOST`, `SMTP_RELAY_PORT`, `SMTP_RELAY_USER`, `SMTP_RELAY_PASSWORD`.
+
+### MongoDB
+- `MONGODB_USERNAME`, `MONGODB_PASSWORD`
+- `MONGODB_CLUSTER_URL` (prod = IP privée Scaleway VPC)
+- `MONGODB_APP_NAME` (def. `mailserver`)
+- `MONGODB_DATABASE` (def. `mailserver`)
+- `MONGODB_URL` complet en prod (injecté via 1Password)
+- `USE_MONGODB=true` (sinon fallback fichiers locaux)
+
+### IMAP
+- `IMAP_SERVER` (def. `0.0.0.0:143`) — lu par `src/bin/imap_server.rs:52`
+- `IMAP_SERVER_API_PORT` (def. `8080`)
+
+### API
+- `API_SERVER_ADDR` (def. `0.0.0.0:8000`)
+- `HERMES_BASE_URL` (adresse VPC privée), `HERMES_API_KEY`, `HERMES_MODEL`
+- `GITHUB_CLIENT_ID`, `GITHUB_CLIENT_SECRET`, `OAUTH_CALLBACK_BASE_URL`, `FRONTEND_BASE_URL`
+
+### DKIM
+- `DKIM_SERVICE_URL` (def. `http://dkim-service:3000/generate-dkim`)
+  → Service externe fourni par `canatac/studious-octo-rotary-phone`.
+
+### Monitoring / Logs
+- `SMTP_MONITORING_ENABLED=true`
+- `RUST_LOG=info|debug`
+
+### Domaine
+- `DOMAIN_NAME=misfits.ai`
+
+## 4. Build local
+
+```bash
+cp env.example .env
+cargo check --lib --bins        # même vérif qu'en CI (cicd.yml job "test")
+cargo build --release --bins
+./target/release/smtp_server &
+./target/release/email_api &
+./target/release/imap_server &
+```
+
+## 5. Build Docker
+
+```bash
+docker build -t smtp-server:local .
+```
+
+Le [`Dockerfile`](../Dockerfile) est multi-stage :
+- Stage 1 (`rust:1.88`) — cache-friendly : `Cargo.toml`+`Cargo.lock` copiés
+  avant les sources pour cacher les 445 dépendances.
+- Stage 2 (`debian:bookworm-slim`) — installe `openssl`, `ca-certificates`,
+  `libssl3`, `netcat-openbsd`, `gosu` ; ajoute un utilisateur `default_user`
+  (UID 10001) et copie les 3 binaires. Certs auto-signés générés à la volée.
+- Healthcheck TCP : `nc -z 127.0.0.1 8025`.
+- `EXPOSE 25 8025 8465 143 993 8000 8443`.
+
+## 6. Déploiement VM Scaleway (workflow réel)
+
+Pipeline : [`.github/workflows/cicd.yml`](../.github/workflows/cicd.yml).
+
+Étapes :
+
+1. **JOB `test`** — `cargo check --lib --bins` (Swatinem/rust-cache).
+2. **JOB `build-push-smtp`** — Buildx → push vers Scaleway Registry :
+   - `registry: ${SCW_REGISTRY_ENDPOINT}` (ex. `rg.fr-par.scw.cloud/smtp-rust-registry`)
+   - `username: nologin`, `password: ${SCW_SECRET_KEY}`
+   - tags : `smtp-server:latest` et `smtp-server:${{ github.sha }}`.
+3. **JOB `deploy`** — SSH `debian@${VM_IP}` (VM Scaleway `51.158.114.182`) :
+   - Charge les secrets via `1password/load-secrets-action@v4`
+     (`op://hermes/ssh-hermes-smtp/private-key`, `op://hermes/scw-hermes-smtp/texte`).
+   - `scp docker-compose.deploy.yml Caddyfile → /home/debian/`.
+   - Injecte `GITHUB_CLIENT_ID/SECRET`, `SCW_REGISTRY_ENDPOINT`,
+     `OAUTH_CALLBACK_BASE_URL`, `FRONTEND_BASE_URL` dans `/home/debian/.env.deploy`.
+   - `docker login`, pull images (SMTP + DKIM), `docker compose -f docker-compose.deploy.yml --env-file .env.deploy up -d`.
+
+Services déployés (cf. [`docker-compose.deploy.yml`](../docker-compose.deploy.yml)) :
+`smtp-server`, `email-api`, `imap-server`, `dkim-service`, `misfits-web`.
+Ports host mappés : `25→8025`, `587→8465`, `8025→8025`, `8465→8465`,
+`email-api` sur `127.0.0.1:8000` (fronté par Caddy).
+
+## 7. Secrets GitHub attendus
+
+Lus par [`cicd.yml`](../.github/workflows/cicd.yml) :
+
+| Secret                     | Rôle                                             |
+|----------------------------|--------------------------------------------------|
+| `SCW_REGISTRY_ENDPOINT`    | Endpoint du registry Scaleway                    |
+| `SCW_SECRET_KEY`           | Password registry (username fixe = `nologin`)    |
+| `VM_IP`                    | IP publique VM Scaleway                          |
+| `VM_KNOWN_HOSTS`           | Fingerprint SSH                                  |
+| `OP_SERVICE_ACCOUNT_TOKEN` | Jeton 1Password service-account                  |
+| `OAUTH_GITHUB_CLIENT_ID`   | OAuth GitHub                                     |
+| `OAUTH_GITHUB_CLIENT_SECRET` | OAuth GitHub                                   |
+
+Secrets 1Password (vault `hermes`) chargés au runtime :
+`ssh-hermes-smtp/private-key`, `scw-hermes-smtp/texte` (contenu `.env.deploy`).
+
+## 8. MongoDB natif (VM)
+
+- MongoDB tourne en systemd (`mongod`) sur la VM et écoute sur son IP privée
+  Scaleway (variable `MONGODB_CLUSTER_URL`/`MONGODB_URL`).
+- Base : `mailserver`, collections listées dans
+  [`docs/DATA-DICTIONARY.md`](DATA-DICTIONARY.md).
+
+## 9. DNS — SPF / DKIM / DMARC
+
+Pointeurs (le code n'impose pas les valeurs — à publier côté zone DNS
+`misfits.ai`) :
+
+- **SPF** : `v=spf1 ip4:<IP publique VM> -all`
+- **DKIM** : sélecteur généré par le service DKIM externe
+  (`DKIM_SERVICE_URL`, cf. `canatac/studious-octo-rotary-phone`). La clé
+  publique est publiée en TXT `<selector>._domainkey.misfits.ai`.
+- **DMARC** : `v=DMARC1; p=quarantine; rua=mailto:postmaster@misfits.ai`
+
+## 10. Note régression fix récent
+
+PR #243 (master `6abd9a1b`) : le handler SMTP utilisait le `SessionManager`
+global au lieu de la session courante, et le parsing `MAIL FROM:`/`RCPT TO:`
+n'était pas insensible à la casse. Correction en place dans
+[`src/bin/smtp_server.rs`](../src/bin/smtp_server.rs) (lignes ~738–744).

--- a/docs/SEQUENCE-DIAGRAMS.md
+++ b/docs/SEQUENCE-DIAGRAMS.md
@@ -1,0 +1,148 @@
+# SEQUENCE DIAGRAMS
+
+Diagrammes tirés du code source (`src/bin/*.rs`, `src/imap_server/mod.rs`,
+`src/logic/mod.rs`, `src/external_imap/mod.rs`).
+
+## (a) Réception SMTP entrante → routing RCPT TO → MongoDB
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant MTA as MTA distant
+    participant SMTP as smtp_server (0.0.0.0:8025/8465)
+    participant SM as SessionManager (session courante)
+    participant Mongo as MongoDB mailserver
+
+    MTA->>SMTP: TCP connect
+    SMTP-->>MTA: 220 mail.misfits.ai ESMTP
+    MTA->>SMTP: EHLO client
+    SMTP-->>MTA: 250-STARTTLS / 250 AUTH PLAIN
+    MTA->>SMTP: STARTTLS
+    SMTP-->>MTA: 220 Ready
+    Note over SMTP,SM: Handshake TLS ; session par connexion (fix PR #243)
+    MTA->>SMTP: MAIL FROM:<bob@ext.com>
+    Note right of SMTP: match insensible à la casse (fix PR #243)
+    SMTP-->>MTA: 250 OK
+    MTA->>SMTP: RCPT TO:<alice@misfits.ai>
+    SMTP-->>MTA: 250 OK
+    MTA->>SMTP: DATA + corps + .
+    SMTP->>SMTP: extract_email_content(body)
+    SMTP->>Mongo: insertOne emails { from, to, subject, body, internal_date }
+    SMTP->>Mongo: insertOne mail_events { kind:"inbound", at, from, to }
+    SMTP->>Mongo: insertOne smtp_events { raw, status }
+    SMTP-->>MTA: 250 OK: message queued
+    MTA->>SMTP: QUIT
+    SMTP-->>MTA: 221 Bye
+```
+
+## (b) Envoi SMTP sortant + service DKIM externe
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant Client as Client (API /api/send)
+    participant API as email_api
+    participant SQ as send_queue (Mongo)
+    participant DKIM as dkim-service (canatac/studious-octo-rotary-phone)
+    participant Relay as MTA sortant (port 25 ou SMTP_RELAY_*)
+    participant Log as mail_events / smtp_events
+
+    Client->>API: POST /api/send {to, subject, body} + x-user-id
+    API->>SQ: insertOne send_queue { status:"pending" }
+    API-->>Client: 202 { id }
+    API->>DKIM: POST DKIM_SERVICE_URL {domain, from, headers, body}
+    DKIM-->>API: 200 { dkim_signature }
+    API->>Relay: MAIL FROM / RCPT TO / DATA (avec header DKIM-Signature)
+    Relay-->>API: 250 OK
+    API->>SQ: updateOne { status:"sent", sentAt }
+    API->>Log: mail_events { kind:"outbound", to, subject }
+    Client->>API: GET /api/send/{id}/status
+    API-->>Client: { status:"sent" }
+```
+
+## (c) IMAP fetch inbox
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant C as Client IMAP (Thunderbird, ...)
+    participant I as imap_server (:143)
+    participant Mongo as MongoDB mailserver
+
+    C->>I: connect
+    I-->>C: * OK IMAP4rev1 Service Ready
+    C->>I: a1 CAPABILITY
+    I-->>C: * CAPABILITY IMAP4rev1 AUTH=PLAIN LOGIN IDLE UIDPLUS MULTIAPPEND
+    C->>I: a2 LOGIN alice pass
+    I->>Mongo: users.find({email:"alice"}) + bcrypt verify
+    Mongo-->>I: ok
+    I-->>C: a2 OK LOGIN completed
+    C->>I: a3 LIST "" "*"
+    I->>Mongo: mailboxes.find({owner:"alice"})
+    Mongo-->>I: [INBOX, Sent, ...]
+    I-->>C: * LIST (\HasNoChildren) "/" "INBOX" ...
+    C->>I: a4 SELECT INBOX
+    I->>Mongo: emails.count({to:"alice"}), maxUid, unseen
+    I-->>C: * FLAGS / EXISTS / UIDVALIDITY / UIDNEXT + OK [READ-WRITE]
+    C->>I: a5 UID FETCH 1:* (FLAGS ENVELOPE)
+    I->>Mongo: emails.find({to:"alice"}).sort(uid)
+    Mongo-->>I: docs
+    I-->>C: * n FETCH (...) + a5 OK
+```
+
+## (d) API GET /api/emails (inbox client authentifié)
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant Web as misfits-web (front)
+    participant Caddy as Caddy (TLS, mail.misfits.ai)
+    participant API as email_api (127.0.0.1:8000)
+    participant Mongo as MongoDB mailserver
+
+    Web->>Caddy: GET /api/emails (Cookie session)
+    Caddy->>API: proxy_pass /api/emails + x-user-id: alice@misfits.ai
+    API->>API: read header "x-user-id" (email_api.rs:2650)
+    API->>Mongo: emails.find({to: user}).sort({internal_date:-1})
+    Mongo-->>API: [Email, ...]
+    API-->>Caddy: 200 [{id, from, subject, ...}]
+    Caddy-->>Web: 200 JSON
+```
+
+## (e) Auth flow — login + 2FA + OAuth GitHub
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant U as User (browser)
+    participant API as email_api
+    participant Mongo as MongoDB mailserver
+    participant GH as GitHub OAuth
+
+    Note over U,API: --- Password login ---
+    U->>API: POST /api/auth/login {email, password}
+    API->>Mongo: users.findOne({email})
+    Mongo-->>API: user
+    API->>API: bcrypt::verify(password, user.hash)
+    alt 2FA activé
+        API->>Mongo: two_factor_codes.insertOne
+        API-->>U: 200 { need2fa: true }
+        U->>API: POST /api/auth/2fa/verify {code}
+        API->>Mongo: two_factor_codes.findOne + expire
+    end
+    API->>Mongo: auth_events.insertOne { kind:"login" }
+    API-->>U: 200 { token / cookie }
+
+    Note over U,GH: --- OAuth GitHub ---
+    U->>API: GET /api/auth/oauth/github/start
+    API-->>U: 302 redirect to GH authorize (GITHUB_CLIENT_ID)
+    U->>GH: consent
+    GH-->>U: 302 → /api/auth/oauth/github/callback?code=...
+    U->>API: GET /api/auth/oauth/github/callback?code
+    API->>GH: POST /login/oauth/access_token (client_id/secret)
+    GH-->>API: access_token
+    API->>GH: GET /user
+    GH-->>API: profile
+    API->>Mongo: users.upsert({email})
+    API-->>U: 302 → FRONTEND_BASE_URL avec session
+```

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -1,0 +1,182 @@
+# USAGE — misfits.ai Mail
+
+## 1. Lancer les binaires
+
+```bash
+# 1) API HTTP (port 8000 par défaut)
+API_SERVER_ADDR=0.0.0.0:8000 ./target/release/email_api
+
+# 2) SMTP (plain 8025, TLS 8465)
+./target/release/smtp_server
+
+# 3) IMAP (port 143)
+IMAP_SERVER=0.0.0.0:143 ./target/release/imap_server
+```
+
+Sous Docker, chaque binaire est démarré via `entrypoint.sh` + `command:` du
+compose (`smtp_server`, `email_api`, `imap_server`).
+
+## 2. SMTP — commandes supportées
+
+Source : [`src/bin/smtp_server.rs`](../src/bin/smtp_server.rs).
+
+Commandes reconnues :
+- `HELO` / `EHLO`
+- `STARTTLS` (obligatoire si `SMTP_REQUIRE_STARTTLS=true`)
+- `AUTH PLAIN` (via `SessionManager`, session par connexion)
+- `MAIL FROM:` — parsé insensible à la casse, cf. fix PR #243
+- `RCPT TO:` — idem
+- `DATA` … `.` (fin de corps)
+- `RSET`, `NOOP`, `QUIT`
+
+Routing entrant : à `QUIT`, si `from` et `to` sont non vides, le corps est
+parsé (`extract_email_content`), puis stocké MongoDB (`emails`) et un événement
+publié dans `mail_events` / `smtp_events`.
+
+## 3. IMAP — capabilities
+
+Bannière et CAPABILITY (cf. `src/imap_server/mod.rs:41,168`) :
+
+```
+* OK IMAP4rev1 Service Ready
+* CAPABILITY IMAP4rev1 AUTH=PLAIN LOGIN IDLE UIDPLUS MULTIAPPEND
+```
+
+Commandes implémentées : `CAPABILITY`, `LOGIN`, `LOGOUT`, `LIST`, `SELECT`,
+`FETCH`, `NOOP`. `SELECT` renvoie `FLAGS/EXISTS/RECENT/UNSEEN/UIDVALIDITY/UIDNEXT`
+puis `OK [READ-WRITE] SELECT completed`.
+
+## 4. Endpoints HTTP (email_api)
+
+Extrait depuis la configuration `HttpServer::new(...)` (ligne 6489 de
+[`src/bin/email_api.rs`](../src/bin/email_api.rs)). Auth = header
+`x-user-id: <user>` sur les endpoints utilisateur (cf. ligne 2650) ; endpoints
+`/api/admin/*` protégés par `admin_auth::require_admin` (cf. `src/bin/admin_auth.rs`).
+
+### Docs / méta
+| Méthode | Path                       | Handler                  |
+|---------|----------------------------|--------------------------|
+| GET     | `/api/openapi.json`        | `api_openapi_json`       |
+| GET     | `/api/docs`                | `api_swagger_ui`         |
+| GET     | `/api/external/openapi.json` | `api_external_openapi` |
+
+### Auth / user
+| Méthode | Path                                | Handler                       |
+|---------|-------------------------------------|-------------------------------|
+| POST    | `/api/auth/login`                   | `auth_login`                  |
+| POST    | `/api/auth/register`                | `auth_register`               |
+| POST    | `/api/auth/logout`                  | `auth_logout`                 |
+| POST    | `/api/auth/refresh`                 | `auth_refresh`                |
+| POST    | `/api/auth/2fa/verify`              | `api_2fa_verify`              |
+| POST    | `/api/auth/password-reset/request`  | `api_password_reset_request`  |
+| POST    | `/api/auth/password-reset/confirm`  | `api_password_reset_confirm`  |
+| GET     | `/api/auth/oauth/{provider}/start`  | `auth_oauth_start`            |
+| GET     | `/api/auth/oauth/{provider}/callback` | `auth_oauth_callback`       |
+| PATCH   | `/api/user/locale`                  | `api_patch_user_locale`       |
+
+### Emails (inbox / envoi / brouillons / templates)
+| Méthode | Path                          | Handler                 |
+|---------|-------------------------------|-------------------------|
+| GET     | `/api/emails`                 | `api_emails`            |
+| GET     | `/api/emails/{id}`            | `api_email_by_id`       |
+| POST    | `/api/emails/{id}/action`     | `api_email_action`      |
+| GET     | `/api/tags`                   | `api_tags`              |
+| POST    | `/api/send`                   | `api_send`              |
+| GET     | `/api/send/{id}/status`       | `api_send_status`       |
+| POST    | `/api/send/undo`              | `api_send_undo`         |
+| POST    | `/api/send/schedule`          | `api_send_schedule`     |
+| GET     | `/api/drafts`                 | `api_drafts_list`       |
+| POST    | `/api/drafts`                 | `api_drafts_upsert`     |
+| DELETE  | `/api/drafts/{id}`            | `api_drafts_delete`     |
+| GET     | `/api/templates`              | `api_templates`         |
+
+### AI / Hermes
+| Méthode | Path                                | Handler                  |
+|---------|-------------------------------------|--------------------------|
+| GET     | `/api/settings/ai`                  | `api_get_ai_settings`    |
+| PUT     | `/api/settings/ai`                  | `api_put_ai_settings`    |
+| POST    | `/api/hermes/chat`                  | `api_hermes_chat`        |
+| GET     | `/api/hermes/runs`                  | `api_hermes_runs_list`   |
+| POST    | `/api/hermes/runs`                  | `api_hermes_runs`        |
+| GET     | `/api/hermes/runs/{id}/status`      | `api_hermes_run_status`  |
+| GET     | `/api/hermes/runs/{id}/events`      | `api_hermes_run_events`  |
+
+### Calendrier
+| Méthode | Path                          | Handler                 |
+|---------|-------------------------------|-------------------------|
+| POST    | `/api/calendar/events`        | `calendar_create_event` |
+| GET     | `/api/calendar/events`        | `calendar_list_events`  |
+| GET     | `/api/calendar/events/{id}`   | `calendar_get_event`    |
+
+### External IMAP (Gmail/Outlook connectés)
+| Méthode | Path                                                        | Handler                            |
+|---------|-------------------------------------------------------------|------------------------------------|
+| GET     | `/api/external/accounts`                                    | `api_external_accounts_list`       |
+| POST    | `/api/external/accounts`                                    | `api_external_accounts_create`     |
+| GET     | `/api/external/accounts/{id}`                               | `api_external_account_get`         |
+| PATCH   | `/api/external/accounts/{id}`                               | `api_external_account_patch`       |
+| DELETE  | `/api/external/accounts/{id}`                               | `api_external_account_delete`      |
+| POST    | `/api/external/accounts/{id}/test`                          | `api_external_account_test`        |
+| GET     | `/api/external/accounts/{id}/folders`                       | `api_external_folders_list`        |
+| POST    | `/api/external/accounts/{id}/folders/discover`              | `api_external_folders_discover`    |
+| PUT     | `/api/external/accounts/{id}/folders/{folder_id}/mapping`   | `api_external_folder_mapping_put`  |
+| POST    | `/api/external/accounts/{id}/sync/start`                    | `api_external_sync_start`          |
+| GET     | `/api/external/accounts/{id}/sync/status`                   | `api_external_sync_status`         |
+| POST    | `/api/external/accounts/{id}/sync/pause`                    | `api_external_sync_pause`          |
+| POST    | `/api/external/accounts/{id}/sync/resume`                   | `api_external_sync_resume`         |
+| GET     | `/api/external/sync/runs/{run_id}`                          | `api_external_sync_run_get`        |
+| GET     | `/api/external/accounts/{id}/messages`                      | `api_external_messages_list`       |
+| POST    | `/api/external/messages/{message_id}/action`                | `api_external_message_action`      |
+
+### Admin (require_admin)
+| Méthode | Path                          | Handler                     |
+|---------|-------------------------------|-----------------------------|
+| GET     | `/api/admin/whoami`           | `api_admin_whoami`          |
+| GET     | `/api/admin/users`            | `api_admin_users_list`      |
+| POST    | `/api/admin/users`            | `api_admin_user_create`     |
+| GET     | `/api/admin/users/{id}`       | `api_admin_user_get`        |
+| GET     | `/api/monitoring/live`        | `api_monitoring_live`       |
+| GET     | `/api/security/live`          | `api_security_live`         |
+
+### Events / SSE / mailing lists
+| Méthode | Path                     | Handler                |
+|---------|--------------------------|------------------------|
+| GET     | `/api/events`            | `api_events`           |
+| GET     | `/api/events/stream`     | `api_events_stream`    |
+| POST    | `/send-email`            | `send_email_handler`   |
+| POST    | `/create-mailing-list`   | `create_mailing_list`  |
+
+## 5. Exemples curl
+
+```bash
+# Lister l'inbox
+curl -H 'x-user-id: alice@misfits.ai' http://localhost:8000/api/emails
+
+# Envoyer un email
+curl -X POST http://localhost:8000/api/send \
+  -H 'x-user-id: alice@misfits.ai' \
+  -H 'Content-Type: application/json' \
+  -d '{"to":"bob@example.com","subject":"hi","body":"hello"}'
+
+# Register + login
+curl -X POST http://localhost:8000/api/auth/register \
+  -H 'Content-Type: application/json' \
+  -d '{"email":"alice@misfits.ai","password":"secret"}'
+
+# Connecter un compte IMAP externe (Gmail)
+curl -X POST http://localhost:8000/api/external/accounts \
+  -H 'x-user-id: alice@misfits.ai' \
+  -H 'Content-Type: application/json' \
+  -d '{"provider":"gmail","email":"alice@gmail.com","imapHost":"imap.gmail.com","imapPort":993,"imapTls":true,"authType":"password","secretValue":"app-password"}'
+
+# Test SMTP local via swaks (STARTTLS obligatoire en prod)
+swaks --to alice@misfits.ai --from bob@example.com --server localhost:8025
+```
+
+## 6. OpenAPI
+
+Deux specs servies :
+- `/api/openapi.json` — API principale (fichier embarqué via `include_str!`
+  depuis `ops/openapi/`).
+- `/api/external/openapi.json` — sous-API "External IMAP".
+UI Swagger : `/api/docs`.


### PR DESCRIPTION
## Portée
Synchronisation docs/ avec le code réel (docs-only, aucune modif code/CI).

## Sources d'info inspectées
- `Cargo.toml` (bins déclarés, deps)
- `src/bin/smtp_server.rs` (parsing MAIL/RCPT, SessionManager, fix PR #243)
- `src/bin/email_api.rs` (routes actix-web ligne ~6489–6800, collections Mongo, auth `x-user-id`, `admin_auth::require_admin`)
- `src/bin/imap_server.rs` + `src/imap_server/mod.rs` (CAPABILITY, LOGIN, LIST, SELECT)
- `src/entities.rs` (structs Email, CalendarEvent, ExternalImap*, AdminUser*, ChangeRequestItem)
- `src/logic/mod.rs` (collections `users`, `mailboxes`, `emails`, `archive`, `aliases`, `mail_events`, `subscriptions`)
- `src/external_imap/mod.rs` (`external_imap_accounts|folders|messages|sync_runs`)
- `env.example` (variables réelles)
- `Dockerfile` (multi-stage rust:1.88 → debian:bookworm-slim)
- `docker-compose.deploy.yml` (5 services, ports 25/587/8025/8465, MongoDB natif)
- `.github/workflows/cicd.yml` (jobs test / build-push-smtp / deploy, 1Password, SCW Registry)

## Livrables
- `docs/INSTALL.md` — prérequis, env vars, build local/Docker, déploiement VM Scaleway, secrets GitHub, DNS SPF/DKIM/DMARC, note fix PR #243.
- `docs/USAGE.md` — lancement 3 binaires, commandes SMTP, IMAP capabilities, tableau exhaustif des routes actix-web (auth/emails/hermes/calendar/external/admin), exemples curl.
- `docs/DATA-DICTIONARY.md` — 22 collections MongoDB avec type sérialisé, fichier source et ligne, structs Rust détaillés, index recommandés.
- `docs/SEQUENCE-DIAGRAMS.md` — 5 diagrammes Mermaid (SMTP entrant, SMTP sortant+DKIM, IMAP fetch, API GET /api/emails, Auth login+2FA+OAuth GitHub).

## À NE PAS MERGER
Autres contributeurs à review (GitOps strict).
