### PR TITLE
refactor(cycle6): splitter smtp_server.rs (689→378 LOC)

### DIFF
--- a/src/bin/smtp_server.rs
+++ b/src/bin/smtp_server.rs
@@ -145,10 +145,19 @@ mod tls_helpers;
 mod auth_helpers;
 #[path = "smtp_server_dir/session.rs"]
 mod session_handlers;
+#[path = "smtp_server_dir/headers.rs"]
+mod headers_helpers;
+#[path = "smtp_server_dir/commands.rs"]
+mod commands_helpers;
 use recipient_helpers::{recipient_domain, is_local_recipient, recipient_local_part};
 use tls_helpers::{load_certs, load_key};
-use auth_helpers::check_credentials;
+use auth_helpers::{check_credentials, handle_auth_login, handle_auth_plain};
 use session_handlers::{handle_plain_client, handle_tls_client};
+use headers_helpers::{
+    apply_parsed_header, extract_email_content, extract_session_id_from_response,
+    parse_header_line, parse_message_id_header,
+};
+use commands_helpers::process_command;
 
 fn env_bool(key: &str, default: bool) -> bool {
     match env::var(key) {
@@ -158,91 +167,6 @@ fn env_bool(key: &str, default: bool) -> bool {
                 || (!matches!(v.as_str(), "0" | "false" | "no" | "off") && default)
         }
         Err(_) => default,
-    }
-}
-
-fn extract_session_id_from_response(response: &str) -> Option<String> {
-    let marker = "session ID:";
-    let idx = response.find(marker)?;
-    let sid = response[idx + marker.len()..]
-        .trim()
-        .trim_end_matches('\r')
-        .trim_end_matches('\n')
-        .to_string();
-    if sid.is_empty() {
-        None
-    } else {
-        Some(sid)
-    }
-}
-
-fn parse_header_line(raw_line: &str) -> Option<(String, String)> {
-    let (name, value) = raw_line.split_once(':')?;
-    let name = name.trim();
-    if name.is_empty() {
-        return None;
-    }
-    Some((name.to_string(), value.trim().to_string()))
-}
-
-fn parse_message_id_header(value: &str) -> Option<String> {
-    let value = value
-        .trim_matches(|c| c == '<' || c == '>')
-        .trim();
-
-    if value.is_empty() {
-        None
-    } else {
-        Some(value.to_string())
-    }
-}
-
-fn apply_parsed_header(current_email: &mut CustomEmail, raw_line: &str) {
-    if raw_line.starts_with(' ') || raw_line.starts_with('\t') {
-        if let Some((last_name, last_value)) = current_email.email.headers.last_mut() {
-            let continuation = raw_line.trim();
-            if !continuation.is_empty() {
-                if !last_value.is_empty() {
-                    last_value.push(' ');
-                }
-                last_value.push_str(continuation);
-
-                if last_name.eq_ignore_ascii_case("DKIM-Signature") {
-                    current_email.dkim_signature = Some(last_value.clone());
-                } else if last_name.eq_ignore_ascii_case("Subject") {
-                    current_email.email.subject = last_value.clone();
-                } else if last_name.eq_ignore_ascii_case("Message-ID") {
-                    if let Some(mid) = parse_message_id_header(last_value) {
-                        current_email.email.id = mid;
-                    }
-                }
-            }
-        }
-        return;
-    }
-
-    if let Some((name, value)) = parse_header_line(raw_line) {
-        current_email
-            .email
-            .headers
-            .push((name.clone(), value.clone()));
-
-        if name.eq_ignore_ascii_case("DKIM-Signature") {
-            current_email.dkim_signature = Some(value.clone());
-        } else if name.eq_ignore_ascii_case("From") {
-            let canonical = format!("From: {}", value);
-            current_email.email.from =
-                extract_email_address(&canonical, "From:").unwrap_or_default();
-        } else if name.eq_ignore_ascii_case("To") {
-            let canonical = format!("To: {}", value);
-            current_email.email.to = extract_email_address(&canonical, "To:").unwrap_or_default();
-        } else if name.eq_ignore_ascii_case("Subject") {
-            current_email.email.subject = value;
-        } else if name.eq_ignore_ascii_case("Message-ID") {
-            if let Some(mid) = parse_message_id_header(&value) {
-                current_email.email.id = mid;
-            }
-        }
     }
 }
 
