### PR TITLE
fix(docker): copier crates/ dans stage builder (débloquer CI master)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,9 @@ USER default_user
 # This layer is cached unless Cargo.toml changes, so subsequent builds
 # only recompile the application crate (seconds), not 445 dependencies (minutes).
 COPY --chown=default_user:default_user Cargo.toml Cargo.lock* ./
+# Workspace members must be readable even in the dummy layer, otherwise
+# `cargo build` fails with "failed to load manifest for dependency simple-smtp-domain".
+COPY --chown=default_user:default_user crates/ ./crates/
 
 # Create dummy src so cargo can resolve the crate
 RUN mkdir -p src/bin && \


### PR DESCRIPTION
## Contexte

Pipeline CI/CD **rouge sur master depuis 5 runs consécutifs** (job `Build & Push SMTP image`).

## Cause

Introduction du workspace hexagonal (`crates/domain`) sans mise à jour du Dockerfile :

```
error: failed to load manifest for workspace member '/app/.'
Caused by: failed to load manifest for dependency 'simple-smtp-domain'
Caused by: failed to read '/app/crates/domain/Cargo.toml'
Caused by: No such file or directory (os error 2)
```

Le Dockerfile copie `Cargo.toml` qui référence `crates/domain` mais ne copie pas le dossier `crates/`.

## Fix

Ajouter `COPY crates/ ./crates/` juste après le `COPY Cargo.toml`, avant `cargo build` du stage cache. Le cache Docker reste efficace : `crates/` change rarement.

## Vérification

- Compile & Check reste vert (pas de changement Rust)
- Build & Push doit passer (fix direct de la cause)
- Deploy peut enfin dérouler