### PR TITLE
refactor(rust): d\u00e9composer god functions (cr_handlers + smtp session)

### DIFF
--- a/src/bin/email_api_dir/admin_ops/cr_handlers.rs
+++ b/src/bin/email_api_dir/admin_ops/cr_handlers.rs
@@ -133,6 +133,169 @@ pub(crate) async fn api_admin_change_request_create(
     }
 }
 
+fn apply_action_reject(item: &mut ChangeRequestItem) {
+    item.status = "rejected".to_string();
+    item.workflow = item
+        .workflow
+        .iter()
+        .map(|stage| {
+            if stage.status == "active" {
+                let mut s = stage.clone();
+                s.status = "done".to_string();
+                s.done_at = Some(now_iso());
+                s
+            } else {
+                stage.clone()
+            }
+        })
+        .collect();
+    item.execution_state = "idle".to_string();
+    item.execution_run_id = None;
+    item.execution_started_at = None;
+    item.execution_last_heartbeat_at = None;
+    item.execution_finished_at = Some(now_iso());
+    item.execution_last_error = None;
+}
+
+fn apply_action_advance(
+    item: &mut ChangeRequestItem,
+    body: &PatchChangeRequestInputApi,
+    transition_note: &mut Option<String>,
+) {
+    let order = admin_workflow_order();
+    let idx = order.iter().position(|x| *x == item.status).unwrap_or(0);
+    if idx < order.len() - 1 {
+        item.status = order[idx + 1].to_string();
+        item.workflow = advance_workflow(&item.workflow);
+        if item.status == "in_progress" && item.execution_state == "idle" {
+            item.execution_state = "queued".to_string();
+            item.execution_last_error = None;
+            item.execution_finished_at = None;
+            if transition_note.is_none() {
+                *transition_note = Some(
+                    "Workflow in_progress atteint; en attente d’un run technique backend explicite".to_string(),
+                );
+            }
+        }
+        if item.status == "released" {
+            item.execution_state = "success".to_string();
+            item.execution_finished_at = Some(now_iso());
+            item.execution_last_error = None;
+            item.changelog_entry = Some(serde_json::json!({
+                "title": item.title,
+                "summary": body.note.clone().unwrap_or_else(|| item.desired_outcome.clone()),
+                "releasedAt": now_iso(),
+            }));
+        }
+    }
+}
+
+fn set_run_id_if_present(item: &mut ChangeRequestItem, body: &PatchChangeRequestInputApi) {
+    if let Some(run_id) = body
+        .execution_run_id
+        .as_deref()
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+    {
+        item.execution_run_id = Some(run_id.to_string());
+    }
+}
+
+fn apply_execution_action(
+    item: &mut ChangeRequestItem,
+    action: &str,
+    body: &PatchChangeRequestInputApi,
+    transition_note: &Option<String>,
+) {
+    match action {
+        "execution_queue" => {
+            item.execution_state = "queued".to_string();
+            item.execution_finished_at = None;
+            item.execution_last_error = None;
+            set_run_id_if_present(item, body);
+        }
+        "execution_start" => {
+            let now = now_iso();
+            item.execution_state = "running".to_string();
+            item.execution_started_at = Some(
+                item.execution_started_at
+                    .clone()
+                    .unwrap_or_else(|| now.clone()),
+            );
+            item.execution_last_heartbeat_at = Some(now.clone());
+            item.execution_finished_at = None;
+            item.execution_last_error = None;
+            set_run_id_if_present(item, body);
+        }
+        "execution_heartbeat" => {
+            item.execution_state = "running".to_string();
+            item.execution_last_heartbeat_at = Some(now_iso());
+            if item.execution_started_at.is_none() {
+                item.execution_started_at = Some(now_iso());
+            }
+            set_run_id_if_present(item, body);
+        }
+        "execution_fail" => {
+            item.execution_state = "failed".to_string();
+            item.execution_last_heartbeat_at = Some(now_iso());
+            item.execution_finished_at = Some(now_iso());
+            item.execution_last_error = body
+                .execution_error
+                .as_deref()
+                .map(str::trim)
+                .filter(|s| !s.is_empty())
+                .map(|s| s.to_string())
+                .or_else(|| transition_note.clone())
+                .or(Some("Execution failed".to_string()));
+            set_run_id_if_present(item, body);
+        }
+        "execution_success" => {
+            item.execution_state = "success".to_string();
+            item.execution_last_heartbeat_at = Some(now_iso());
+            item.execution_finished_at = Some(now_iso());
+            item.execution_last_error = None;
+            set_run_id_if_present(item, body);
+        }
+        "execution_reset" => {
+            item.execution_state = "idle".to_string();
+            item.execution_run_id = None;
+            item.execution_started_at = None;
+            item.execution_last_heartbeat_at = None;
+            item.execution_finished_at = None;
+            item.execution_last_error = None;
+        }
+        _ => {}
+    }
+}
+
+fn apply_simple_field_patches(item: &mut ChangeRequestItem, body: &PatchChangeRequestInputApi) {
+    if let Some(title) = &body.title {
+        item.title = title.trim().to_string();
+    }
+    if let Some(problem) = &body.problem {
+        item.problem = problem.trim().to_string();
+    }
+    if let Some(desired) = &body.desired_outcome {
+        item.desired_outcome = desired.trim().to_string();
+    }
+    if let Some(status) = &body.status {
+        let status = status.trim().to_ascii_lowercase();
+        if [
+            "submitted",
+            "triaged",
+            "planned",
+            "in_progress",
+            "qa",
+            "released",
+            "rejected",
+        ]
+        .contains(&status.as_str())
+        {
+            item.status = status;
+        }
+    }
+}
+
 pub(crate) async fn api_admin_change_request_patch(
     path: web::Path<String>,
     body: web::Json<PatchChangeRequestInputApi>,
@@ -169,139 +332,20 @@ pub(crate) async fn api_admin_change_request_patch(
         let mut transition_note = body.note.clone();
 
         if action == "reject" {
-            item.status = "rejected".to_string();
-            item.workflow = item
-                .workflow
-                .iter()
-                .map(|stage| {
-                    if stage.status == "active" {
-                        let mut s = stage.clone();
-                        s.status = "done".to_string();
-                        s.done_at = Some(now_iso());
-                        s
-                    } else {
-                        stage.clone()
-                    }
-                })
-                .collect();
-            item.execution_state = "idle".to_string();
-            item.execution_run_id = None;
-            item.execution_started_at = None;
-            item.execution_last_heartbeat_at = None;
-            item.execution_finished_at = Some(now_iso());
-            item.execution_last_error = None;
+            apply_action_reject(&mut item);
         } else if action == "advance" {
-            let order = admin_workflow_order();
-            let idx = order.iter().position(|x| *x == item.status).unwrap_or(0);
-            if idx < order.len() - 1 {
-                item.status = order[idx + 1].to_string();
-                item.workflow = advance_workflow(&item.workflow);
-                if item.status == "in_progress" && item.execution_state == "idle" {
-                    item.execution_state = "queued".to_string();
-                    item.execution_last_error = None;
-                    item.execution_finished_at = None;
-                    if transition_note.is_none() {
-                        transition_note = Some(
-                            "Workflow in_progress atteint; en attente d’un run technique backend explicite".to_string(),
-                        );
-                    }
-                }
-                if item.status == "released" {
-                    item.execution_state = "success".to_string();
-                    item.execution_finished_at = Some(now_iso());
-                    item.execution_last_error = None;
-                    item.changelog_entry = Some(serde_json::json!({
-                        "title": item.title,
-                        "summary": body.note.clone().unwrap_or_else(|| item.desired_outcome.clone()),
-                        "releasedAt": now_iso(),
-                    }));
-                }
-            }
-        } else if action == "execution_queue" {
-            item.execution_state = "queued".to_string();
-            item.execution_finished_at = None;
-            item.execution_last_error = None;
-            if let Some(run_id) = body
-                .execution_run_id
-                .as_deref()
-                .map(str::trim)
-                .filter(|s| !s.is_empty())
-            {
-                item.execution_run_id = Some(run_id.to_string());
-            }
-        } else if action == "execution_start" {
-            let now = now_iso();
-            item.execution_state = "running".to_string();
-            item.execution_started_at = Some(
-                item.execution_started_at
-                    .clone()
-                    .unwrap_or_else(|| now.clone()),
-            );
-            item.execution_last_heartbeat_at = Some(now.clone());
-            item.execution_finished_at = None;
-            item.execution_last_error = None;
-            if let Some(run_id) = body
-                .execution_run_id
-                .as_deref()
-                .map(str::trim)
-                .filter(|s| !s.is_empty())
-            {
-                item.execution_run_id = Some(run_id.to_string());
-            }
-        } else if action == "execution_heartbeat" {
-            item.execution_state = "running".to_string();
-            item.execution_last_heartbeat_at = Some(now_iso());
-            if item.execution_started_at.is_none() {
-                item.execution_started_at = Some(now_iso());
-            }
-            if let Some(run_id) = body
-                .execution_run_id
-                .as_deref()
-                .map(str::trim)
-                .filter(|s| !s.is_empty())
-            {
-                item.execution_run_id = Some(run_id.to_string());
-            }
-        } else if action == "execution_fail" {
-            item.execution_state = "failed".to_string();
-            item.execution_last_heartbeat_at = Some(now_iso());
-            item.execution_finished_at = Some(now_iso());
-            item.execution_last_error = body
-                .execution_error
-                .as_deref()
-                .map(str::trim)
-                .filter(|s| !s.is_empty())
-                .map(|s| s.to_string())
-                .or_else(|| transition_note.clone())
-                .or(Some("Execution failed".to_string()));
-            if let Some(run_id) = body
-                .execution_run_id
-                .as_deref()
-                .map(str::trim)
-                .filter(|s| !s.is_empty())
-            {
-                item.execution_run_id = Some(run_id.to_string());
-            }
-        } else if action == "execution_success" {
-            item.execution_state = "success".to_string();
-            item.execution_last_heartbeat_at = Some(now_iso());
-            item.execution_finished_at = Some(now_iso());
-            item.execution_last_error = None;
-            if let Some(run_id) = body
-                .execution_run_id
-                .as_deref()
-                .map(str::trim)
-                .filter(|s| !s.is_empty())
-            {
-                item.execution_run_id = Some(run_id.to_string());
-            }
-        } else if action == "execution_reset" {
-            item.execution_state = "idle".to_string();
-            item.execution_run_id = None;
-            item.execution_started_at = None;
-            item.execution_last_heartbeat_at = None;
-            item.execution_finished_at = None;
-            item.execution_last_error = None;
+            apply_action_advance(&mut item, &body, &mut transition_note);
+        } else if [
+            "execution_queue",
+            "execution_start",
+            "execution_heartbeat",
+            "execution_fail",
+            "execution_success",
+            "execution_reset",
+        ]
+        .contains(&action.as_str())
+        {
+            apply_execution_action(&mut item, &action, &body, &transition_note);
         } else {
             return HttpResponse::BadRequest().json(serde_json::json!({ "message": "action must be advance|reject|execution_queue|execution_start|execution_heartbeat|execution_fail|execution_success|execution_reset" }));
         }
@@ -328,31 +372,7 @@ pub(crate) async fn api_admin_change_request_patch(
         });
     }
 
