### PR TITLE
feat(sprint1): OpenAPI specs + tests d'intégration (6 flux critiques)

### DIFF
--- a/ops/openapi/admin-v1.yaml
+++ b/ops/openapi/admin-v1.yaml
@@ -1,0 +1,434 @@
+openapi: "3.1.0"
+info:
+  title: misfits.ai — Admin API
+  version: "1.0.0"
+  description: |
+    Admin CRUD for users, change requests, deliverability, and AI activity.
+    All endpoints require an admin session token when ADMIN_RBAC_ENFORCE=1.
+
+servers:
+  - url: https://api.misfits.ai
+
+tags:
+  - name: admin-users
+  - name: admin-change-requests
+  - name: admin-deliverability
+
+security:
+  - adminSession: []
+
+paths:
+  /api/admin/whoami:
+    get:
+      operationId: adminWhoami
+      tags: [admin-users]
+      summary: Return the authenticated admin user and RBAC enforcement status
+      responses:
+        "200":
+          description: Current admin identity
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  user_id:
+                    type: string
+                  email:
+                    type: string
+                  role:
+                    type: string
+                  enforced:
+                    type: boolean
+                    description: true when ADMIN_RBAC_ENFORCE=1
+
+  /api/admin/users:
+    get:
+      operationId: listAdminUsers
+      tags: [admin-users]
+      summary: List all admin panel users (up to 500, sorted by last activity)
+      responses:
+        "200":
+          description: User list
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  generatedAt:
+                    type: string
+                    format: date-time
+                  users:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/AdminUserRecord"
+    post:
+      operationId: createAdminUser
+      tags: [admin-users]
+      summary: Create a new admin panel user
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CreateAdminUserInput"
+      responses:
+        "200":
+          description: User created
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AdminUserRecord"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "409":
+          description: Email already exists
+
+  /api/admin/users/{id}:
+    get:
+      operationId: getAdminUser
+      tags: [admin-users]
+      parameters:
+        - $ref: "#/components/parameters/AdminUserId"
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  user:
+                    $ref: "#/components/schemas/AdminUserRecord"
+        "404":
+          $ref: "#/components/responses/NotFound"
+    patch:
+      operationId: patchAdminUser
+      tags: [admin-users]
+      summary: Update role or status of a user
+      parameters:
+        - $ref: "#/components/parameters/AdminUserId"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                role:
+                  type: string
+                  enum: [user, admin, support]
+                status:
+                  type: string
+                  enum: [active, inactive, suspended]
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AdminUserRecord"
+        "404":
+          $ref: "#/components/responses/NotFound"
+    delete:
+      operationId: deleteAdminUser
+      tags: [admin-users]
+      parameters:
+        - $ref: "#/components/parameters/AdminUserId"
+      responses:
+        "200":
+          description: User deleted
+        "404":
+          $ref: "#/components/responses/NotFound"
+
+  /api/admin/users/{id}/invite:
+    post:
+      operationId: inviteAdminUser
+      tags: [admin-users]
+      summary: Send invitation email to a user
+      parameters:
+        - $ref: "#/components/parameters/AdminUserId"
+      responses:
+        "200":
+          description: Invitation sent
+
+  /api/admin/users/{id}/reset-password:
+    post:
+      operationId: resetAdminUserPassword
+      tags: [admin-users]
+      summary: Trigger password reset for a user
+      parameters:
+        - $ref: "#/components/parameters/AdminUserId"
+      responses:
+        "200":
+          description: Reset triggered
+
+  /api/admin/change-requests:
+    get:
+      operationId: listChangeRequests
+      tags: [admin-change-requests]
+      summary: List all change requests
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  items:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/ChangeRequest"
+    post:
+      operationId: createChangeRequest
+      tags: [admin-change-requests]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ChangeRequestCreateInput"
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ChangeRequest"
+
+  /api/admin/change-requests/{id}:
+    get:
+      operationId: getChangeRequest
+      tags: [admin-change-requests]
+      parameters:
+        - $ref: "#/components/parameters/ChangeRequestId"
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ChangeRequest"
+        "404":
+          $ref: "#/components/responses/NotFound"
+    patch:
+      operationId: patchChangeRequest
+      tags: [admin-change-requests]
+      parameters:
+        - $ref: "#/components/parameters/ChangeRequestId"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ChangeRequestPatchInput"
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ChangeRequest"
+    delete:
+      operationId: deleteChangeRequest
+      tags: [admin-change-requests]
+      parameters:
+        - $ref: "#/components/parameters/ChangeRequestId"
+      responses:
+        "200":
+          description: Deleted
+
+  /api/admin/deliverability/procedure:
+    get:
+      operationId: getDeliverabilityProcedure
+      tags: [admin-deliverability]
+      summary: Get deliverability diagnostic procedure status
+      parameters:
+        - name: window
+          in: query
+          schema:
+            type: string
+            default: "1h"
+            description: Time window (e.g. 1h, 24h, 7d)
+      responses:
+        "200":
+          description: Procedure status
+    post:
+      operationId: updateDeliverabilityProcedure
+      tags: [admin-deliverability]
+      summary: Trigger or update a deliverability procedure
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+      responses:
+        "200":
+          description: Procedure updated
+
+  /api/admin/audit-log:
+    get:
+      operationId: getAuditLog
+      tags: [admin-users]
+      summary: Fetch admin audit log entries
+      parameters:
+        - name: limit
+          in: query
+          schema:
+            type: integer
+            default: 50
+        - name: offset
+          in: query
+          schema:
+            type: integer
+            default: 0
+      responses:
+        "200":
+          description: Audit log entries
+
+components:
+  securitySchemes:
+    adminSession:
+      type: http
+      scheme: bearer
+      description: Admin session token (from /api/auth/login response). Only enforced when ADMIN_RBAC_ENFORCE=1.
+
+  parameters:
+    AdminUserId:
+      name: id
+      in: path
+      required: true
+      schema:
+        type: string
+    ChangeRequestId:
+      name: id
+      in: path
+      required: true
+      schema:
+        type: string
+
+  responses:
+    BadRequest:
+      description: Validation error
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/MessageError"
+    NotFound:
+      description: Not found
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/MessageError"
+
+  schemas:
+    AdminUserRecord:
+      type: object
+      properties:
+        id:
+          type: string
+        email:
+          type: string
+        role:
+          type: string
+          enum: [user, admin, support]
+        status:
+          type: string
+          enum: [active, inactive, suspended]
+        displayName:
+          type: string
+        createdAt:
+          type: string
+          format: date-time
+        lastActivityAt:
+          type: string
+          format: date-time
+
+    CreateAdminUserInput:
+      type: object
+      required: [email, role]
+      properties:
+        email:
+          type: string
+          format: email
+        role:
+          type: string
+          enum: [user, admin, support]
+        displayName:
+          type: string
+
+    ChangeRequest:
+      type: object
+      properties:
+        id:
+          type: string
+        title:
+          type: string
+        problem:
+          type: string
+        desiredOutcome:
+          type: string
+        status:
+          type: string
+          enum: [draft, in_progress, review, released, rejected]
+        priority:
+          type: string
+          enum: [P0, P1, P2]
+        scope:
+          type: string
+          enum: [ux, backend, fullstack, security]
+        actor:
+          type: string
+        createdAt:
+          type: string
+          format: date-time
+        updatedAt:
+          type: string
+          format: date-time
+        changelogEntry:
+          type: object
+          properties:
+            summary:
+              type: string
+            releasedAt:
+              type: string
+              format: date-time
+
+    ChangeRequestCreateInput:
+      type: object
+      required: [title]
+      properties:
+        title:
+          type: string
+        problem:
+          type: string
+        desiredOutcome:
+          type: string
+        priority:
+          type: string
+          enum: [P0, P1, P2]
+        scope:
+          type: string
+          enum: [ux, backend, fullstack, security]
+
+    ChangeRequestPatchInput:
+      type: object
+      properties:
+        action:
+          type: string
+        note:
+          type: string
+        actor:
+          type: string
+        title:
+          type: string
+        problem:
+          type: string
+        desiredOutcome:
+          type: string
+        status:
+          type: string
+          enum: [draft, in_progress, review, released, rejected]
+
+    MessageError:
+      type: object
+      properties:
+        message:
+          type: string
+        code:
+          type: string

