### PR TITLE
fix(deploy): expose ADMIN_RBAC_ENFORCE + ADMIN_INVITE_* to email-api

### DIFF
--- a/docker-compose.deploy.yml
+++ b/docker-compose.deploy.yml
@@ -84,6 +84,12 @@ services:
       - HERMES_API_KEY=${HERMES_API_KEY}
       - HERMES_BASE_URL=${HERMES_BASE_URL:-http://172.16.12.2:8642}
       - HERMES_MODEL=${HERMES_MODEL:-hermes-agent}
+      # RBAC admin — activé via .env.deploy (source: op://hermes/scw-hermes-smtp/texte).
+      # Défaut vide → guard renvoie AuthUser::system(). "1"/"true" → RBAC réel.
+      - ADMIN_RBAC_ENFORCE=${ADMIN_RBAC_ENFORCE:-}
+      - ADMIN_INVITE_TTL_HOURS=${ADMIN_INVITE_TTL_HOURS:-}
+      - ADMIN_INVITE_BASE_URL=${ADMIN_INVITE_BASE_URL:-}
+      - ADMIN_INVITE_FROM=${ADMIN_INVITE_FROM:-}
     command: ["email_api"]
     # Image HEALTHCHECK probes :8025 (SMTP). Override for API binary.
     # wget --spider treats some 2xx oddly; use full GET + HTTP code check.


### PR DESCRIPTION
L'opérateur a activé ADMIN_RBAC_ENFORCE=1 dans .env.deploy mais le container email-api ne reçoit toujours pas la variable → whoami répond enforced:false. Cette PR ajoute les mappings manquants côté docker-compose.deploy.yml (même pattern que #242).

Aucun changement de code Rust.