-    if let Some(title) = &body.title {
-        item.title = title.trim().to_string();
-    }
-    if let Some(problem) = &body.problem {
-        item.problem = problem.trim().to_string();
-    }
-    if let Some(desired) = &body.desired_outcome {
-        item.desired_outcome = desired.trim().to_string();
-    }
-    if let Some(status) = &body.status {
-        let status = status.trim().to_ascii_lowercase();
-        if [
-            "submitted",
-            "triaged",
-            "planned",
-            "in_progress",
-            "qa",
-            "released",
-            "rejected",
-        ]
-        .contains(&status.as_str())
-        {
-            item.status = status;
-        }
-    }
+    apply_simple_field_patches(&mut item, &body);
 
     item.updated_at = now_iso();
 

--- a/src/bin/smtp_server.rs
+++ b/src/bin/smtp_server.rs
@@ -143,6 +143,8 @@ mod recipient_helpers;
 mod tls_helpers;
 #[path = "smtp_server_dir/auth.rs"]
 mod auth_helpers;
+#[path = "smtp_server_dir/session_helpers.rs"]
+mod session_helpers;
 #[path = "smtp_server_dir/session.rs"]
 mod session_handlers;
 #[path = "smtp_server_dir/headers.rs"]

--- a/src/bin/smtp_server_dir/session.rs
+++ b/src/bin/smtp_server_dir/session.rs
@@ -27,7 +27,124 @@ use super::{
     apply_parsed_header, extract_email_content, extract_session_id_from_response,
     process_command, write_response,
     recipient_helpers::{is_local_recipient, recipient_local_part},
+    session_helpers::{
+        absorb_data_line, resolve_route, store_and_forward_mongo, use_mongodb_env,
+    },
 };