--- a/ops/openapi/auth-v1.yaml
+++ b/ops/openapi/auth-v1.yaml
@@ -1,0 +1,336 @@
+openapi: "3.1.0"
+info:
+  title: misfits.ai — Auth API
+  version: "1.0.0"
+  description: Authentication endpoints (login, register, logout, refresh, 2FA, password reset).
+
+servers:
+  - url: https://api.misfits.ai
+    description: Production
+
+tags:
+  - name: auth
+    description: Authentication flows
+
+paths:
+  /api/auth/login:
+    post:
+      operationId: authLogin
+      tags: [auth]
+      summary: Login with email + password
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/LoginRequest"
+      responses:
+        "200":
+          description: Login successful
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AuthResponse"
+        "401":
+          description: Invalid credentials
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/MessageError"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /api/auth/register:
+    post:
+      operationId: authRegister
+      tags: [auth]
+      summary: Register a new misfits.ai account
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/RegisterRequest"
+      responses:
+        "200":
+          description: Registration successful
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AuthResponse"
+        "400":
+          description: Validation error (conditions not accepted, password too short, etc.)
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CodeError"
+        "409":
+          description: Email already registered
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CodeError"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /api/auth/logout:
+    post:
+      operationId: authLogout
+      tags: [auth]
+      summary: Invalidate current session
+      security:
+        - sessionCookie: []
+      responses:
+        "200":
+          description: Logged out
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+
+  /api/auth/refresh:
+    post:
+      operationId: authRefresh
+      tags: [auth]
+      summary: Refresh access token using refresh token
+      security:
+        - sessionCookie: []
+      responses:
+        "200":
+          description: New session tokens
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AuthResponse"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+
+  /api/auth/2fa/verify:
+    post:
+      operationId: auth2faVerify
+      tags: [auth]
+      summary: Verify a 2FA code (TOTP or email OTP)
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/TwoFactorVerifyRequest"
+      responses:
+        "200":
+          description: 2FA verified, session returned
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AuthResponse"
+        "400":
+          description: TOTP not configured
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/VerifyError"
+        "401":
+          description: Invalid or expired code
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/VerifyError"
+
+  /api/auth/password-reset/request:
+    post:
+      operationId: passwordResetRequest
+      tags: [auth]
+      summary: Request a password reset email
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [email]
+              properties:
+                email:
+                  type: string
+                  format: email
+      responses:
+        "200":
+          description: Reset email sent (always 200 to avoid enumeration)
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+
+  /api/auth/password-reset/confirm:
+    post:
+      operationId: passwordResetConfirm
+      tags: [auth]
+      summary: Confirm password reset with token + new password
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [token, password]
+              properties:
+                token:
+                  type: string
+                password:
+                  type: string
+                  minLength: 8
+      responses:
+        "200":
+          description: Password updated
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+        "400":
+          description: Invalid token or weak password
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CodeError"
+
+components:
+  securitySchemes:
+    sessionCookie:
+      type: apiKey
+      in: cookie
+      name: mfa_session
+
+  responses:
+    Unauthorized:
+      description: Not authenticated
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/MessageError"
+    InternalError:
+      description: Server error
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/CodeError"
+
+  schemas:
+    LoginRequest:
+      type: object
+      required: [email, password]
+      properties:
+        email:
+          type: string
+          format: email
+        password:
+          type: string
+
+    RegisterRequest:
+      type: object
+      required: [email, password, first_name, last_name, condition_accepted]
+      properties:
+        email:
+          type: string
+          format: email
+        password:
+          type: string
+          minLength: 8
+        first_name:
+          type: string
+        last_name:
+          type: string
+        alias:
+          type: string
+          nullable: true
+        condition_accepted:
+          type: boolean
+
+    TwoFactorVerifyRequest:
+      type: object
+      required: [email, code, method]
+      properties:
+        email:
+          type: string
+          format: email
+        code:
+          type: string
+        method:
+          type: string
+          enum: [totp, email]
+
+    UserResponse:
+      type: object
+      properties:
+        id:
+          type: string
+        email:
+          type: string
+        display_name:
+          type: string
+        role:
+          type: string
+        two_factor_enabled:
+          type: boolean
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+
+    SessionResponse:
+      type: object
+      properties:
+        id:
+          type: string
+        user:
+          $ref: "#/components/schemas/UserResponse"
+        access_token:
+          type: string
+        refresh_token:
+          type: string
+        expires_at:
+          type: integer
+          description: Unix ms
+        refresh_expires_at:
+          type: integer
+          description: Unix ms
+        issued_at:
+          type: integer
+          description: Unix ms
+
+    AuthResponse:
+      type: object
+      properties:
+        session:
+          $ref: "#/components/schemas/SessionResponse"
+
+    MessageError:
+      type: object
+      properties:
+        message:
+          type: string
+
+    CodeError:
+      type: object
+      properties:
+        code:
+          type: string
+        message:
+          type: string
+
+    VerifyError:
+      type: object
+      properties:
+        verified:
+          type: boolean
+        error:
+          type: string

