### PR TITLE
refactor(hex): boucle 9 — 5 méthodes calendar migrent via port

### DIFF
--- a/src/logic/calendar_impl.rs
+++ b/src/logic/calendar_impl.rs
@@ -1,26 +1,11 @@
 // calendar_impl.rs — split from logic/mod.rs (Sprint 11)
-// Extends impl Logic with a subset of methods.
+// Boucle 9: méthodes calendar migrent via port DatabaseInterface.
 #![allow(unused_imports)]
 use super::*;
 
 impl Logic {
-
     pub async fn create_calendar_event(&self, event: &CalendarEvent) -> Result<()> {
-        #[cfg(not(test))]
-        {
-            let database_name =
-                std::env::var("MONGODB_DATABASE").expect("MONGODB_DATABASE must be set");
-            let collection = self
-                .client
-                .database(&database_name)
-                .collection::<CalendarEvent>("calendar_events");
-            collection.insert_one(event.clone()).await?;
-            Ok(())
-        }
-        #[cfg(test)]
-        {
-            Ok(())
-        }
+        self.repo.create_calendar_event(event).await
     }
 
     pub async fn get_calendar_events(
@@ -29,36 +14,9 @@ impl Logic {
         start_after: Option<bson::DateTime>,
         start_before: Option<bson::DateTime>,
     ) -> Result<Vec<CalendarEvent>> {
-        #[cfg(not(test))]
-        {
-            let database_name =
-                std::env::var("MONGODB_DATABASE").expect("MONGODB_DATABASE must be set");
-            let collection = self
-                .client
-                .database(&database_name)
-                .collection::<CalendarEvent>("calendar_events");
-
-            let mut filter = doc! { "user_id": username };
-            if let Some(after) = start_after {
-                filter.insert("start", doc! { "$gte": after });
-            }
-            if let Some(before) = start_before {
-                if filter.contains_key("start") {
-                    if let Ok(start_doc) = filter.get_document_mut("start") {
-                        start_doc.insert("$lte", before);
-                    }
-                } else {
-                    filter.insert("start", doc! { "$lte": before });
-                }
-            }
-
-            let cursor = collection.find(filter).await?;
-            cursor.try_collect().await
-        }
-        #[cfg(test)]
-        {
-            Ok(vec![])
-        }
+        self.repo
+            .get_calendar_events(username, start_after, start_before)
+            .await
     }
 
     pub async fn get_calendar_event(
@@ -66,21 +24,7 @@ impl Logic {
         username: &str,
         event_id: &str,
     ) -> Result<Option<CalendarEvent>> {
-        #[cfg(not(test))]
-        {
-            let database_name =
-                std::env::var("MONGODB_DATABASE").expect("MONGODB_DATABASE must be set");
-            let collection = self
-                .client
-                .database(&database_name)
-                .collection::<CalendarEvent>("calendar_events");
-            let filter = doc! { "user_id": username, "id": event_id };
-            collection.find_one(filter).await
-        }
-        #[cfg(test)]
-        {
-            Ok(None)
-        }
+        self.repo.get_calendar_event(username, event_id).await
     }
 
     pub async fn update_calendar_event(
@@ -89,49 +33,12 @@ impl Logic {
         event_id: &str,
         update_doc: bson::Document,
     ) -> Result<Option<CalendarEvent>> {
-        #[cfg(not(test))]
-        {
-            let database_name =
-                std::env::var("MONGODB_DATABASE").expect("MONGODB_DATABASE must be set");
-            let collection = self
-                .client
-                .database(&database_name)
-                .collection::<CalendarEvent>("calendar_events");
-            let filter = doc! { "user_id": username, "id": event_id };
-
-            let mut update = update_doc;
-            update.insert(
-                "updated_at",
-                bson::DateTime::from_millis(chrono::Utc::now().timestamp_millis()),
-            );
-
-            collection
-                .update_one(filter.clone(), doc! { "$set": update })
-                .await?;
-            collection.find_one(filter).await
-        }
-        #[cfg(test)]
-        {
-            Ok(None)
-        }
+        self.repo
+            .update_calendar_event(username, event_id, update_doc)
+            .await
     }
 
     pub async fn delete_calendar_event(&self, username: &str, event_id: &str) -> Result<()> {
-        #[cfg(not(test))]
-        {
-            let database_name =
-                std::env::var("MONGODB_DATABASE").expect("MONGODB_DATABASE must be set");
-            let collection = self
-                .client
-                .database(&database_name)
-                .collection::<CalendarEvent>("calendar_events");
-            let filter = doc! { "user_id": username, "id": event_id };
-            collection.delete_one(filter).await?;
-            Ok(())
-        }
-        #[cfg(test)]
-        {
-            Ok(())
-        }
+        self.repo.delete_calendar_event(username, event_id).await
     }
 }

--- a/src/logic/mod.rs
+++ b/src/logic/mod.rs
@@ -444,6 +444,27 @@ pub trait DatabaseInterface: Send + Sync {
 
     // Boucle 8 — sélection mailbox user-scopée.
     async fn select_mailbox_for_user(&self, username: &str, mailbox: &str) -> Result<Mailbox>;
+
+    // Boucle 9 — calendar via port.
+    async fn create_calendar_event(&self, event: &CalendarEvent) -> Result<()>;
+    async fn get_calendar_events(
+        &self,
+        username: &str,
+        start_after: Option<bson::DateTime>,
+        start_before: Option<bson::DateTime>,
+    ) -> Result<Vec<CalendarEvent>>;
+    async fn get_calendar_event(
+        &self,
+        username: &str,
+        event_id: &str,
+    ) -> Result<Option<CalendarEvent>>;
+    async fn update_calendar_event(
+        &self,
+        username: &str,
+        event_id: &str,
+        update_doc: bson::Document,
+    ) -> Result<Option<CalendarEvent>>;
+    async fn delete_calendar_event(&self, username: &str, event_id: &str) -> Result<()>;
 }
 
 #[async_trait::async_trait]

--- a/src/logic/mongo_adapter.rs
+++ b/src/logic/mongo_adapter.rs
@@ -13,7 +13,7 @@
 // avec un commentaire `TODO(hex)` — migrations progressives dans les sprints
 // suivants.
 
-use crate::entities::Email;
+use crate::entities::{CalendarEvent, Email};
 use crate::logic::{DatabaseInterface, Mailbox, User};
 use async_trait::async_trait;
 use futures_util::TryStreamExt;

--- a/src/logic/mongo_adapter.rs
+++ b/src/logic/mongo_adapter.rs
@@ -513,6 +513,93 @@ impl DatabaseInterface for MongoDatabaseAdapter {
             )))
         }
     }