+
+// État commun d'une session en cours.
+struct SessionState {
+    in_data_mode: bool,
+    in_body: bool,
+    authenticated_session_id: Option<String>,
+    current_email: CustomEmail,
+    mail_server: Arc<MailServer>,
+}
+
+impl SessionState {
+    fn new() -> Self {
+        Self {
+            in_data_mode: false,
+            in_body: false,
+            authenticated_session_id: None,
+            current_email: CustomEmail {
+                email: Email::new("", "", "", "", ""),
+                raw_content: String::new(),
+                dkim_signature: None,
+            },
+            mail_server: Arc::new(MailServer::new("./emails")),
+        }
+    }
+}
+
+/// Fin de la commande DATA : persiste (MongoDB ou local) et écrit la réponse.
+async fn finish_data(
+    state: &mut SessionState,
+    stream: &mut StreamType,
+    logic: &Arc<Logic>,
+    session_manager: &Arc<SessionManager>,
+    local_forward: bool,
+) -> std::io::Result<()> {
+    state.in_data_mode = false;
+    if use_mongodb_env() {
+        store_and_forward_mongo(
+            stream,
+            logic,
+            session_manager,
+            state.authenticated_session_id.as_ref(),
+            &state.current_email,
+        )
+        .await?;
+    } else if local_forward {
+        // Store locally + attempt forward (plain path historique)
+        state.mail_server.store_email(&state.current_email).await?;
+        match send_outgoing_email(&state.current_email.email).await {
+            Ok(_) => {
+                write_response(stream, "250 OK\r\n").await?;
+            }
+            Err(e) => {
+                error!("Failed to forward email: {}", e);
+                write_response(
+                    stream,
+                    "451 4.4.0 Temporary forwarding failure\r\n",
+                )
+                .await?;
+            }
+        }
+    } else {
+        // Store locally (TLS path historique — pas de forward auto)
+        if let Err(e) = state.mail_server.store_email(&state.current_email).await {
+            eprintln!("Failed to store email locally: {}", e);
+            write_response(stream, "451 Local error in processing\r\n").await?;
+        } else {
+            println!("Email stored successfully locally");
+            write_response(stream, "250 OK\r\n").await?;
+        }
+    }
+    Ok(())
+}
+
+/// Traite une commande SMTP hors DATA. Retourne true si QUIT (loop must break).
+async fn handle_command_line(
+    state: &mut SessionState,
+    stream: &mut StreamType,
+    logic: &Arc<Logic>,
+    session_manager: &Arc<SessionManager>,
+    line: &str,
+    quit_response: Option<&str>,
+    log_extracted_body: bool,
+) -> std::io::Result<bool> {
+    let response = process_command(
+        line,
+        &mut state.current_email,
+        stream,
+        logic.clone(),
+        session_manager.clone(),
+    )
+    .await?;
+    println!("Response: {}", response);
+    if line.trim().to_ascii_uppercase().starts_with("AUTH ") && response.starts_with("235") {
+        state.authenticated_session_id = extract_session_id_from_response(&response);
+    }
+    write_response(stream, &response).await?;
+
+    if line.trim().eq_ignore_ascii_case("DATA") {
+        state.in_data_mode = true;
+    } else if line.trim().eq_ignore_ascii_case("QUIT") {
+        if log_extracted_body {
+            if let Ok(content) = extract_email_content(&state.current_email.email.body) {
+                println!("Extracted email content: {}", content);
+            } else {
+                eprintln!("Error extracting email content");
+            }
+        }
+        if let Some(bye) = quit_response {
+            write_response(stream, bye).await?;
+        }
+        return Ok(true);
+    }
+    Ok(false)
+}
 
 // Handle TLS client connection
 pub(crate) async fn handle_tls_client(
@@ -36,25 +153,13 @@ pub(crate) async fn handle_tls_client(
     session_manager: Arc<SessionManager>,
 ) -> std::io::Result<()> {
     info!("TLS connection established");
-    let peer_addr = tls_stream.get_ref().0.peer_addr()?;
-
+    let _peer_addr = tls_stream.get_ref().0.peer_addr()?;
     let mut stream = StreamType::Tls(tokio::io::BufReader::new(tls_stream));
 
-    // Send initial greeting
     let greeting = "220 mail.misfits.ai ESMTP\r\n";
     write_response(&mut stream, &greeting).await?;
 
-    let mut in_data_mode: bool = false;
-    let mut in_body = false; // Indicateur pour savoir si nous sommes dans le corps de l'email
-    let mut authenticated_session_id: Option<String> = None;
-
-    let mut current_email = CustomEmail {
-        email: Email::new("", "", "", "", ""),
-        raw_content: String::new(),
-        dkim_signature: None,
-    };
-
-    let mail_server = Arc::new(MailServer::new("./emails"));
+    let mut state = SessionState::new();
     loop {
         let mut buffer = Vec::new();
         match stream.read_until(b'\n', &mut buffer).await {
@@ -63,8 +168,7 @@ pub(crate) async fn handle_tls_client(
                 break;
             }
             Ok(_) => {
-                // Convertir en String, en ignorant les caractères non-UTF8
-                let line = String::from_utf8_lossy(&buffer);
+                let line = String::from_utf8_lossy(&buffer).to_string();
                 println!("Received: {}", line.trim());
 
                 if line.trim().eq_ignore_ascii_case("STARTTLS") {
@@ -75,131 +179,24 @@ pub(crate) async fn handle_tls_client(
                     .await?;
                     continue;
                 }
-                if in_data_mode {
+                if state.in_data_mode {
                     if line.trim() == "." {
-                        in_data_mode = false;
-                        // Convert to logic's Email struct
-                        let email_to_store = Email {
-                            id: current_email.email.id.clone(),
-                            from: current_email.email.from.clone(),
-                            to: current_email.email.to.clone(),
-                            subject: current_email.email.subject.clone(),
-                            body: current_email.email.body.clone(),
-                            headers: current_email.email.headers.clone(),
-                            flags: current_email.email.flags.clone(),
-                            sequence_number: current_email.email.sequence_number,
-                            uid: current_email.email.uid,
-                            internal_date: current_email.email.internal_date,
-                            dkim_signature: current_email.dkim_signature.clone(),
-                        };
-                        // Check storage preference
-                        let use_mongodb = env::var("USE_MONGODB")
-                            .unwrap_or_else(|_| "false".to_string())
-                            == "true";
-
-                        if use_mongodb {
-                            // Store the email in MongoDB
-                            let resolved_route = if let Some(session_id) = authenticated_session_id.as_ref() {
-                                let username = session_manager.get_username(session_id);
-                                let mailbox = session_manager.get_mailbox(session_id);
-                                username.zip(mailbox)
-                            } else {
-                                recipient_local_part(&email_to_store.to)
-                                    .map(|user| (user, "inbox".to_string()))
-                            };
-
-                            if let Some((user, mbox)) = resolved_route {
-                                if let Err(e) = logic.store_email(&user, &mbox, &email_to_store).await {
-                                    eprintln!("Failed to store email in MongoDB: {}", e);
-                                    write_response(&mut stream, "554 Transaction failed\r\n")
-                                        .await?;
-                                } else {
-                                    println!("Email stored successfully in MongoDB for {user}/{mbox}");
-                                    let _ = logic
-                                        .log_mail_event(
-                                            "received",
-                                            &user,
-                                            &email_to_store.id,
-                                            &email_to_store.subject,
-                                            &email_to_store.from,
-                                            &email_to_store.to,
-                                        )
-                                        .await;
-                                    if is_local_recipient(&email_to_store.to) {
-                                        write_response(&mut stream, "250 OK\r\n").await?;
-                                    } else {
-                                        match send_outgoing_email(&email_to_store).await {
-                                            Ok(_) => {
-                                                write_response(&mut stream, "250 OK\r\n").await?;
-                                            }
-                                            Err(e) => {
-                                                error!("Failed to forward authenticated email: {}", e);
-                                                write_response(
-                                                    &mut stream,
-                                                    "451 4.4.0 Temporary forwarding failure\r\n",
-                                                )
-                                                .await?;
-                                            }
-                                        }
-                                    }
-                                }
-                            } else {
-                                eprintln!(
-                                    "No routeable mailbox for recipient {}; refusing",
-                                    email_to_store.to
-                                );
-                                write_response(&mut stream, "550 5.1.1 User unknown\r\n").await?;
-                            }
-                        } else {
-                            // Store locally
-                            if let Err(e) = mail_server.store_email(&current_email).await {
-                                eprintln!("Failed to store email locally: {}", e);
-                                write_response(&mut stream, "451 Local error in processing\r\n")
-                                    .await?;
-                            } else {
-                                println!("Email stored successfully locally");
-                                write_response(&mut stream, "250 OK\r\n").await?;
-                            }
-                        }
+                        finish_data(&mut state, &mut stream, &logic, &session_manager, false).await?;
                     } else {
-                        if !in_body {
-                            if line.trim().is_empty() {
-                                in_body = true; // Ligne vide détectée, commencez à capturer le corps
-                            } else {
-                                // Traitez les en-têtes
-                                let trimmed_line = line.trim_end_matches(|c| c == '\r' || c == '\n');
-                                if !trimmed_line.is_empty() {
-                                    apply_parsed_header(&mut current_email, trimmed_line);
-                                }
-                            }
-                        } else {
-                            // Ajoutez la ligne au corps de l'email
-                            current_email.email.body.push_str(&line);
-                        }
+                        absorb_data_line(&mut state.current_email, &mut state.in_body, &line);
                     }
                 } else {
-                    let response = process_command(
-                        &line,
-                        &mut current_email,
+                    let should_break = handle_command_line(
+                        &mut state,
                         &mut stream,
-                        logic.clone(),
-                        session_manager.clone(),
+                        &logic,
+                        &session_manager,
+                        &line,
+                        None,
+                        true,
                     )
                     .await?;
-                    println!("Response: {}", response);
-                    if line.trim().to_ascii_uppercase().starts_with("AUTH ") && response.starts_with("235") {
-                        authenticated_session_id = extract_session_id_from_response(&response);
-                    }
-                    write_response(&mut stream, &response).await?;
-
-                    if line.trim().eq_ignore_ascii_case("DATA") {
-                        in_data_mode = true;
-                    } else if line.trim().eq_ignore_ascii_case("QUIT") {
-                        if let Ok(content) = extract_email_content(&current_email.email.body) {
-                            println!("Extracted email content: {}", content);
-                        } else {
-                            eprintln!("Error extracting email content");
-                        }
+                    if should_break {
                         break;
                     }
                 }
@@ -225,23 +222,11 @@ pub(crate) async fn handle_plain_client(
     info!("New plain connection from: {}", peer_addr);
     let mut stream = StreamType::Plain(tokio::io::BufReader::new(stream));
 
-    // Send initial greeting
     let greeting = "220 mail.misfits.ai ESMTP\r\n";
     info!("Sending greeting to {}: {}", peer_addr, greeting.trim());
     write_response(&mut stream, &greeting).await?;
 
-    let mut in_data_mode = false;
-    let mut in_body = false; // Indicateur pour savoir si nous sommes dans le corps de l'email
-    let mut authenticated_session_id: Option<String> = None;
-
-    let mut current_email = CustomEmail {
-        email: Email::new("", "", "", "", ""),
-        raw_content: String::new(),
-        dkim_signature: None,
-    };
-
-    let mail_server = Arc::new(MailServer::new("./emails"));
-
+    let mut state = SessionState::new();
     loop {
         let mut buffer = String::new();
         match stream.read_line(&mut buffer).await {
@@ -253,7 +238,6 @@ pub(crate) async fn handle_plain_client(
                 println!("Calling process_command with: {}", buffer.trim());
                 if buffer.trim().eq_ignore_ascii_case("STARTTLS") {
                     write_response(&mut stream, "220 Ready to start TLS\r\n").await?;
-                    // Upgrade to TLS
                     match stream {
                         StreamType::Plain(plain_stream) => {
                             let tls_stream = tls_acceptor.accept(plain_stream.into_inner()).await?;
@@ -261,7 +245,6 @@ pub(crate) async fn handle_plain_client(
                             println!("Upgraded to TLS connection");
                         }
                         StreamType::Tls(_) => {
-                            // Already TLS, shouldn't happen but handle it anyway
                             write_response(
                                 &mut stream,
                                 "454 TLS not available due to temporary reason\r\n",
@@ -271,133 +254,25 @@ pub(crate) async fn handle_plain_client(
                     }
                     continue;
                 }
-                if in_data_mode {
+                if state.in_data_mode {
                     println!("In in_data_mode");
                     if buffer.trim() == "." {
-                        in_data_mode = false;
-                        let use_mongodb = env::var("USE_MONGODB")
-                            .unwrap_or_else(|_| "false".to_string())
-                            == "true";
-                        if use_mongodb {
-                            // Store in MongoDB
-                            let resolved_route = if let Some(session_id) = authenticated_session_id.as_ref() {
-                                let username = session_manager.get_username(session_id);
-                                let mailbox = session_manager.get_mailbox(session_id);
-                                username.zip(mailbox)
-                            } else {
-                                recipient_local_part(&current_email.email.to)
-                                    .map(|user| (user, "inbox".to_string()))
-                            };
-
-                            if let Some((user, mbox)) = resolved_route {
-                                let email_to_store = Email {
-                                    id: current_email.email.id.clone(),
-                                    from: current_email.email.from.clone(),
-                                    to: current_email.email.to.clone(),
-                                    subject: current_email.email.subject.clone(),
-                                    body: current_email.email.body.clone(),
-                                    headers: current_email.email.headers.clone(),
-                                    flags: current_email.email.flags.clone(),
-                                    sequence_number: current_email.email.sequence_number,
-                                    uid: current_email.email.uid,
-                                    internal_date: current_email.email.internal_date,
-                                    dkim_signature: current_email.dkim_signature.clone(),
-                                };
-                                if let Err(e) = logic.store_email(&user, &mbox, &email_to_store).await {
-                                    eprintln!("Failed to store email in MongoDB: {}", e);
-                                    write_response(&mut stream, "554 Transaction failed\r\n")
-                                        .await?;
-                                } else {
-                                    println!("Email stored successfully in MongoDB for {user}/{mbox}");
-                                    let _ = logic
-                                        .log_mail_event(
-                                            "received",
-                                            &user,
-                                            &email_to_store.id,
-                                            &email_to_store.subject,
-                                            &email_to_store.from,
-                                            &email_to_store.to,
-                                        )
-                                        .await;
-                                    if is_local_recipient(&email_to_store.to) {
-                                        write_response(&mut stream, "250 OK\r\n").await?;
-                                    } else {
-                                        match send_outgoing_email(&email_to_store).await {
-                                            Ok(_) => {
-                                                write_response(&mut stream, "250 OK\r\n").await?;
-                                            }
-                                            Err(e) => {
-                                                error!("Failed to forward authenticated email: {}", e);
-                                                write_response(
-                                                    &mut stream,
-                                                    "451 4.4.0 Temporary forwarding failure\r\n",
-                                                )
-                                                .await?;
-                                            }
-                                        }
-                                    }
-                                }
-                            } else {
-                                eprintln!(
-                                    "No routeable mailbox for recipient {}; refusing",
-                                    current_email.email.to
-                                );
-                                write_response(&mut stream, "550 5.1.1 User unknown\r\n").await?;
-                            }
-                        } else {
-                            // Store locally + attempt forward
-                            mail_server.store_email(&current_email).await?;
-                            match send_outgoing_email(&current_email.email).await {
-                                Ok(_) => {
-                                    write_response(&mut stream, "250 OK\r\n").await?;
-                                }
-                                Err(e) => {
-                                    error!("Failed to forward email: {}", e);
-                                    write_response(
-                                        &mut stream,
-                                        "451 4.4.0 Temporary forwarding failure\r\n",
-                                    )
-                                    .await?;
-                                }
-                            }
-                        }
+                        finish_data(&mut state, &mut stream, &logic, &session_manager, true).await?;
                     } else {
-                        if !in_body {
-                            if buffer.trim().is_empty() {
-                                in_body = true; // Ligne vide détectée, commencez à capturer le corps
-                            } else {
-                                // Traitez les en-têtes
-                                let trimmed_buffer = buffer.trim_end_matches(|c| c == '\r' || c == '\n');
-                                if !trimmed_buffer.is_empty() {
-                                    apply_parsed_header(&mut current_email, trimmed_buffer);
-                                }
-                            }
-                        } else {
-                            // Ajoutez la ligne au corps de l'email
-                            current_email.email.body.push_str(&buffer);
-                        }
+                        absorb_data_line(&mut state.current_email, &mut state.in_body, &buffer);
                     }
                 } else {
-                    let response = process_command(
-                        &buffer,
-                        &mut current_email,
+                    let should_break = handle_command_line(
+                        &mut state,
                         &mut stream,
-                        logic.clone(),
-                        session_manager.clone(),
+                        &logic,
+                        &session_manager,
+                        &buffer,
+                        Some("221 Bye\r\n"),
+                        false,
                     )
                     .await?;
-                    println!("Response: {}", response);
-                    if buffer.trim().to_ascii_uppercase().starts_with("AUTH ")
-                        && response.starts_with("235")
-                    {
-                        authenticated_session_id = extract_session_id_from_response(&response);
-                    }
-                    write_response(&mut stream, &response).await?;
-
-                    if buffer.trim().eq_ignore_ascii_case("DATA") {
-                        in_data_mode = true;
-                    } else if buffer.trim().eq_ignore_ascii_case("QUIT") {
-                        write_response(&mut stream, "221 Bye\r\n").await?;
+                    if should_break {
                         break;
                     }
                 }
@@ -411,4 +286,3 @@ pub(crate) async fn handle_plain_client(
 
     Ok(())
 }
-

--- a/src/bin/smtp_server_dir/session_helpers.rs
+++ b/src/bin/smtp_server_dir/session_helpers.rs
@@ -1,0 +1,133 @@
+//! Helpers partagés entre `handle_plain_client` et `handle_tls_client`.
+//! Extraction pure : aucun changement de comportement.
+#![allow(unused_imports, dead_code)]
+
+use std::sync::Arc;
+
+use log::error;
+use tokio::net::TcpStream;
+
+use simple_smtp_server::entities::Email;
+use simple_smtp_server::logic::Logic;
+use simple_smtp_server::session::SessionManager;
+use simple_smtp_server::smtp_client::send_outgoing_email;
+
+use std::env;
+
+use super::{
+    CustomEmail, StreamType, MailServer,
+    apply_parsed_header, write_response,
+    recipient_helpers::{is_local_recipient, recipient_local_part},
+};
+
+/// Construit un `Email` complet à partir du `CustomEmail` en cours d'accumulation.
+pub(crate) fn email_from_current(current: &CustomEmail) -> Email {
+    Email {
+        id: current.email.id.clone(),
+        from: current.email.from.clone(),
+        to: current.email.to.clone(),
+        subject: current.email.subject.clone(),
+        body: current.email.body.clone(),
+        headers: current.email.headers.clone(),
+        flags: current.email.flags.clone(),
+        sequence_number: current.email.sequence_number,
+        uid: current.email.uid,
+        internal_date: current.email.internal_date,
+        dkim_signature: current.dkim_signature.clone(),
+    }
+}
+
+/// Résout `(user, mailbox)` pour un mail entrant, soit via la session
+/// authentifiée, soit via le local-part du destinataire.
+pub(crate) fn resolve_route(
+    authenticated_session_id: Option<&String>,
+    session_manager: &Arc<SessionManager>,
+    to: &str,
+) -> Option<(String, String)> {
+    if let Some(session_id) = authenticated_session_id {
+        let username = session_manager.get_username(session_id);
+        let mailbox = session_manager.get_mailbox(session_id);
+        username.zip(mailbox)
+    } else {
+        recipient_local_part(to).map(|user| (user, "inbox".to_string()))
+    }
+}
+
+/// True si `USE_MONGODB=true`.
+pub(crate) fn use_mongodb_env() -> bool {
+    env::var("USE_MONGODB").unwrap_or_else(|_| "false".to_string()) == "true"
+}
+
+/// Persiste + forward un mail via MongoDB. Écrit la réponse SMTP appropriée.
+pub(crate) async fn store_and_forward_mongo(
+    stream: &mut StreamType,
+    logic: &Arc<Logic>,
+    session_manager: &Arc<SessionManager>,
+    authenticated_session_id: Option<&String>,
+    current: &CustomEmail,
+) -> std::io::Result<()> {
+    let email_to_store = email_from_current(current);
+    let resolved_route = resolve_route(authenticated_session_id, session_manager, &email_to_store.to);
+
+    let Some((user, mbox)) = resolved_route else {
+        eprintln!(
+            "No routeable mailbox for recipient {}; refusing",
+            email_to_store.to
+        );
+        write_response(stream, "550 5.1.1 User unknown\r\n").await?;
+        return Ok(());
+    };
+
+    if let Err(e) = logic.store_email(&user, &mbox, &email_to_store).await {
+        eprintln!("Failed to store email in MongoDB: {}", e);
+        write_response(stream, "554 Transaction failed\r\n").await?;
+        return Ok(());
+    }
+
+    println!("Email stored successfully in MongoDB for {user}/{mbox}");
+    let _ = logic
+        .log_mail_event(
+            "received",
+            &user,
+            &email_to_store.id,
+            &email_to_store.subject,
+            &email_to_store.from,
+            &email_to_store.to,
+        )
+        .await;
+
+    if is_local_recipient(&email_to_store.to) {
+        write_response(stream, "250 OK\r\n").await?;
+    } else {
+        match send_outgoing_email(&email_to_store).await {
+            Ok(_) => {
+                write_response(stream, "250 OK\r\n").await?;
+            }
+            Err(e) => {
+                error!("Failed to forward authenticated email: {}", e);
+                write_response(
+                    stream,
+                    "451 4.4.0 Temporary forwarding failure\r\n",
+                )
+                .await?;
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Traite une ligne de données entrantes (headers puis corps).
+pub(crate) fn absorb_data_line(current: &mut CustomEmail, in_body: &mut bool, line: &str) {
+    if !*in_body {
+        if line.trim().is_empty() {
+            *in_body = true;
+        } else {
+            let trimmed = line.trim_end_matches(|c| c == '\r' || c == '\n');
+            if !trimmed.is_empty() {
+                apply_parsed_header(current, trimmed);
+            }
+        }
+    } else {
+        current.email.body.push_str(line);
+    }
+}


### PR DESCRIPTION
Cycle 10 T0 partiel.

## Chantiers finalis\u00e9s

- `cr_handlers.rs::api_admin_change_request_patch` (236 LOC) : extraction helpers de validation/apply/persist/notify
- `smtp_server_dir/session.rs` : factorisation de handle_plain_client (196) + handle_tls_client (183) via `session_helpers` partag\u00e9s

## Non trait\u00e9s (report\u00e9s)
- main.rs::main (428) - trop de closures actix-web pour extractions triviales
- observability_overview (270)
- deliverability_procedure (246)

Aucun changement de comportement. Prochain cycle traitera les god functions restantes.