--- a/ops/openapi/mailbox-v1.yaml
+++ b/ops/openapi/mailbox-v1.yaml
@@ -1,0 +1,447 @@
+openapi: "3.1.0"
+info:
+  title: misfits.ai — Mailbox API
+  version: "1.0.0"
+  description: Email list, fetch, send, drafts, actions, and tags.
+
+servers:
+  - url: https://api.misfits.ai
+
+tags:
+  - name: mailbox
+  - name: send
+  - name: drafts
+
+paths:
+  /api/emails:
+    get:
+      operationId: listEmails
+      tags: [mailbox]
+      summary: List emails in a folder with pagination
+      parameters:
+        - name: folder
+          in: query
+          required: true
+          schema:
+            type: string
+            enum: [inbox, sent, drafts, archive, trash, spam]
+        - name: page
+          in: query
+          schema:
+            type: integer
+            default: 1
+        - name: page_size
+          in: query
+          schema:
+            type: integer
+            default: 20
+            maximum: 100
+        - name: q
+          in: query
+          description: Search query
+          schema:
+            type: string
+        - name: filter
+          in: query
+          schema:
+            type: string
+            enum: [all, unread, starred, attachments]
+      security:
+        - userHeaders: []
+      responses:
+        "200":
+          description: Paginated email list
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/EmailListResponse"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+
+  /api/emails/{id}:
+    get:
+      operationId: getEmail
+      tags: [mailbox]
+      summary: Get a single email by ID
+      parameters:
+        - $ref: "#/components/parameters/EmailId"
+      security:
+        - userHeaders: []
+      responses:
+        "200":
+          description: Email detail
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/EmailDetail"
+        "404":
+          $ref: "#/components/responses/NotFound"
+
+  /api/emails/{id}/action:
+    post:
+      operationId: emailAction
+      tags: [mailbox]
+      summary: Perform an action on an email (read, star, move, delete, etc.)
+      parameters:
+        - $ref: "#/components/parameters/EmailId"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/EmailActionRequest"
+      security:
+        - userHeaders: []
+      responses:
+        "200":
+          description: Action applied
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+        "400":
+          $ref: "#/components/responses/BadRequest"
+
+  /api/send:
+    post:
+      operationId: sendEmail
+      tags: [send]
+      summary: Compose and send an email (DKIM-signed via studious-octo-rotary-phone)
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ComposeSendRequest"
+      security:
+        - userHeaders: []
+      responses:
+        "200":
+          description: Send result
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SendResult"
+        "400":
+          description: Missing recipients or invalid request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SendError"
+        "500":
+          description: DKIM signing or SMTP delivery failed
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SendError"
+
+  /api/send/undo/{id}:
+    post:
+      operationId: undoSend
+      tags: [send]
+      summary: Abort a scheduled send within the undo window
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      security:
+        - userHeaders: []
+      responses:
+        "200":
+          description: Send undone
+        "404":
+          $ref: "#/components/responses/NotFound"
+
+  /api/drafts:
+    get:
+      operationId: listDrafts
+      tags: [drafts]
+      summary: List drafts for current user
+      security:
+        - userHeaders: []
+      responses:
+        "200":
+          description: Draft list
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  drafts:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/DraftDto"
+    put:
+      operationId: upsertDraft
+      tags: [drafts]
+      summary: Create or update a draft
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/DraftUpsertRequest"
+      security:
+        - userHeaders: []
+      responses:
+        "200":
+          description: Draft saved
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/DraftDto"
+
+  /api/drafts/{id}:
+    delete:
+      operationId: deleteDraft
+      tags: [drafts]
+      summary: Delete a draft by ID
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      security:
+        - userHeaders: []
+      responses:
+        "200":
+          description: Draft deleted
+        "404":
+          $ref: "#/components/responses/NotFound"
+
+components:
+  securitySchemes:
+    userHeaders:
+      type: apiKey
+      in: header
+      name: x-user-id
+      description: User identity header set by the frontend session
+
+  parameters:
+    EmailId:
+      name: id
+      in: path
+      required: true
+      schema:
+        type: string
+
+  responses:
+    Unauthorized:
+      description: Not authenticated
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/MessageError"
+    NotFound:
+      description: Resource not found
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/MessageError"
+    BadRequest:
+      description: Validation error
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/MessageError"
+
+  schemas:
+    EmailAddress:
+      type: object
+      required: [address]
+      properties:
+        name:
+          type: string
+        address:
+          type: string
+          format: email
+
+    EmailDto:
+      type: object
+      properties:
+        id:
+          type: string
+        threadId:
+          type: string
+        folder:
+          type: string
+        from:
+          $ref: "#/components/schemas/EmailAddress"
+        to:
+          type: array
+          items:
+            $ref: "#/components/schemas/EmailAddress"
+        subject:
+          type: string
+        preview:
+          type: string
+        date:
+          type: string
+          format: date-time
+        isRead:
+          type: boolean
+        isStarred:
+          type: boolean
+        isImportant:
+          type: boolean
+        hasAttachments:
+          type: boolean
+        labels:
+          type: array
+          items:
+            type: string
+
+    EmailDetail:
+      allOf:
+        - $ref: "#/components/schemas/EmailDto"
+        - type: object
+          properties:
+            body:
+              type: string
+            bodyType:
+              type: string
+              enum: [html, text]
+            cc:
+              type: array
+              items:
+                $ref: "#/components/schemas/EmailAddress"
+            attachments:
+              type: array
+              items:
+                type: object
+
+    EmailListResponse:
+      type: object
+      properties:
+        emails:
+          type: array
+          items:
+            $ref: "#/components/schemas/EmailDto"
+        total:
+          type: integer
+        page:
+          type: integer
+        pageSize:
+          type: integer
+        hasMore:
+          type: boolean
+
+    EmailActionRequest:
+      type: object
+      required: [action]
+      properties:
+        action:
+          type: string
+          enum: [read, unread, star, unstar, important, unimportant, move, delete, archive, restore]
+        folder:
+          type: string
+          description: Target folder for move action
+
+    ComposeSendRequest:
+      type: object
+      required: [to, subject, body]
+      properties:
+        from:
+          type: string
+          format: email
+        to:
+          type: array
+          items:
+            type: string
+            format: email
+        cc:
+          type: array
+          items:
+            type: string
+        bcc:
+          type: array
+          items:
+            type: string
+        subject:
+          type: string
+        body:
+          type: string
+        bodyType:
+          type: string
+          enum: [html, text]
+          default: html
+        inReplyTo:
+          type: string
+        scheduledAt:
+          type: string
+          format: date-time
+          description: If set, send is delayed until this time
+
+    SendResult:
+      type: object
+      properties:
+        sent:
+          type: boolean
+        messageId:
+          type: string
+        sendId:
+          type: string
+          description: ID for undo window tracking
+
+    SendError:
+      type: object
+      properties:
+        sent:
+          type: boolean
+          example: false
+        message:
+          type: string
+
+    DraftDto:
+      type: object
+      properties:
+        id:
+          type: string
+        userId:
+          type: string
+        to:
+          type: array
+          items:
+            type: string
+        cc:
+          type: array
+          items:
+            type: string
+        subject:
+          type: string
+        body:
+          type: string
+        updatedAt:
+          type: string
+          format: date-time
+
+    DraftUpsertRequest:
+      type: object
+      properties:
+        id:
+          type: string
+          description: Omit to create a new draft
+        to:
+          type: array
+          items:
+            type: string
+        cc:
+          type: array
+          items:
+            type: string
+        subject:
+          type: string
+        body:
+          type: string
+
+    MessageError:
+      type: object
+      properties:
+        message:
+          type: string

