### PR TITLE
refactor(hex): boucle 7 — 5 méthodes admin mailbox migrent via port

### DIFF
--- a/src/logic/mailbox_impl.rs
+++ b/src/logic/mailbox_impl.rs
@@ -180,64 +180,11 @@ impl Logic {
     }
 
     pub async fn create_mailbox(&self, username: &str, mailbox: &str) -> Result<()> {
-        #[cfg(not(test))]
-        {
-            let database_name =
-                std::env::var("MONGODB_DATABASE").expect("MONGODB_DATABASE must be set");
-            let collection = self
-                .client
-                .database(&database_name)
-                .collection::<Mailbox>("mailboxes");
-
-            // Vérifiez si la boîte aux lettres existe déjà
-            let mailbox_filter = doc! { "name": mailbox, "user_id": username };
-            if collection.find_one(mailbox_filter.clone()).await?.is_none() {
-                println!("Creating mailbox: {}", mailbox);
-                let new_mailbox = Mailbox {
-                    name: mailbox.to_string(),
-                    flags: vec![],
-                    exists: 0,
-                    recent: 0,
-                    unseen: 0,
-                    permanent_flags: vec![String::from("\\*")],
-                    uid_validity: 1,
-                    uid_next: 1,
-                    user_id: username.to_string(),
-                };
-                collection.insert_one(new_mailbox).await?;
-                println!("Mailbox created: {}", mailbox);
-            } else {
-                println!("Mailbox already exists: {}", mailbox);
-            }
-            Ok(())
-        }
-        #[cfg(test)]
-        {
-            // Pour les tests, nous devons retourner un résultat vide
-            Ok(())
-        }
+        self.repo.create_mailbox_for_user(username, mailbox).await
     }
 
     pub async fn delete_mailbox(&self, username: &str, mailbox: &str) -> Result<()> {
-        #[cfg(not(test))]
-        {
-            let database_name =
-                std::env::var("MONGODB_DATABASE").expect("MONGODB_DATABASE must be set");
-            let collection = self
-                .client
-                .database(&database_name)
-                .collection::<Mailbox>("mailboxes");
-
-            let filter = doc! { "user_id": username, "name": mailbox };
-            collection.delete_one(filter).await?;
-
-            Ok(())
-        }
-        #[cfg(test)]
-        {
-            //For test, we need to return an empty result
-            Ok(())
-        }
+        self.repo.delete_mailbox_for_user(username, mailbox).await
     }
 
     pub async fn rename_mailbox(
@@ -246,69 +193,15 @@ impl Logic {
         old_name: &str,
         new_name: &str,
     ) -> Result<()> {
-        #[cfg(not(test))]
-        {
-            let database_name =
-                std::env::var("MONGODB_DATABASE").expect("MONGODB_DATABASE must be set");
-            let collection = self
-                .client
-                .database(&database_name)
-                .collection::<Mailbox>("mailboxes");
-
-            let filter = doc! { "user_id": username, "name": old_name };
-            let update = doc! { "$set": { "name": new_name } };
-            collection.update_one(filter, update).await?;
-            Ok(())
-        }
-        #[cfg(test)]
-        {
-            //For test, we need to return an empty result
-            Ok(())
-        }
+        self.repo.rename_mailbox_for_user(username, old_name, new_name).await
     }
 
     pub async fn subscribe_mailbox(&self, username: &str, mailbox: &str) -> Result<()> {
-        #[cfg(not(test))]
-        {
-            let database_name =
-                std::env::var("MONGODB_DATABASE").expect("MONGODB_DATABASE must be set");
-            let collection = self
-                .client
-                .database(&database_name)
-                .collection::<User>("subscriptions");
-
-            let filter = doc! { "user_id": username, "mailbox": mailbox };
-            let update = doc! { "$set": { "subscribed": true } };
-            collection.update_one(filter, update).await?;
-            Ok(())
-        }
-        #[cfg(test)]
-        {
-            //For test, we need to return an empty result
-            Ok(())
-        }
+        self.repo.subscribe_mailbox_for_user(username, mailbox).await
     }
 
     pub async fn unsubscribe_mailbox(&self, username: &str, mailbox: &str) -> Result<()> {
-        #[cfg(not(test))]
-        {
-            let database_name =
-                std::env::var("MONGODB_DATABASE").expect("MONGODB_DATABASE must be set");
-            let collection = self
-                .client
-                .database(&database_name)
-                .collection::<User>("subscriptions");
-
-            let filter = doc! { "user_id": username, "mailbox": mailbox };
-            let update = doc! { "$set": { "subscribed": false } };
-            collection.update_one(filter, update).await?;
-            Ok(())
-        }
-        #[cfg(test)]
-        {
-            //For test, we need to return an empty result
-            Ok(())
-        }
+        self.repo.unsubscribe_mailbox_for_user(username, mailbox).await
     }
 
     pub async fn list_subscribed_mailboxes(

--- a/src/logic/mod.rs
+++ b/src/logic/mod.rs
@@ -429,6 +429,18 @@ pub trait DatabaseInterface: Send + Sync {
         email_id: &str,
         target_mailbox: &str,
     ) -> Result<bool>;
+
+    // Boucle 7 — extensions user-scopées pour l'administration des mailboxes.
+    async fn create_mailbox_for_user(&self, username: &str, mailbox: &str) -> Result<()>;
+    async fn delete_mailbox_for_user(&self, username: &str, mailbox: &str) -> Result<()>;
+    async fn rename_mailbox_for_user(
+        &self,
+        username: &str,
+        old_name: &str,
+        new_name: &str,
+    ) -> Result<()>;
+    async fn subscribe_mailbox_for_user(&self, username: &str, mailbox: &str) -> Result<()>;
+    async fn unsubscribe_mailbox_for_user(&self, username: &str, mailbox: &str) -> Result<()>;
 }
 
 #[async_trait::async_trait]

--- a/src/logic/mongo_adapter.rs
+++ b/src/logic/mongo_adapter.rs
@@ -418,6 +418,83 @@ impl DatabaseInterface for MongoDatabaseAdapter {
         let res = collection.update_one(filter, update).await?;
         Ok(res.matched_count > 0)
     }
+
+    // Boucle 7 — 5 méthodes admin mailbox migrées (user-scopées).
+    async fn create_mailbox_for_user(&self, username: &str, mailbox: &str) -> Result<()> {
+        let db_name = Self::database_name();
+        let collection = self
+            .client
+            .database(&db_name)
+            .collection::<Mailbox>("mailboxes");
+        let filter = doc! { "name": mailbox, "user_id": username };
+        if collection.find_one(filter.clone()).await?.is_none() {
+            let new_mailbox = Mailbox {
+                name: mailbox.to_string(),
+                flags: vec![],
+                exists: 0,
+                recent: 0,
+                unseen: 0,
+                permanent_flags: vec![String::from("\\*")],
+                uid_validity: 1,
+                uid_next: 1,
+                user_id: username.to_string(),
+            };
+            collection.insert_one(new_mailbox).await?;
+        }
+        Ok(())
+    }
+
+    async fn delete_mailbox_for_user(&self, username: &str, mailbox: &str) -> Result<()> {
+        let db_name = Self::database_name();
+        let collection = self
+            .client
+            .database(&db_name)
+            .collection::<Mailbox>("mailboxes");
+        let filter = doc! { "user_id": username, "name": mailbox };
+        collection.delete_one(filter).await?;
+        Ok(())
+    }
+
+    async fn rename_mailbox_for_user(
+        &self,
+        username: &str,
+        old_name: &str,
+        new_name: &str,
+    ) -> Result<()> {
+        let db_name = Self::database_name();
+        let collection = self
+            .client
+            .database(&db_name)
+            .collection::<Mailbox>("mailboxes");
+        let filter = doc! { "user_id": username, "name": old_name };
+        let update = doc! { "$set": { "name": new_name } };
+        collection.update_one(filter, update).await?;
+        Ok(())
+    }
+
+    async fn subscribe_mailbox_for_user(&self, username: &str, mailbox: &str) -> Result<()> {
+        let db_name = Self::database_name();
+        let collection = self
+            .client
+            .database(&db_name)
+            .collection::<mongodb::bson::Document>("subscriptions");
+        let filter = doc! { "user_id": username, "mailbox": mailbox };
+        let update = doc! { "$set": { "subscribed": true } };
+        collection.update_one(filter, update).upsert(true).await?;
+        Ok(())
+    }
+
+    async fn unsubscribe_mailbox_for_user(&self, username: &str, mailbox: &str) -> Result<()> {
+        let db_name = Self::database_name();
+        let collection = self
+            .client
+            .database(&db_name)
+            .collection::<mongodb::bson::Document>("subscriptions");
+        let filter = doc! { "user_id": username, "mailbox": mailbox };
+        let update = doc! { "$set": { "subscribed": false } };
+        collection.update_one(filter, update).upsert(true).await?;
+        Ok(())
+    }
 }
 
 // Silencer l'import inutilisé de bson::Document si non exploité (le use ci-dessus


### PR DESCRIPTION
## Boucle 7 — Hex Rust batch mailbox

Suite de la migration hexagonale : 5 méthodes admin mailbox de Logic → port DatabaseInterface.

### Trait étendu
- create_mailbox_for_user
- delete_mailbox_for_user
- rename_mailbox_for_user
- subscribe_mailbox_for_user (avec upsert)
- unsubscribe_mailbox_for_user (avec upsert)

### Métriques
- mailbox_impl.rs : 425 → 318 LOC
- Blocs #[cfg(not(test))] : 14 → 9
- Méthodes via port : 11 → 16 / ~35 (~50%)

### Décisions
- Suffixe `_for_user` pour distinguer les méthodes user-scopées des méthodes du trait sans username (héritées, non appelées par Logic)
- Subscriptions passent en `Document` + `upsert(true)` (l'ancien code faisait update sans insert, semi-cassé)

### Vérifs
- CI: attendre Compile & Check