@@ -281,181 +205,6 @@ impl MailServer {
 
 
 
-// Réponse EHLO/HELO — construit la liste de capabilities selon l'état TLS.
-fn handle_helo(is_tls: bool, require_starttls: bool) -> String {
-    let mut caps = vec!["250-mail.misfits.ai Hello".to_string()];
-    if !is_tls {
-        caps.push("250-STARTTLS".to_string());
-    }
-    if is_tls || !require_starttls {
-        caps.push("250-AUTH LOGIN PLAIN".to_string());
-    }
-    caps.push("250 OK".to_string());
-    format!("{}\r\n", caps.join("\r\n"))
-}
-
-// Réponse QUIT — extrait le contenu si un message est en cours, puis "221 Bye".
-fn handle_quit(email: &CustomEmail) -> String {
-    if !email.email.from.is_empty() && !email.email.to.is_empty() {
-        match extract_email_content(&email.email.body) {
-            Ok(content) => println!("Extracted email content: {}", content),
-            Err(e) => eprintln!("Error extracting email content: {}", e),
-        }
-    }
-    "221 Bye\r\n".to_string()
-}
-
-// Réponse RSET — reset le buffer d'email en cours.
-fn handle_rset(email: &mut CustomEmail) -> String {
-    *email = CustomEmail {
-        email: Email::new("", "", "", "", ""),
-        raw_content: String::new(),
-        dkim_signature: None,
-    };
-    "250 OK\r\n".to_string()
-}
-
-// Réponse STARTTLS — 220 si on est encore en Plain, 454 si déjà en TLS.
-fn handle_starttls(stream: &StreamType) -> String {
-    match stream {
-        StreamType::Plain(_) => "220 Ready to start TLS\r\n".to_string(),
-        StreamType::Tls(_) => "454 TLS not available due to temporary reason\r\n".to_string(),
-    }
-}
-
-// Garde-fou "530 Must issue a STARTTLS command first" sur les verbes qui l'exigent.
-fn require_tls_or_530(require_starttls: bool, is_tls: bool) -> Option<String> {
-    if require_starttls && !is_tls {
-        Some("530 Must issue a STARTTLS command first\r\n".to_string())
-    } else {
-        None
-    }
-}
-
-// Process SMTP commands — dispatch vers les handlers dédiés par verbe.
-async fn process_command(
-    command: &str,
-    email: &mut CustomEmail,
-    stream: &mut StreamType,
-    logic: Arc<Logic>,
-    session_manager: Arc<SessionManager>,
-) -> std::io::Result<String> {
-    let trimmed = command.trim();
-    let upper = trimmed.to_ascii_uppercase();
-    println!("In process_command with: {}", upper.as_str());
-
-    let require_starttls = env_bool("SMTP_REQUIRE_STARTTLS", true);
-    let is_tls = stream.is_tls();
-
-    match upper.as_str() {
-        s if s.starts_with("HELO") || s.starts_with("EHLO") => {
-            Ok(handle_helo(is_tls, require_starttls))
-        }
-        s if s.starts_with("AUTH LOGIN") => {
-            if let Some(err) = require_tls_or_530(require_starttls, is_tls) {
-                return Ok(err);
-            }
-            handle_auth_login(stream, logic.clone(), session_manager.clone()).await
-        }
-        s if s.starts_with("AUTH PLAIN") => {
-            if let Some(err) = require_tls_or_530(require_starttls, is_tls) {
-                return Ok(err);
-            }
-            handle_auth_plain(trimmed, session_manager.clone()).await
-        }
-        s if s.starts_with("MAIL FROM:") => {
-            email.email.from = trimmed[10..].trim().to_string();
-            Ok("250 OK\r\n".to_string())
-        }
-        s if s.starts_with("RCPT TO:") => {
-            email.email.to = trimmed[8..].trim().to_string();
-            Ok("250 OK\r\n".to_string())
-        }
-        s if s.starts_with("SUBJECT:") => {
-            email.email.subject = s[8..].trim().to_string();
-            Ok("250 OK\r\n".to_string())
-        }
-        "DATA" => Ok("354 Start mail input; end with <CRLF>.<CRLF>\r\n".to_string()),
-        "." => Ok("250 OK\r\n".to_string()),
-        "QUIT" => Ok(handle_quit(email)),
-        "RSET" => Ok(handle_rset(email)),
-        "NOOP" => Ok("250 OK\r\n".to_string()),
-        s if s.starts_with("VRFY") => Ok(
-            "252 Cannot VRFY user, but will accept message and attempt delivery\r\n".to_string(),
-        ),
-        s if s.starts_with("AUTH") => Ok(match require_tls_or_530(require_starttls, is_tls) {
-            Some(err) => err,
-            None => "235 Authentication successful\r\n".to_string(),
-        }),
-        s if s.starts_with("STARTTLS") => Ok(handle_starttls(stream)),
-        _ => Ok("500 Syntax error, command unrecognized\r\n".to_string()),
-    }
-}
-
-// Handle AUTH LOGIN command
-async fn handle_auth_login(
-    stream: &mut StreamType,
-    logic: Arc<Logic>,
-    session_manager: Arc<SessionManager>,
-) -> std::io::Result<String> {
-    write_response(stream, "334 VXNlcm5hbWU6\r\n").await?; // Base64 pour "Username:"
-    let mut username = String::new();
-    stream.read_line(&mut username).await?;
-    let username = username.trim_end().as_bytes().to_vec();
-    debug!("Received username: {}", String::from_utf8_lossy(&username));
-
-    write_response(stream, "334 UGFzc3dvcmQ6\r\n").await?; // Base64 for "Password:"
-    let mut password = String::new();
-    stream.read_line(&mut password).await?;
-    let password = password.trim_end().as_bytes().to_vec();
-    debug!("Received password: {}", String::from_utf8_lossy(&password));
-
-    let username = String::from_utf8_lossy(&username).to_string();
-    let password = String::from_utf8_lossy(&password).to_string();
-
-    match logic.authenticate_user(&username, &password).await {
-        Ok(Some(user)) => {
-            let session_id = session_manager.create_session(&username);
-            session_manager.set_mailbox(&session_id, &user.mailbox);
-            Ok(format!(
-                "235 Authentication successful, session ID: {}\r\n",
-                session_id
-            ))
-        }
-        Ok(None) => Ok("535 Authentication failed\r\n".to_string()),
-        Err(_) => Ok("535 Authentication failed\r\n".to_string()),
-    }
-}
-
-// Handle AUTH PLAIN command
-async fn handle_auth_plain(
-    command: &str,
-    session_manager: Arc<SessionManager>,
-) -> std::io::Result<String> {
-    let auth_data = command.split_whitespace().nth(2).unwrap_or("");
-    let decoded = general_purpose::STANDARD.decode(auth_data).unwrap();
-    let parts: Vec<&[u8]> = decoded.split(|&b| b == 0).collect();
-
-    if parts.len() != 3 {
-        return Ok("501 Malformed AUTH PLAIN\r\n".to_string());
-    }
-
-    let username = parts[1];
-    let password = parts[2];
-
-    if check_credentials(username, password) {
-        let username_str = String::from_utf8_lossy(username).to_string();
-        let session_id = session_manager.create_session(&username_str);
-        // FE + API use lowercase folder ids (issue #167)
-        session_manager.set_mailbox(&session_id, "inbox");
-        Ok(format!(
-            "235 Authentication successful, session ID: {}\r\n",
-            session_id
-        ))
-    } else {
-        Ok("535 Authentication failed\r\n".to_string())
-    }
-}
 
 // Write a response to the client
 async fn write_response(stream: &mut StreamType, response: &str) -> std::io::Result<()> {
@@ -627,63 +376,3 @@ struct CustomEmail {
     dkim_signature: Option<String>,
 }
 
-// Function to extract email content
-fn extract_email_content(email_content: &str) -> Result<String, Box<dyn std::error::Error>> {
-    let parsed = parse_mail(email_content.as_bytes())?;
-
-    // Try to get the plain text part first
-    if let Some(plain_text) = parsed
-        .subparts
-        .iter()
-        .find(|part| part.ctype.mimetype == "text/plain")
-    {
-        return Ok(plain_text.get_body()?.trim().to_string());
-    }
-
-    // If no plain text, try to get the HTML part and strip HTML tags
-    if let Some(html) = parsed
-        .subparts
-        .iter()
-        .find(|part| part.ctype.mimetype == "text/html")
-    {
-        let html_content = html.get_body()?;
-        // This is a very basic HTML stripping, you might want to use a proper HTML parser
-        return Ok(html_content
-            .replace(|c: char| c == '<' || c == '>', "")
-            .trim()
-            .to_string());
-    }
-
-    // If no multipart, just return the body
-    Ok(parsed.get_body()?.trim().to_string())
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_extract_email_content_plain_text() {
-        let email_content = "From: sender@example.com\r\nTo: recipient@example.com\r\nSubject: Test\r\n\r\nThis is a plain text email.";
-        let result = extract_email_content(email_content).unwrap();
-        assert_eq!(result, "This is a plain text email.");
-    }
-
-    #[test]
-    fn test_extract_email_content_html() {
-        let email_content = "From: sender@example.com\r\nTo: recipient@example.com\r\nSubject: Test\r\nContent-Type: text/html\r\n\r\n<html><body>This is an <b>HTML</b> email.</body></html>";
-        let result = extract_email_content(email_content).unwrap();
-        assert_eq!(
-            result,
-            "<html><body>This is an <b>HTML</b> email.</body></html>"
-        );
-    }
-
-    #[test]
-    fn test_extract_email_content_no_body() {
-        let email_content =
-            "From: sender@example.com\r\nTo: recipient@example.com\r\nSubject: Test\r\n";
-        let result = extract_email_content(email_content).unwrap();
-        assert_eq!(result, "");
-    }
-}

--- a/src/bin/smtp_server_dir/auth.rs
+++ b/src/bin/smtp_server_dir/auth.rs
@@ -1,13 +1,21 @@
-//! Vérification de credentials SMTP AUTH.
-//! Extrait de smtp_server.rs (refactor architecte).
+//! Vérification de credentials SMTP AUTH + handlers AUTH LOGIN/PLAIN.
+//! Extrait de smtp_server.rs (refactor architecte + cycle 6).
+#![allow(dead_code)]
 
 use std::env;
+use std::sync::Arc;
+
+use base64::{engine::general_purpose, Engine as _};
 use constant_time_eq::constant_time_eq;
 use log::debug;
+use tokio::io::AsyncBufReadExt;
+
+use simple_smtp_server::logic::Logic;
+use simple_smtp_server::session::SessionManager;
+
+use super::{write_response, StreamType};
 
 pub(crate) fn check_credentials(username: &[u8], password: &[u8]) -> bool {
-    // Implement your authentication logic here
-    // For example:
     let expected_username = env::var("SMTP_USERNAME").expect("SMTP_USERNAME must be set");
     let expected_password = env::var("SMTP_PASSWORD").expect("SMTP_PASSWORD must be set");
 
@@ -18,4 +26,68 @@ pub(crate) fn check_credentials(username: &[u8], password: &[u8]) -> bool {
     debug!("Password match: {}", password_match);
 
     username_match && password_match
+}
+
+// Handle AUTH LOGIN command
+pub(crate) async fn handle_auth_login(
+    stream: &mut StreamType,
+    logic: Arc<Logic>,
+    session_manager: Arc<SessionManager>,
+) -> std::io::Result<String> {
+    write_response(stream, "334 VXNlcm5hbWU6\r\n").await?; // Base64 pour "Username:"
+    let mut username = String::new();
+    stream.read_line(&mut username).await?;
+    let username = username.trim_end().as_bytes().to_vec();
+    debug!("Received username: {}", String::from_utf8_lossy(&username));
+
+    write_response(stream, "334 UGFzc3dvcmQ6\r\n").await?; // Base64 for "Password:"
+    let mut password = String::new();
+    stream.read_line(&mut password).await?;
+    let password = password.trim_end().as_bytes().to_vec();
+    debug!("Received password: {}", String::from_utf8_lossy(&password));
+
+    let username = String::from_utf8_lossy(&username).to_string();
+    let password = String::from_utf8_lossy(&password).to_string();
+
+    match logic.authenticate_user(&username, &password).await {
+        Ok(Some(user)) => {
+            let session_id = session_manager.create_session(&username);
+            session_manager.set_mailbox(&session_id, &user.mailbox);
+            Ok(format!(
+                "235 Authentication successful, session ID: {}\r\n",
+                session_id
+            ))
+        }
+        Ok(None) => Ok("535 Authentication failed\r\n".to_string()),
+        Err(_) => Ok("535 Authentication failed\r\n".to_string()),
+    }
+}
+
+// Handle AUTH PLAIN command
+pub(crate) async fn handle_auth_plain(
+    command: &str,
+    session_manager: Arc<SessionManager>,
+) -> std::io::Result<String> {
+    let auth_data = command.split_whitespace().nth(2).unwrap_or("");
+    let decoded = general_purpose::STANDARD.decode(auth_data).unwrap();
+    let parts: Vec<&[u8]> = decoded.split(|&b| b == 0).collect();
+
+    if parts.len() != 3 {
+        return Ok("501 Malformed AUTH PLAIN\r\n".to_string());
+    }
+
+    let username = parts[1];
+    let password = parts[2];
+
+    if check_credentials(username, password) {
+        let username_str = String::from_utf8_lossy(username).to_string();
+        let session_id = session_manager.create_session(&username_str);
+        session_manager.set_mailbox(&session_id, "inbox");
+        Ok(format!(
+            "235 Authentication successful, session ID: {}\r\n",
+            session_id
+        ))
+    } else {
+        Ok("535 Authentication failed\r\n".to_string())
+    }
 }

--- a/src/bin/smtp_server_dir/commands.rs
+++ b/src/bin/smtp_server_dir/commands.rs
@@ -1,0 +1,124 @@
+//! Handlers de commandes SMTP (HELO/QUIT/RSET/STARTTLS/dispatcher).
+//! Extrait de smtp_server.rs (refactor cycle 6).
+#![allow(dead_code)]
+
+use std::sync::Arc;
+
+use simple_smtp_server::entities::Email;
+use simple_smtp_server::logic::Logic;
+use simple_smtp_server::session::SessionManager;
+
+use super::{
+    env_bool, handle_auth_login, handle_auth_plain, extract_email_content, CustomEmail, StreamType,
+};
+
+// Réponse EHLO/HELO — construit la liste de capabilities selon l'état TLS.
+pub(crate) fn handle_helo(is_tls: bool, require_starttls: bool) -> String {
+    let mut caps = vec!["250-mail.misfits.ai Hello".to_string()];
+    if !is_tls {
+        caps.push("250-STARTTLS".to_string());
+    }
+    if is_tls || !require_starttls {
+        caps.push("250-AUTH LOGIN PLAIN".to_string());
+    }
+    caps.push("250 OK".to_string());
+    format!("{}\r\n", caps.join("\r\n"))
+}
+
+// Réponse QUIT.
+pub(crate) fn handle_quit(email: &CustomEmail) -> String {
+    if !email.email.from.is_empty() && !email.email.to.is_empty() {
+        match extract_email_content(&email.email.body) {
+            Ok(content) => println!("Extracted email content: {}", content),
+            Err(e) => eprintln!("Error extracting email content: {}", e),
+        }
+    }
+    "221 Bye\r\n".to_string()
+}
+
+// Réponse RSET — reset le buffer d'email en cours.
+pub(crate) fn handle_rset(email: &mut CustomEmail) -> String {
+    *email = CustomEmail {
+        email: Email::new("", "", "", "", ""),
+        raw_content: String::new(),
+        dkim_signature: None,
+    };
+    "250 OK\r\n".to_string()
+}
+
+// Réponse STARTTLS.
+pub(crate) fn handle_starttls(stream: &StreamType) -> String {
+    match stream {
+        StreamType::Plain(_) => "220 Ready to start TLS\r\n".to_string(),
+        StreamType::Tls(_) => "454 TLS not available due to temporary reason\r\n".to_string(),
+    }
+}
+
+// Garde-fou "530 Must issue a STARTTLS command first".
+pub(crate) fn require_tls_or_530(require_starttls: bool, is_tls: bool) -> Option<String> {
+    if require_starttls && !is_tls {
+        Some("530 Must issue a STARTTLS command first\r\n".to_string())
+    } else {
+        None
+    }
+}
+
+// Dispatch SMTP commands.
+pub(crate) async fn process_command(
+    command: &str,
+    email: &mut CustomEmail,
+    stream: &mut StreamType,
+    logic: Arc<Logic>,
+    session_manager: Arc<SessionManager>,
+) -> std::io::Result<String> {
+    let trimmed = command.trim();
+    let upper = trimmed.to_ascii_uppercase();
+    println!("In process_command with: {}", upper.as_str());
+
+    let require_starttls = env_bool("SMTP_REQUIRE_STARTTLS", true);
+    let is_tls = stream.is_tls();
+
+    match upper.as_str() {
+        s if s.starts_with("HELO") || s.starts_with("EHLO") => {
+            Ok(handle_helo(is_tls, require_starttls))
+        }
+        s if s.starts_with("AUTH LOGIN") => {
+            if let Some(err) = require_tls_or_530(require_starttls, is_tls) {
+                return Ok(err);
+            }
+            handle_auth_login(stream, logic.clone(), session_manager.clone()).await
+        }
+        s if s.starts_with("AUTH PLAIN") => {
+            if let Some(err) = require_tls_or_530(require_starttls, is_tls) {
+                return Ok(err);
+            }
+            handle_auth_plain(trimmed, session_manager.clone()).await
+        }
+        s if s.starts_with("MAIL FROM:") => {
+            email.email.from = trimmed[10..].trim().to_string();
+            Ok("250 OK\r\n".to_string())
+        }
+        s if s.starts_with("RCPT TO:") => {
+            email.email.to = trimmed[8..].trim().to_string();
+            Ok("250 OK\r\n".to_string())
+        }
+        s if s.starts_with("SUBJECT:") => {
+            email.email.subject = s[8..].trim().to_string();
+            Ok("250 OK\r\n".to_string())
+        }
+        "DATA" => Ok("354 Start mail input; end with <CRLF>.<CRLF>\r\n".to_string()),
+        "." => Ok("250 OK\r\n".to_string()),
+        "QUIT" => Ok(handle_quit(email)),
+        "RSET" => Ok(handle_rset(email)),
+        "NOOP" => Ok("250 OK\r\n".to_string()),
+        s if s.starts_with("VRFY") => Ok(
+            "252 Cannot VRFY user, but will accept message and attempt delivery\r\n".to_string(),
+        ),
+        s if s.starts_with("AUTH") => Ok(match require_tls_or_530(require_starttls, is_tls) {
+            Some(err) => err,
+            None => "235 Authentication successful\r\n".to_string(),
+        }),
+        s if s.starts_with("STARTTLS") => Ok(handle_starttls(stream)),
+        _ => Ok("500 Syntax error, command unrecognized\r\n".to_string()),
+    }
+}

--- a/src/bin/smtp_server_dir/headers.rs
+++ b/src/bin/smtp_server_dir/headers.rs
@@ -1,0 +1,151 @@
+//! Parsing headers d'emails entrants + extraction contenu.
+//! Extrait de smtp_server.rs (refactor cycle 6).
+#![allow(dead_code)]
+
+use mailparse::parse_mail;
+use simple_smtp_server::smtp_client::extract_email_address;
+
+use super::CustomEmail;
+
+pub(crate) fn extract_session_id_from_response(response: &str) -> Option<String> {
+    let marker = "session ID:";
+    let idx = response.find(marker)?;
+    let sid = response[idx + marker.len()..]
+        .trim()
+        .trim_end_matches('\r')
+        .trim_end_matches('\n')
+        .to_string();
+    if sid.is_empty() {
+        None
+    } else {
+        Some(sid)
+    }
+}
+
+pub(crate) fn parse_header_line(raw_line: &str) -> Option<(String, String)> {
+    let (name, value) = raw_line.split_once(':')?;
+    let name = name.trim();
+    if name.is_empty() {
+        return None;
+    }
+    Some((name.to_string(), value.trim().to_string()))
+}
+
+pub(crate) fn parse_message_id_header(value: &str) -> Option<String> {
+    let value = value
+        .trim_matches(|c| c == '<' || c == '>')
+        .trim();
+
+    if value.is_empty() {
+        None
+    } else {
+        Some(value.to_string())
+    }
+}
+
+pub(crate) fn apply_parsed_header(current_email: &mut CustomEmail, raw_line: &str) {
+    if raw_line.starts_with(' ') || raw_line.starts_with('\t') {
+        if let Some((last_name, last_value)) = current_email.email.headers.last_mut() {
+            let continuation = raw_line.trim();
+            if !continuation.is_empty() {
+                if !last_value.is_empty() {
+                    last_value.push(' ');
+                }
+                last_value.push_str(continuation);
+
+                if last_name.eq_ignore_ascii_case("DKIM-Signature") {
+                    current_email.dkim_signature = Some(last_value.clone());
+                } else if last_name.eq_ignore_ascii_case("Subject") {
+                    current_email.email.subject = last_value.clone();
+                } else if last_name.eq_ignore_ascii_case("Message-ID") {
+                    if let Some(mid) = parse_message_id_header(last_value) {
+                        current_email.email.id = mid;
+                    }
+                }
+            }
+        }
+        return;
+    }
+
+    if let Some((name, value)) = parse_header_line(raw_line) {
+        current_email
+            .email
+            .headers
+            .push((name.clone(), value.clone()));
+
+        if name.eq_ignore_ascii_case("DKIM-Signature") {
+            current_email.dkim_signature = Some(value.clone());
+        } else if name.eq_ignore_ascii_case("From") {
+            let canonical = format!("From: {}", value);
+            current_email.email.from =
+                extract_email_address(&canonical, "From:").unwrap_or_default();
+        } else if name.eq_ignore_ascii_case("To") {
+            let canonical = format!("To: {}", value);
+            current_email.email.to = extract_email_address(&canonical, "To:").unwrap_or_default();
+        } else if name.eq_ignore_ascii_case("Subject") {
+            current_email.email.subject = value;
+        } else if name.eq_ignore_ascii_case("Message-ID") {
+            if let Some(mid) = parse_message_id_header(&value) {
+                current_email.email.id = mid;
+            }
+        }
+    }
+}
+
+pub(crate) fn extract_email_content(
+    email_content: &str,
+) -> Result<String, Box<dyn std::error::Error>> {
+    let parsed = parse_mail(email_content.as_bytes())?;
+
+    if let Some(plain_text) = parsed
+        .subparts
+        .iter()
+        .find(|part| part.ctype.mimetype == "text/plain")
+    {
+        return Ok(plain_text.get_body()?.trim().to_string());
+    }
+
+    if let Some(html) = parsed
+        .subparts
+        .iter()
+        .find(|part| part.ctype.mimetype == "text/html")
+    {
+        let html_content = html.get_body()?;
+        return Ok(html_content
+            .replace(|c: char| c == '<' || c == '>', "")
+            .trim()
+            .to_string());
+    }
+
+    Ok(parsed.get_body()?.trim().to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_extract_email_content_plain_text() {
+        let email_content = "From: sender@example.com\r\nTo: recipient@example.com\r\nSubject: Test\r\n\r\nThis is a plain text email.";
+        let result = extract_email_content(email_content).unwrap();
+        assert_eq!(result, "This is a plain text email.");
+    }
+
+    #[test]
+    fn test_extract_email_content_html() {
+        let email_content = "From: sender@example.com\r\nTo: recipient@example.com\r\nSubject: Test\r\nContent-Type: text/html\r\n\r\n<html><body>This is an <b>HTML</b> email.</body></html>";
+        let result = extract_email_content(email_content).unwrap();
+        assert_eq!(
+            result,
+            "<html><body>This is an <b>HTML</b> email.</body></html>"
+        );
+    }
+
+    #[test]
+    fn test_extract_email_content_no_body() {
+        let email_content =
+            "From: sender@example.com\r\nTo: recipient@example.com\r\nSubject: Test\r\n";
+        let result = extract_email_content(email_content).unwrap();
+        assert_eq!(result, "");
+    }
+}


### PR DESCRIPTION
Split de smtp_server.rs en 2 nouveaux modules :

- `smtp_server_dir/headers.rs` : parsers headers + extract_email_content
- `smtp_server_dir/commands.rs` : dispatcher process_command + handle_helo/quit/rset/starttls/require_tls_or_530
- `smtp_server_dir/auth.rs` étendu avec handle_auth_login + handle_auth_plain

Aucun changement de comportement. Tests conservés dans headers.rs.

Fichiers imap_server/mod.rs (529) et smtp_client/mod.rs (538) laissés pour un cycle ultérieur (leçon: shipping > perfection).

LOC : 689 → 378 ✅ (budget ≤450).