--- a/ops/openapi/monitoring-v1.yaml
+++ b/ops/openapi/monitoring-v1.yaml
@@ -1,0 +1,252 @@
+openapi: "3.1.0"
+info:
+  title: misfits.ai — Monitoring API
+  version: "1.0.0"
+  description: Email delivery monitoring — summary, events, bounces, providers, alerts.
+
+servers:
+  - url: https://api.misfits.ai
+
+tags:
+  - name: monitoring
+
+paths:
+  /api/monitoring/summary:
+    get:
+      operationId: monitoringSummary
+      tags: [monitoring]
+      summary: Delivery summary stats for a time window
+      parameters:
+        - name: window
+          in: query
+          schema:
+            type: string
+            default: "1h"
+            description: e.g. 1h, 24h, 7d
+      responses:
+        "200":
+          description: Delivery metrics
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/MonitoringSummary"
+
+  /api/monitoring/events:
+    get:
+      operationId: monitoringEvents
+      tags: [monitoring]
+      summary: List recent mail events (paginated)
+      parameters:
+        - name: window
+          in: query
+          schema:
+            type: string
+            default: "1h"
+        - name: status
+          in: query
+          schema:
+            type: string
+        - name: page
+          in: query
+          schema:
+            type: integer
+            default: 1
+        - name: page_size
+          in: query
+          schema:
+            type: integer
+            default: 20
+      responses:
+        "200":
+          description: Event list
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  events:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/MailEvent"
+                  total:
+                    type: integer
+
+  /api/monitoring/bounces:
+    get:
+      operationId: monitoringBounces
+      tags: [monitoring]
+      summary: Recent bounce events
+      parameters:
+        - name: window
+          in: query
+          schema:
+            type: string
+            default: "24h"
+        - name: limit
+          in: query
+          schema:
+            type: integer
+            default: 50
+      responses:
+        "200":
+          description: Bounce list
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  bounces:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/MailEvent"
+
+  /api/monitoring/providers/top:
+    get:
+      operationId: monitoringProvidersTop
+      tags: [monitoring]
+      summary: Top recipient providers by volume
+      parameters:
+        - name: window
+          in: query
+          schema:
+            type: string
+            default: "24h"
+        - name: limit
+          in: query
+          schema:
+            type: integer
+            default: 10
+      responses:
+        "200":
+          description: Provider stats
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  providers:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/ProviderStat"
+
+  /api/monitoring/alerts/active:
+    get:
+      operationId: monitoringAlertsActive
+      tags: [monitoring]
+      summary: Active monitoring alerts
+      responses:
+        "200":
+          description: Alert list
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  alerts:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/MonitoringAlert"
+
+  /api/monitoring/live:
+    get:
+      operationId: monitoringLive
+      tags: [monitoring]
+      summary: Live delivery stats (last N minutes rolling)
+      parameters:
+        - name: minutes
+          in: query
+          schema:
+            type: integer
+            default: 60
+      responses:
+        "200":
+          description: Rolling stats
+
+components:
+  schemas:
+    MonitoringSummary:
+      type: object
+      properties:
+        window:
+          type: string
+        generatedAt:
+          type: string
+          format: date-time
+        total:
+          type: integer
+        delivered:
+          type: integer
+        bounced:
+          type: integer
+        deliveryRate:
+          type: number
+          format: float
+        bounceRate:
+          type: number
+          format: float
+        avgTotalMs:
+          type: number
+        p95TotalMs:
+          type: number
+        avgRiskScore:
+          type: number
+        byStatus:
+          type: object
+          additionalProperties:
+            type: integer
+
+    MailEvent:
+      type: object
+      properties:
+        id:
+          type: string
+        ts:
+          type: string
+          format: date-time
+        status:
+          type: string
+          enum: [delivered, bounced, deferred, failed, queued]
+        from:
+          type: string
+        to:
+          type: string
+        subject:
+          type: string
+        provider:
+          type: string
+        total_ms:
+          type: integer
+        risk_score:
+          type: number
+        error:
+          type: string
+
+    ProviderStat:
+      type: object
+      properties:
+        provider:
+          type: string
+        count:
+          type: integer
+        delivered:
+          type: integer
+        bounced:
+          type: integer
+        deliveryRate:
+          type: number
+
+    MonitoringAlert:
+      type: object
+      properties:
+        id:
+          type: string
+        level:
+          type: string
+          enum: [info, warning, critical]
+        message:
+          type: string
+        triggeredAt:
+          type: string
+          format: date-time
+        resolved:
+          type: boolean

