### PR TITLE
refactor(hex): boucle 8 — unification prod/test + select_mailbox via port

### DIFF
--- a/src/logic/email_impl.rs
+++ b/src/logic/email_impl.rs
@@ -27,16 +27,8 @@ impl Logic {
     }
 
     pub async fn store_email_flag(&self, username: &str, email_id: &str, flag: &str) -> Result<()> {
-        // Boucle 4 — port hexagonal : délègue au repo.
         let _ = username;
-        #[cfg(not(test))]
-        {
-            self.repo.update_email_flag(email_id, flag).await
-        }
-        #[cfg(test)]
-        {
-            self.client.update_email_flag(email_id, flag).await
-        }
+        self.repo.update_email_flag(email_id, flag).await
     }
 
     pub async fn move_email_to_mailbox(
@@ -73,28 +65,12 @@ impl Logic {
     }
 
     pub async fn delete_email(&self, username: &str, email_id: &str) -> Result<()> {
-        // Boucle 4 — port hexagonal : délègue au repo.
         let _ = username;
-        #[cfg(not(test))]
-        {
-            self.repo.delete_email(email_id).await
-        }
-        #[cfg(test)]
-        {
-            self.client.delete_email(email_id).await
-        }
+        self.repo.delete_email(email_id).await
     }
 
     pub async fn archive_email(&self, username: &str, email_id: &str) -> Result<()> {
-        // Boucle 4 — port hexagonal : délègue au repo.
         let _ = username;
-        #[cfg(not(test))]
-        {
-            self.repo.archive_email(email_id).await
-        }
-        #[cfg(test)]
-        {
-            self.client.archive_email(email_id).await
-        }
+        self.repo.archive_email(email_id).await
     }
 }

--- a/src/logic/mailbox_impl.rs
+++ b/src/logic/mailbox_impl.rs
@@ -6,39 +6,7 @@ use super::*;
 impl Logic {
 
     pub async fn select_mailbox(&self, username: &str, mailbox: &str) -> Result<Mailbox> {
-        #[cfg(not(test))]
-        {
-            let database_name =
-                std::env::var("MONGODB_DATABASE").expect("MONGODB_DATABASE must be set");
-            let collection = self
-                .client
-                .database(&database_name)
-                .collection::<Mailbox>("mailboxes");
-
-            let filter = doc! { "user_id": username, "name": mailbox };
-            if let Some(mailbox) = collection.find_one(filter).await? {
-                Ok(mailbox)
-            } else {
-                Err(Error::from(std::io::Error::new(
-                    std::io::ErrorKind::NotFound,
-                    "Mailbox not found",
-                )))
-            }
-        }
-        #[cfg(test)]
-        {
-            Ok(Mailbox {
-                name: mailbox.to_string(),
-                flags: vec![],
-                exists: 10,
-                recent: 2,
-                unseen: 5,
-                permanent_flags: vec![],
-                uid_validity: 1,
-                uid_next: 11,
-                user_id: username.to_string(),
-            })
-        }
+        self.repo.select_mailbox_for_user(username, mailbox).await
     }
 
     pub async fn search_messages(&self, username: &str, criteria: &str) -> Result<Vec<u32>> {
@@ -269,15 +237,7 @@ impl Logic {
     }
 
     pub async fn store_email(&self, username: &str, mailbox: &str, email: &Email) -> Result<()> {
-        // Boucle 4 — port hexagonal : délègue au repo.
-        #[cfg(not(test))]
-        {
-            self.repo.store_email(username, mailbox, email).await
-        }
-        #[cfg(test)]
-        {
-            self.client.store_email(username, mailbox, email).await
-        }
+        self.repo.store_email(username, mailbox, email).await
     }
 
     pub async fn list_mailboxes(

--- a/src/logic/mod.rs
+++ b/src/logic/mod.rs
@@ -441,6 +441,9 @@ pub trait DatabaseInterface: Send + Sync {
     ) -> Result<()>;
     async fn subscribe_mailbox_for_user(&self, username: &str, mailbox: &str) -> Result<()>;
     async fn unsubscribe_mailbox_for_user(&self, username: &str, mailbox: &str) -> Result<()>;
+
+    // Boucle 8 — sélection mailbox user-scopée.
+    async fn select_mailbox_for_user(&self, username: &str, mailbox: &str) -> Result<Mailbox>;
 }
 
 #[async_trait::async_trait]

--- a/src/logic/mongo_adapter.rs
+++ b/src/logic/mongo_adapter.rs
@@ -495,6 +495,24 @@ impl DatabaseInterface for MongoDatabaseAdapter {
         collection.update_one(filter, update).upsert(true).await?;
         Ok(())
     }
+
+    // Boucle 8 — select_mailbox user-scopé.
+    async fn select_mailbox_for_user(&self, username: &str, mailbox: &str) -> Result<Mailbox> {
+        let db_name = Self::database_name();
+        let collection = self
+            .client
+            .database(&db_name)
+            .collection::<Mailbox>("mailboxes");
+        let filter = doc! { "user_id": username, "name": mailbox };
+        if let Some(mb) = collection.find_one(filter).await? {
+            Ok(mb)
+        } else {
+            Err(mongodb::error::Error::from(std::io::Error::new(
+                std::io::ErrorKind::NotFound,
+                "Mailbox not found",
+            )))
+        }
+    }
 }
 
 // Silencer l'import inutilisé de bson::Document si non exploité (le use ci-dessus


### PR DESCRIPTION
## Boucle 8 — Cleanup + select_mailbox

### Cleanup: 4 méthodes unifiées (retrait du split cfg)
- email_impl: store_email_flag / delete_email / archive_email
- mailbox_impl: store_email

Elles utilisaient `#[cfg(not(test))] self.repo.X vs #[cfg(test)] self.client.X`.
Le split était un vestige pré-mockall. Maintenant que le port est mocké,
le bloc test est redondant. Simplification = gain net de lisibilité.

### Migration: select_mailbox
- Nouveau trait method `select_mailbox_for_user(username, mailbox)`
- Impl Mongo réelle
- Logic::select_mailbox devient one-liner

### Métriques
- email_impl.rs: 100 → 76 LOC
- mailbox_impl.rs: 318 → 278 LOC
- Blocs #[cfg(not(test))] totaux: 29 → 24
- Méthodes via port: 16 → 17 (~48%)