### PR TITLE
refactor(smtp): décompose process_command en 5 handlers dédiés (clean code)

### DIFF
--- a/src/bin/smtp_server.rs
+++ b/src/bin/smtp_server.rs
@@ -693,7 +693,58 @@ async fn handle_plain_client(
     Ok(())
 }
 
-// Process SMTP commands
+// Réponse EHLO/HELO — construit la liste de capabilities selon l'état TLS.
+fn handle_helo(is_tls: bool, require_starttls: bool) -> String {
+    let mut caps = vec!["250-mail.misfits.ai Hello".to_string()];
+    if !is_tls {
+        caps.push("250-STARTTLS".to_string());
+    }
+    if is_tls || !require_starttls {
+        caps.push("250-AUTH LOGIN PLAIN".to_string());
+    }
+    caps.push("250 OK".to_string());
+    format!("{}\r\n", caps.join("\r\n"))
+}
+
+// Réponse QUIT — extrait le contenu si un message est en cours, puis "221 Bye".
+fn handle_quit(email: &CustomEmail) -> String {
+    if !email.email.from.is_empty() && !email.email.to.is_empty() {
+        match extract_email_content(&email.email.body) {
+            Ok(content) => println!("Extracted email content: {}", content),
+            Err(e) => eprintln!("Error extracting email content: {}", e),
+        }
+    }
+    "221 Bye\r\n".to_string()
+}
+
+// Réponse RSET — reset le buffer d'email en cours.
+fn handle_rset(email: &mut CustomEmail) -> String {
+    *email = CustomEmail {
+        email: Email::new("", "", "", "", ""),
+        raw_content: String::new(),
+        dkim_signature: None,
+    };
+    "250 OK\r\n".to_string()
+}
+
+// Réponse STARTTLS — 220 si on est encore en Plain, 454 si déjà en TLS.
+fn handle_starttls(stream: &StreamType) -> String {
+    match stream {
+        StreamType::Plain(_) => "220 Ready to start TLS\r\n".to_string(),
+        StreamType::Tls(_) => "454 TLS not available due to temporary reason\r\n".to_string(),
+    }
+}
+
+// Garde-fou "530 Must issue a STARTTLS command first" sur les verbes qui l'exigent.
+fn require_tls_or_530(require_starttls: bool, is_tls: bool) -> Option<String> {
+    if require_starttls && !is_tls {
+        Some("530 Must issue a STARTTLS command first\r\n".to_string())
+    } else {
+        None
+    }
+}
+
+// Process SMTP commands — dispatch vers les handlers dédiés par verbe.
 async fn process_command(
     command: &str,
     email: &mut CustomEmail,
@@ -701,9 +752,6 @@ async fn process_command(
     logic: Arc<Logic>,
     session_manager: Arc<SessionManager>,
 ) -> std::io::Result<String> {
-    // Implement your SMTP command processing logic here
-    // This is a basic example and should be expanded based on your needs
-
     let trimmed = command.trim();
     let upper = trimmed.to_ascii_uppercase();
     println!("In process_command with: {}", upper.as_str());
@@ -713,25 +761,17 @@ async fn process_command(
 
     match upper.as_str() {
         s if s.starts_with("HELO") || s.starts_with("EHLO") => {
-            let mut caps = vec!["250-mail.misfits.ai Hello".to_string()];
-            if !is_tls {
-                caps.push("250-STARTTLS".to_string());
-            }
-            if is_tls || !require_starttls {
-                caps.push("250-AUTH LOGIN PLAIN".to_string());
-            }
-            caps.push("250 OK".to_string());
-            Ok(format!("{}\r\n", caps.join("\r\n")))
+            Ok(handle_helo(is_tls, require_starttls))
         }
         s if s.starts_with("AUTH LOGIN") => {
-            if require_starttls && !is_tls {
-                return Ok("530 Must issue a STARTTLS command first\r\n".to_string());
+            if let Some(err) = require_tls_or_530(require_starttls, is_tls) {
+                return Ok(err);
             }
             handle_auth_login(stream, logic.clone(), session_manager.clone()).await
         }
         s if s.starts_with("AUTH PLAIN") => {
-            if require_starttls && !is_tls {
-                return Ok("530 Must issue a STARTTLS command first\r\n".to_string());
+            if let Some(err) = require_tls_or_530(require_starttls, is_tls) {
+                return Ok(err);
             }
             handle_auth_plain(trimmed, session_manager.clone()).await
         }
@@ -749,47 +789,17 @@ async fn process_command(
         }
         "DATA" => Ok("354 Start mail input; end with <CRLF>.<CRLF>\r\n".to_string()),
         "." => Ok("250 OK\r\n".to_string()),
-        "QUIT" => {
-            if !email.email.from.is_empty() && !email.email.to.is_empty() {
-                match extract_email_content(&email.email.body) {
-                    Ok(content) => {
-                        println!("Extracted email content: {}", content);
-                    }
-                    Err(e) => eprintln!("Error extracting email content: {}", e),
-                }
-            }
-            Ok("221 Bye\r\n".to_string())
-        }
-        "RSET" => {
-            *email = CustomEmail {
-                email: Email::new("", "", "", "", ""),
-                raw_content: String::new(),
-                dkim_signature: None,
-            };
-            // Reset the email using new() instead of default()
-            Ok("250 OK\r\n".to_string())
-        }
+        "QUIT" => Ok(handle_quit(email)),
+        "RSET" => Ok(handle_rset(email)),
         "NOOP" => Ok("250 OK\r\n".to_string()),
-        s if s.starts_with("VRFY") => {
-            // In a real implementation, you'd verify the email address here
-            Ok(
-                "252 Cannot VRFY user, but will accept message and attempt delivery\r\n"
-                    .to_string(),
-            )
-        }
-        s if s.starts_with("AUTH") => {
-            if require_starttls && !is_tls {
-                Ok("530 Must issue a STARTTLS command first\r\n".to_string())
-            } else {
-                Ok("235 Authentication successful\r\n".to_string())
-            }
-        }
-        s if s.starts_with("STARTTLS") => match stream {
-            StreamType::Plain(_) => Ok("220 Ready to start TLS\r\n".to_string()),
-            StreamType::Tls(_) => {
-                Ok("454 TLS not available due to temporary reason\r\n".to_string())
-            }
-        },
+        s if s.starts_with("VRFY") => Ok(
+            "252 Cannot VRFY user, but will accept message and attempt delivery\r\n".to_string(),
+        ),
+        s if s.starts_with("AUTH") => Ok(match require_tls_or_530(require_starttls, is_tls) {
+            Some(err) => err,
+            None => "235 Authentication successful\r\n".to_string(),
+        }),
+        s if s.starts_with("STARTTLS") => Ok(handle_starttls(stream)),
         _ => Ok("500 Syntax error, command unrecognized\r\n".to_string()),
     }
 }


### PR DESCRIPTION
process_command 100 → 57 LOC. Extraits: handle_helo, handle_quit, handle_rset, handle_starttls, require_tls_or_530. Chaque helper est une fn pure. Élimine duplication de la garde STARTTLS.