### PR TITLE
fix(inbox-list): keep headers to decode multipart previews

### DIFF
--- a/src/logic/mod.rs
+++ b/src/logic/mod.rs
@@ -415,8 +415,6 @@ impl Logic {
                 .sort(doc! { "internal_date": -1 })
                 .skip(skip)
                 .limit(limit.max(1).min(200))
-                // Omit very large SMTP header blobs when listing (Email.headers is #[serde(default)])
-                .projection(doc! { "headers": 0 })
                 .await?;
             cursor.try_collect().await
         }


### PR DESCRIPTION
## Summary
- include `headers` in inbox list query results
- required by MIME decoder used in `email_to_list_dto`

## Why
Detail view was formatted correctly, but list preview still showed MIME boundary fragments for some messages because headers were projected out in list fetch path.