--- a/src/bin/email_api.rs
+++ b/src/bin/email_api.rs
@@ -7504,7 +7504,267 @@ mod tests {
             "http://172.16.12.2:8642"
         );
     }
-}
+
+    // ─── Sprint 1: Integration tests on critical flows ────────────────────────
+    //
+    // These tests exercise the HTTP handler shape (status codes, response
+    // structure) without a live MongoDB or SMTP server. They verify:
+    //  - Correct 4xx on bad / missing input
+    //  - Response JSON shape on valid input (where the handler does not
+    //    require a DB connection at the validation stage)
+    //
+    // Flow 1: POST /api/auth/login — rejects empty password
+    #[actix_web::test]
+    async fn test_auth_login_rejects_empty_password() {
+        let app = test::init_service(
+            App::new()
+                .app_data(
+                    web::JsonConfig::default()
+                        .error_handler(|err, req| {
+                            let resp = actix_web::HttpResponse::BadRequest()
+                                .json(serde_json::json!({ "code": "INVALID_JSON", "message": err.to_string() }));
+                            actix_web::error::InternalError::from_response(err, resp).into()
+                        })
+                )
+                .route("/api/auth/login", web::post().to(auth_login)),
+        )
+        .await;
+
+        // Missing password field → JSON parse error → 400
+        let req = test::TestRequest::post()
+            .uri("/api/auth/login")
+            .set_json(serde_json::json!({ "email": "test@misfits.ai" }))
+            .to_request();
+        let resp = test::call_service(&app, req).await;
+        assert_eq!(resp.status(), actix_web::http::StatusCode::BAD_REQUEST);
+    }
+
+    // Flow 1b: POST /api/auth/login — correct shape → 200 or 401 (never 500)
+    #[actix_web::test]
+    async fn test_auth_login_valid_shape_returns_200_or_401() {
+        dotenv::from_filename(".env.test").ok();
+        use std::sync::Arc;
+        let mongo_url = std::env::var("MONGODB_URI").unwrap_or_else(|_| "mongodb://localhost:27017".to_string());
+        let mongo = match mongodb::Client::with_uri_str(&mongo_url).await {
+            Ok(c) => Arc::new(c),
+            Err(_) => return, // Skip if no test DB
+        };
+        let logic = web::Data::new(Arc::new(Logic::new(mongo.clone())));
+        let mongo_data = web::Data::new(mongo);
+        let bus_data = web::Data::new(EventBus::new());
+
+        let app = test::init_service(
+            App::new()
+                .app_data(logic)
+                .app_data(mongo_data)
+                .app_data(bus_data)
+                .route("/api/auth/login", web::post().to(auth_login)),
+        )
+        .await;
+
+        let req = test::TestRequest::post()
+            .uri("/api/auth/login")
+            .set_json(serde_json::json!({
+                "email": "nonexistent@misfits.ai",
+                "password": "wrongpassword"
+            }))
+            .to_request();
+        let resp = test::call_service(&app, req).await;
+        let status = resp.status().as_u16();
+        assert!(
+            status == 200 || status == 401,
+            "Expected 200 or 401, got {}",
+            status
+        );
+    }
+
+    // Flow 2: POST /api/auth/2fa/verify — rejects missing fields
+    #[actix_web::test]
+    async fn test_2fa_verify_rejects_missing_fields() {
+        let app = test::init_service(
+            App::new()
+                .app_data(
+                    web::JsonConfig::default().error_handler(|err, _req| {
+                        let resp = actix_web::HttpResponse::BadRequest()
+                            .json(serde_json::json!({ "verified": false, "error": err.to_string() }));
+                        actix_web::error::InternalError::from_response(err, resp).into()
+                    })
+                )
+                .route("/api/auth/2fa/verify", web::post().to(api_2fa_verify)),
+        )
+        .await;
+
+        // Missing code → 400
+        let req = test::TestRequest::post()
+            .uri("/api/auth/2fa/verify")
+            .set_json(serde_json::json!({ "email": "test@misfits.ai", "method": "email" }))
+            .to_request();
+        let resp = test::call_service(&app, req).await;
+        assert_eq!(resp.status(), actix_web::http::StatusCode::BAD_REQUEST);
+    }
+
+    // Flow 3: GET /api/emails — rejects request with no user identity (empty folder)
+    #[actix_web::test]
+    async fn test_api_emails_empty_folder_returns_empty_list() {
+        dotenv::from_filename(".env.test").ok();
+        use std::sync::Arc;
+        let mongo_url = std::env::var("MONGODB_URI").unwrap_or_else(|_| "mongodb://localhost:27017".to_string());
+        let mongo = match mongodb::Client::with_uri_str(&mongo_url).await {
+            Ok(c) => Arc::new(c),
+            Err(_) => return,
+        };
+        let logic = web::Data::new(Arc::new(Logic::new(mongo.clone())));
+
+        let app = test::init_service(
+            App::new()
+                .app_data(logic)
+                .route("/api/emails", web::get().to(api_emails)),
+        )
+        .await;
+
+        // No x-user-id header → resolve_user_id returns empty string → returns empty list
+        let req = test::TestRequest::get()
+            .uri("/api/emails?folder=inbox&page=1&page_size=5")
+            .to_request();
+        let resp = test::call_service(&app, req).await;
+        // Handler always returns 200 (empty list for unknown user)
+        assert_eq!(resp.status(), actix_web::http::StatusCode::OK);
+        let body: serde_json::Value = test::read_body_json(resp).await;
+        assert!(body["emails"].is_array(), "Expected emails array");
+    }
+
+    // Flow 4: POST /api/send — rejects missing recipients
+    #[actix_web::test]
+    async fn test_api_send_rejects_empty_recipients() {
+        dotenv::from_filename(".env.test").ok();
+        use std::sync::Arc;
+        let mongo_url = std::env::var("MONGODB_URI").unwrap_or_else(|_| "mongodb://localhost:27017".to_string());
+        let mongo = match mongodb::Client::with_uri_str(&mongo_url).await {
+            Ok(c) => Arc::new(c),
+            Err(_) => return,
+        };
+        let logic = web::Data::new(Arc::new(Logic::new(mongo.clone())));
+        let mongo_data = web::Data::new(mongo);
+        let bus_data = web::Data::new(EventBus::new());
+
+        let app = test::init_service(
+            App::new()
+                .app_data(logic)
+                .app_data(mongo_data)
+                .app_data(bus_data)
+                .route("/api/send", web::post().to(api_send)),
+        )
+        .await;
+
+        let req = test::TestRequest::post()
+            .uri("/api/send")
+            .set_json(serde_json::json!({
+                "to": [],
+                "subject": "Test",
+                "body": "Hello"
+            }))
+            .to_request();
+        let resp = test::call_service(&app, req).await;
+        assert_eq!(resp.status(), actix_web::http::StatusCode::BAD_REQUEST);
+        let body: serde_json::Value = test::read_body_json(resp).await;
+        assert_eq!(body["sent"], false);
+        assert!(body["message"].is_string());
+    }
+
+    // Flow 5: GET /api/monitoring/summary — returns required fields
+    #[actix_web::test]
+    async fn test_monitoring_summary_shape() {
+        dotenv::from_filename(".env.test").ok();
+        use std::sync::Arc;
+        let mongo_url = std::env::var("MONGODB_URI").unwrap_or_else(|_| "mongodb://localhost:27017".to_string());
+        let mongo = match mongodb::Client::with_uri_str(&mongo_url).await {
+            Ok(c) => Arc::new(c),
+            Err(_) => return,
+        };
+        let mongo_data = web::Data::new(mongo);
+
+        let app = test::init_service(
+            App::new()
+                .app_data(mongo_data)
+                .route("/api/monitoring/summary", web::get().to(api_monitoring_summary)),
+        )
+        .await;
+
+        let req = test::TestRequest::get()
+            .uri("/api/monitoring/summary?window=1h")
+            .to_request();
+        let resp = test::call_service(&app, req).await;
+        assert_eq!(resp.status(), actix_web::http::StatusCode::OK);
+        let body: serde_json::Value = test::read_body_json(resp).await;
+        // Shape assertions: all required fields present
+        assert!(body["total"].is_number(), "Expected total field");
+        assert!(body["deliveryRate"].is_number(), "Expected deliveryRate field");
+        assert!(body["bounceRate"].is_number(), "Expected bounceRate field");
+        assert!(body["byStatus"].is_object(), "Expected byStatus object");
+    }
+
+    // Flow 6: GET /api/admin/users — returns 200 with users array (RBAC flag off)
+    #[actix_web::test]
+    async fn test_admin_users_list_shape() {
+        dotenv::from_filename(".env.test").ok();
+        use std::sync::Arc;
+        let mongo_url = std::env::var("MONGODB_URI").unwrap_or_else(|_| "mongodb://localhost:27017".to_string());
+        let mongo = match mongodb::Client::with_uri_str(&mongo_url).await {
+            Ok(c) => Arc::new(c),
+            Err(_) => return,
+        };
+        let mongo_data = web::Data::new(mongo);
+
+        let app = test::init_service(
+            App::new()
+                .app_data(mongo_data)
+                .route("/api/admin/users", web::get().to(api_admin_users_list)),
+        )
+        .await;
+
+        let req = test::TestRequest::get()
+            .uri("/api/admin/users")
+            .to_request();
+        let resp = test::call_service(&app, req).await;
+        assert_eq!(resp.status(), actix_web::http::StatusCode::OK);
+        let body: serde_json::Value = test::read_body_json(resp).await;
+        assert!(body["users"].is_array(), "Expected users array");
+        assert!(body["generatedAt"].is_string(), "Expected generatedAt");
+    }
+
+    // Flow 6b: GET /api/admin/whoami — returns enforced flag
+    #[actix_web::test]
+    async fn test_admin_whoami_returns_enforced_flag() {
+        dotenv::from_filename(".env.test").ok();
+        use std::sync::Arc;
+        let mongo_url = std::env::var("MONGODB_URI").unwrap_or_else(|_| "mongodb://localhost:27017".to_string());
+        let mongo = match mongodb::Client::with_uri_str(&mongo_url).await {
+            Ok(c) => Arc::new(c),
+            Err(_) => return,
+        };
+        let mongo_data = web::Data::new(mongo);
+
+        let app = test::init_service(
+            App::new()
+                .app_data(mongo_data)
+                .route("/api/admin/whoami", web::get().to(api_admin_whoami)),
+        )
+        .await;
+
+        let req = test::TestRequest::get()
+            .uri("/api/admin/whoami")
+            .insert_header(("Authorization", "Bearer test-token"))
+            .to_request();
+        let resp = test::call_service(&app, req).await;
+        // Either 200 (flag off, system user) or 401 (flag on, token unknown)
+        let status = resp.status().as_u16();
+        assert!(
+            status == 200 || status == 401,
+            "Expected 200 or 401, got {}",
+            status
+        );
+    }
+} // end mod tests
 
 #[async_trait::async_trait]
 pub trait DkimService: Send + Sync {


### PR DESCRIPTION
## Sprint 1 — OpenAPI + Tests

### OpenAPI specs (ops/openapi/)

| Fichier | Endpoints |
|---|---|
| `auth-v1.yaml` | login, register, logout, refresh, 2FA/verify, password-reset |
| `mailbox-v1.yaml` | GET/emails, GET/emails/{id}, email action, POST/send, drafts |
| `admin-v1.yaml` | users CRUD, change-requests CRUD, deliverability, audit-log |
| `monitoring-v1.yaml` | summary, events, bounces, providers/top, alerts, live |

Ces specs complètent `external-imap-v1.yaml` existant — couverture complète de l'API.

### Tests d'intégration (src/bin/email_api.rs)

8 nouveaux tests ajoutés au module `tests` existant:

| Test | Flux | Type |
|---|---|---|
| `test_auth_login_rejects_empty_password` | Flow 1 | Shape validation |
| `test_auth_login_valid_shape_returns_200_or_401` | Flow 1b | Status code |
| `test_2fa_verify_rejects_missing_fields` | Flow 2 | Shape validation |
| `test_api_emails_empty_folder_returns_empty_list` | Flow 3 | Response shape |
| `test_api_send_rejects_empty_recipients` | Flow 4 | Business rule |
| `test_monitoring_summary_shape` | Flow 5 | Response fields |
| `test_admin_users_list_shape` | Flow 6 | Response shape |
| `test_admin_whoami_returns_enforced_flag` | Flow 6b | RBAC status |

**Stratégie**: tests sans DB requis skip gracieusement (`return;` sur connexion échouée). Tests de shape ne nécessitent pas de données.

### Validation CI
```
cargo test --bin email_api 2>&1 | grep -E 'test.*ok|FAILED|error'
```