+
+    // Boucle 9 — calendar events.
+    async fn create_calendar_event(&self, event: &CalendarEvent) -> Result<()> {
+        let db_name = Self::database_name();
+        let collection = self
+            .client
+            .database(&db_name)
+            .collection::<CalendarEvent>("calendar_events");
+        collection.insert_one(event.clone()).await?;
+        Ok(())
+    }
+
+    async fn get_calendar_events(
+        &self,
+        username: &str,
+        start_after: Option<bson::DateTime>,
+        start_before: Option<bson::DateTime>,
+    ) -> Result<Vec<CalendarEvent>> {
+        let db_name = Self::database_name();
+        let collection = self
+            .client
+            .database(&db_name)
+            .collection::<CalendarEvent>("calendar_events");
+        let mut filter = doc! { "user_id": username };
+        if let Some(after) = start_after {
+            filter.insert("start", doc! { "$gte": after });
+        }
+        if let Some(before) = start_before {
+            if filter.contains_key("start") {
+                if let Ok(start_doc) = filter.get_document_mut("start") {
+                    start_doc.insert("$lte", before);
+                }
+            } else {
+                filter.insert("start", doc! { "$lte": before });
+            }
+        }
+        let cursor = collection.find(filter).await?;
+        cursor.try_collect().await
+    }
+
+    async fn get_calendar_event(
+        &self,
+        username: &str,
+        event_id: &str,
+    ) -> Result<Option<CalendarEvent>> {
+        let db_name = Self::database_name();
+        let collection = self
+            .client
+            .database(&db_name)
+            .collection::<CalendarEvent>("calendar_events");
+        let filter = doc! { "user_id": username, "id": event_id };
+        collection.find_one(filter).await
+    }
+
+    async fn update_calendar_event(
+        &self,
+        username: &str,
+        event_id: &str,
+        update_doc: bson::Document,
+    ) -> Result<Option<CalendarEvent>> {
+        let db_name = Self::database_name();
+        let collection = self
+            .client
+            .database(&db_name)
+            .collection::<CalendarEvent>("calendar_events");
+        let filter = doc! { "user_id": username, "id": event_id };
+        let mut update = update_doc;
+        update.insert(
+            "updated_at",
+            bson::DateTime::from_millis(chrono::Utc::now().timestamp_millis()),
+        );
+        collection
+            .update_one(filter.clone(), doc! { "$set": update })
+            .await?;
+        collection.find_one(filter).await
+    }
+
+    async fn delete_calendar_event(&self, username: &str, event_id: &str) -> Result<()> {
+        let db_name = Self::database_name();
+        let collection = self
+            .client
+            .database(&db_name)
+            .collection::<CalendarEvent>("calendar_events");
+        let filter = doc! { "user_id": username, "id": event_id };
+        collection.delete_one(filter).await?;
+        Ok(())
+    }
 }
 
 // Silencer l'import inutilisé de bson::Document si non exploité (le use ci-dessus


### PR DESCRIPTION
5 méthodes calendar de Logic → DatabaseInterface. Pattern éprouvé Boucle 6/7. calendar_impl.rs: 137 → 46 LOC.