### PR TITLE
refactor(rust): décomposer 5 god functions (cycle 12)

### DIFF
--- a/src/bin/email_api_dir/admin_ops/diag_handlers/observability.rs
+++ b/src/bin/email_api_dir/admin_ops/diag_handlers/observability.rs
@@ -1,31 +1,33 @@
 #![allow(unused_imports, dead_code)]
 use super::super::*;
-pub(crate) async fn api_admin_observability_overview(
-    query: web::Query<AdminWindowQuery>,
-    mongo: web::Data<Arc<mongodb::Client>>,
-) -> impl Responder {
-    use simple_smtp_server::security::audit;
 
-    let since = since_str(&query.window);
-    let window_minutes = parse_window(&query.window).num_minutes().max(1) as f64;
-    let base_filter = doc! { "ts": { "$gte": &since } };
+/// Résumé des compteurs SMTP par statut sur la fenêtre.
+struct SmtpStatusStats {
+    total: u64,
+    delivered: u64,
+    bounced: u64,
+    failed: u64,
+    deferred: u64,
+    by_status: serde_json::Map<String, serde_json::Value>,
+    p95: u64,
+}
 
-    let total = storage::count_events(&mongo, base_filter.clone()).await;
+async fn collect_smtp_stats(
+    mongo: &Arc<mongodb::Client>,
+    since: &str,
+    base_filter: &bson::Document,
+) -> SmtpStatusStats {
+    let total = storage::count_events(mongo, base_filter.clone()).await;
     let by_status_docs = storage::aggregate(
-        &mongo,
+        mongo,
         vec![
             doc! { "$match": base_filter.clone() },
             doc! { "$group": { "_id": "$status", "count": { "$sum": 1 }, "avg_ms": { "$avg": "$total_ms" } } },
         ],
     )
     .await;
-
     let mut by_status = serde_json::Map::new();
-    let mut delivered = 0u64;
-    let mut bounced = 0u64;
-    let mut failed = 0u64;
-    let mut deferred = 0u64;
-
+    let (mut delivered, mut bounced, mut failed, mut deferred) = (0u64, 0u64, 0u64, 0u64);
     for doc in &by_status_docs {
         let status = doc.get_str("_id").unwrap_or("unknown").to_string();
         let count = doc.get_i64("count").unwrap_or(0) as u64;
@@ -38,81 +40,111 @@ pub(crate) async fn api_admin_observability_overview(
         }
         by_status.insert(status, serde_json::json!(count));
     }
+    let p95 = storage::p95_total_ms(mongo, base_filter.clone(), 1000).await;
+    let _ = since;
+    SmtpStatusStats { total, delivered, bounced, failed, deferred, by_status, p95 }
+}
 
-    let p95 = storage::p95_total_ms(&mongo, base_filter.clone(), 1000).await;
+struct QueueStats {
+    depth: u64,
+    oldest_age_seconds: Option<u64>,
+}
 
-    let outcome_total = delivered + bounced + failed + deferred;
-    let success_rate = if outcome_total == 0 {
-        0.0
-    } else {
-        delivered as f64 / outcome_total as f64
-    };
-
-    // SMTP queue depth + oldest age
+async fn collect_queue_stats(mongo: &Arc<mongodb::Client>) -> QueueStats {
     let db = env::var("MONGODB_DATABASE").unwrap_or_else(|_| "mailserver".to_string());
     let queue_coll = mongo
         .database(&db)
         .collection::<bson::Document>(SEND_QUEUE_COLL);
     let pending_queue_filter = doc! { "status": { "$in": ["pending", "scheduled", "sending"] } };
-    let queue_depth = queue_coll
+    let depth = queue_coll
         .count_documents(pending_queue_filter.clone())
         .await
         .unwrap_or(0);
-
     let oldest_pending = queue_coll
-        .find_one(pending_queue_filter.clone())
+        .find_one(pending_queue_filter)
         .sort(doc! { "created_at": 1 })
         .await
         .ok()
         .flatten();
-    let queue_oldest_age_seconds = oldest_pending
+    let oldest_age_seconds = oldest_pending
         .as_ref()
         .and_then(|d| d.get_datetime("created_at").ok())
         .map(|dt| (Utc::now().timestamp_millis() - dt.timestamp_millis()).max(0) as u64 / 1000);
+    QueueStats { depth, oldest_age_seconds }
+}
 
-    // Throughput and SMTP response classes
-    let incoming_events = storage::count_events(
-        &mongo,
-        doc! { "ts": { "$gte": &since }, "event_type": { "$in": ["accepted", "received"] } },
+struct ThroughputStats {
+    incoming: u64,
+    outgoing: u64,
+    smtp_4xx: u64,
+    smtp_5xx: u64,
+    dns_issue_events: u64,
+}
+
+async fn collect_throughput_stats(
+    mongo: &Arc<mongodb::Client>,
+    since: &str,
+) -> ThroughputStats {
+    let incoming = storage::count_events(
+        mongo,
+        doc! { "ts": { "$gte": since }, "event_type": { "$in": ["accepted", "received"] } },
     )
     .await;
-    let outgoing_events = storage::count_events(
-        &mongo,
-        doc! { "ts": { "$gte": &since }, "status": { "$in": ["delivered", "bounced", "failed", "deferred"] } },
+    let outgoing = storage::count_events(
+        mongo,
+        doc! { "ts": { "$gte": since }, "status": { "$in": ["delivered", "bounced", "failed", "deferred"] } },
     )
     .await;
-
     let smtp_4xx = storage::count_events(
-        &mongo,
-        doc! { "ts": { "$gte": &since }, "smtp_code": { "$gte": 400, "$lt": 500 } },
+        mongo,
+        doc! { "ts": { "$gte": since }, "smtp_code": { "$gte": 400, "$lt": 500 } },
     )
     .await;
     let smtp_5xx = storage::count_events(
-        &mongo,
-        doc! { "ts": { "$gte": &since }, "smtp_code": { "$gte": 500, "$lt": 600 } },
+        mongo,
+        doc! { "ts": { "$gte": since }, "smtp_code": { "$gte": 500, "$lt": 600 } },
     )
     .await;
+    let dns_issue_events = storage::count_events(
+        mongo,
+        doc! { "ts": { "$gte": since }, "event_type": "dns_lookup", "status": { "$in": ["failed", "deferred"] } },
+    )
+    .await;
+    ThroughputStats { incoming, outgoing, smtp_4xx, smtp_5xx, dns_issue_events }
+}
 
-    let monitoring_alerts = monitoring::alerts::evaluate_alerts(
-        &mongo,
-        parse_window(&query.window).num_minutes(),
+struct AlertsSnapshot {
+    monitoring: Vec<monitoring::alerts::ActiveAlert>,
+    security: Vec<simple_smtp_server::security::SecurityAlert>,
+    queue_growth: usize,
+    auth_failures: usize,
+    anomalies: usize,
+}
+
+async fn collect_alerts_snapshot(
+    mongo: &Arc<mongodb::Client>,
+    window: &str,
+) -> AlertsSnapshot {
+    use simple_smtp_server::security::audit;
+    let monitoring = monitoring::alerts::evaluate_alerts(
+        mongo,
+        parse_window(window).num_minutes(),
         &AlertConfig::default(),
     )
     .await;
-    let security_alerts = audit::query_active_alerts(&mongo, 300).await;
-
-    let queue_growth_alerts = monitoring_alerts
+    let security = audit::query_active_alerts(mongo, 300).await;
+    let queue_growth = monitoring
         .iter()
         .filter(|a| a.kind.contains("queue") || a.message.to_ascii_lowercase().contains("queue"))
         .count();
-    let auth_failure_alerts = security_alerts
+    let auth_failures = security
         .iter()
         .filter(|a| {
             let n = a.rule_name.to_ascii_lowercase();
             n.contains("auth") || n.contains("brute") || n.contains("login")
         })
         .count();
-    let anomaly_alerts = security_alerts
+    let anomalies = security
         .iter()
         .filter(|a| {
             let n = a.rule_name.to_ascii_lowercase();
@@ -122,32 +154,20 @@ pub(crate) async fn api_admin_observability_overview(
                 || n.contains("anomaly")
         })
         .count();
+    AlertsSnapshot { monitoring, security, queue_growth, auth_failures, anomalies }
+}
 
-    let dns_issue_events = storage::count_events(
-        &mongo,
-        doc! { "ts": { "$gte": &since }, "event_type": "dns_lookup", "status": { "$in": ["failed", "deferred"] } },
-    )
-    .await;
-
-    let rbl_sources = env::var("RBL_CHECK_HOSTS")
-        .unwrap_or_else(|_| "zen.spamhaus.org,bl.spamcop.net".to_string())
-        .split(',')
-        .map(|s| s.trim().to_string())
-        .filter(|s| !s.is_empty())
-        .collect::<Vec<_>>();
-    let rbl_listed_by = env::var("RBL_LISTED_BY")
-        .unwrap_or_default()
-        .split(',')
-        .map(|s| s.trim().to_string())
-        .filter(|s| !s.is_empty())
-        .collect::<Vec<_>>();
-
+async fn collect_suspicious_logins(
+    mongo: &Arc<mongodb::Client>,
+    since: &str,
+) -> Vec<serde_json::Value> {
+    let db = env::var("MONGODB_DATABASE").unwrap_or_else(|_| "mailserver".to_string());
     let auth_events_coll = mongo
         .database(&db)
         .collection::<bson::Document>("auth_events");
-    let suspicious_login_docs = match auth_events_coll
+    let docs = match auth_events_coll
         .aggregate(vec![
-            doc! { "$match": { "ts": { "$gte": &since }, "success": false } },
+            doc! { "$match": { "ts": { "$gte": since }, "success": false } },
             doc! { "$group": { "_id": "$ip", "attempts": { "$sum": 1 } } },
             doc! { "$sort": { "attempts": -1 } },
             doc! { "$limit": 10 },
@@ -157,18 +177,22 @@ pub(crate) async fn api_admin_observability_overview(
         Ok(cursor) => cursor.try_collect::<Vec<_>>().await.unwrap_or_default(),
         Err(_) => Vec::new(),
     };
-    let suspicious_logins_top = suspicious_login_docs
-        .into_iter()
+    docs.into_iter()
         .map(|d| {
             serde_json::json!({
                 "ip": d.get_str("_id").unwrap_or("unknown"),
                 "attempts": d.get_i64("attempts").unwrap_or(0)
             })
         })
-        .collect::<Vec<_>>();
+        .collect()
+}
 
-    let by_domain_docs = storage::aggregate(
-        &mongo,
+async fn collect_per_domain(
+    mongo: &Arc<mongodb::Client>,
+    base_filter: &bson::Document,
+) -> Vec<serde_json::Value> {
+    let docs = storage::aggregate(
+        mongo,
         vec![
             doc! { "$match": base_filter.clone() },
             doc! { "$project": {
@@ -186,9 +210,7 @@ pub(crate) async fn api_admin_observability_overview(
         ],
     )
     .await;
-
-    let per_domain = by_domain_docs
-        .into_iter()
+    docs.into_iter()
         .map(|d| {
             serde_json::json!({
                 "domain": d.get_str("_id").unwrap_or("unknown"),
@@ -197,70 +219,111 @@ pub(crate) async fn api_admin_observability_overview(
                 "bounced": d.get_i64("bounced").unwrap_or(0)
             })
         })
-        .collect::<Vec<_>>();
+        .collect()
+}
+
+fn rbl_sources() -> Vec<String> {
+    env::var("RBL_CHECK_HOSTS")
+        .unwrap_or_else(|_| "zen.spamhaus.org,bl.spamcop.net".to_string())
+        .split(',')
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+        .collect()
+}
+
+fn rbl_listed_by() -> Vec<String> {
+    env::var("RBL_LISTED_BY")
+        .unwrap_or_default()
+        .split(',')
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+        .collect()
+}
+
+pub(crate) async fn api_admin_observability_overview(
+    query: web::Query<AdminWindowQuery>,
+    mongo: web::Data<Arc<mongodb::Client>>,
+) -> impl Responder {
+    let since = since_str(&query.window);
+    let window_minutes = parse_window(&query.window).num_minutes().max(1) as f64;
+    let base_filter = doc! { "ts": { "$gte": &since } };
+
+    let smtp = collect_smtp_stats(&mongo, &since, &base_filter).await;
+    let queue = collect_queue_stats(&mongo).await;
+    let tput = collect_throughput_stats(&mongo, &since).await;
+    let alerts = collect_alerts_snapshot(&mongo, &query.window).await;
+    let suspicious_logins_top = collect_suspicious_logins(&mongo, &since).await;
+    let per_domain = collect_per_domain(&mongo, &base_filter).await;
+
+    let outcome_total = smtp.delivered + smtp.bounced + smtp.failed + smtp.deferred;
+    let success_rate = if outcome_total == 0 {
+        0.0
+    } else {
+        smtp.delivered as f64 / outcome_total as f64
+    };
 
     HttpResponse::Ok().json(serde_json::json!({
         "window": query.window,
         "since": since,
         "smtp": {
-            "total_events": total,
-            "failure_events": failed + bounced,
-            "p95_total_ms": p95,
-            "by_status": by_status
+            "total_events": smtp.total,
+            "failure_events": smtp.failed + smtp.bounced,
+            "p95_total_ms": smtp.p95,
+            "by_status": smtp.by_status
         },
         "health_realtime": {
             "queue": {
-                "depth": queue_depth,
-                "oldest_age_seconds": queue_oldest_age_seconds
+                "depth": queue.depth,
+                "oldest_age_seconds": queue.oldest_age_seconds
             },
             "throughput": {
-                "incoming_per_min": ((incoming_events as f64 / window_minutes) * 100.0).round() / 100.0,
-                "outgoing_per_min": ((outgoing_events as f64 / window_minutes) * 100.0).round() / 100.0
+                "incoming_per_min": ((tput.incoming as f64 / window_minutes) * 100.0).round() / 100.0,
+                "outgoing_per_min": ((tput.outgoing as f64 / window_minutes) * 100.0).round() / 100.0
             },
             "delivery": {
                 "success_rate": (success_rate * 10000.0).round() / 10000.0,
-                "smtp_4xx_rate": if total == 0 { 0.0 } else { ((smtp_4xx as f64 / total as f64) * 10000.0).round() / 10000.0 },
-                "smtp_5xx_rate": if total == 0 { 0.0 } else { ((smtp_5xx as f64 / total as f64) * 10000.0).round() / 10000.0 },
-                "p95_total_ms": p95
+                "smtp_4xx_rate": if smtp.total == 0 { 0.0 } else { ((tput.smtp_4xx as f64 / smtp.total as f64) * 10000.0).round() / 10000.0 },
+                "smtp_5xx_rate": if smtp.total == 0 { 0.0 } else { ((tput.smtp_5xx as f64 / smtp.total as f64) * 10000.0).round() / 10000.0 },
+                "p95_total_ms": smtp.p95
             }
         },
         "proactive_alerting": {
             "threshold_alerts": {
-                "queue_growth": queue_growth_alerts,
-                "auth_failures": auth_failure_alerts,
+                "queue_growth": alerts.queue_growth,
+                "auth_failures": alerts.auth_failures,
                 "imap_latency_alert": env::var("IMAP_P95_MS").ok().and_then(|v| v.parse::<u64>().ok()).map(|v| v > env::var("IMAP_P95_MS_THRESHOLD").ok().and_then(|t| t.parse::<u64>().ok()).unwrap_or(4000)).unwrap_or(false)
             },
             "anomaly_detection": {
-                "anomaly_alerts": anomaly_alerts,
-                "spam_or_volume_spike": anomaly_alerts > 0,
-                "sudden_bounce_signal": monitoring_alerts.iter().any(|a| a.kind == "bounce_rate")
+                "anomaly_alerts": alerts.anomalies,
+                "spam_or_volume_spike": alerts.anomalies > 0,
+                "sudden_bounce_signal": alerts.monitoring.iter().any(|a| a.kind == "bounce_rate")
             },
             "correlation": {
-                "smtp": { "events": total, "smtp_4xx": smtp_4xx, "smtp_5xx": smtp_5xx },
+                "smtp": { "events": smtp.total, "smtp_4xx": tput.smtp_4xx, "smtp_5xx": tput.smtp_5xx },
                 "imap": {
                     "active_connections": env::var("IMAP_ACTIVE_CONNECTIONS").ok().and_then(|v| v.parse::<u64>().ok()),
                     "p95_ms": env::var("IMAP_P95_MS").ok().and_then(|v| v.parse::<u64>().ok())
                 },
-                "dns": { "lookup_issue_events": dns_issue_events },
+                "dns": { "lookup_issue_events": tput.dns_issue_events },
                 "blacklist": {
-                    "sources": rbl_sources,
-                    "listed_by": rbl_listed_by,
+                    "sources": rbl_sources(),
+                    "listed_by": rbl_listed_by(),
                     "listed": !env::var("RBL_LISTED_BY").unwrap_or_default().trim().is_empty()
                 }
             }
         },
         "security_deliverability": {
             "suspicious_logins_top": suspicious_logins_top,
-            "active_security_alerts": security_alerts.len(),
-            "active_monitoring_alerts": monitoring_alerts.len()
+            "active_security_alerts": alerts.security.len(),
+            "active_monitoring_alerts": alerts.monitoring.len()
         },
         "imap": {
             "active_connections": env::var("IMAP_ACTIVE_CONNECTIONS").ok().and_then(|v| v.parse::<u64>().ok()),
             "note": "Connecter un compteur runtime IMAP pour une métrique live fiable"
         },
         "realtime_alerts": {
-            "monitoring_active": monitoring_alerts.len(),
-            "security_active": security_alerts.len()
+            "monitoring_active": alerts.monitoring.len(),
+            "security_active": alerts.security.len()
         },
         "per_domain": per_domain,
         "exports": {

--- a/src/bin/email_api_dir/admin_ops/diag_handlers/observability.rs
+++ b/src/bin/email_api_dir/admin_ops/diag_handlers/observability.rs
@@ -9,7 +9,7 @@ struct SmtpStatusStats {
     failed: u64,
     deferred: u64,
     by_status: serde_json::Map<String, serde_json::Value>,
-    p95: u64,
+    p95: Option<u64>,
 }
 
 async fn collect_smtp_stats(

--- a/src/bin/email_api_dir/admin_ops/user_handlers/lifecycle.rs
+++ b/src/bin/email_api_dir/admin_ops/user_handlers/lifecycle.rs
@@ -148,6 +148,55 @@ pub(crate) async fn api_admin_user_invite(
     }))
 }
 
+/// Génère un mot de passe temporaire (16 chars, avec 2 symboles) conforme
+/// aux politiques classiques.
+fn generate_temp_password() -> String {
+    let a = Uuid::new_v4().simple().to_string();
+    let b = Uuid::new_v4().simple().to_string();
+    let mixed = format!("{}{}", &a[..7], &b[..7]);
+    format!("{}!{}#", &mixed[..7], &mixed[7..])
+}
+
+/// Résout le mot de passe à appliquer : celui fourni par l'admin ou un
+/// mot de passe temporaire généré. Retourne (password, generated).
+fn resolve_new_password(input: &Option<String>) -> (String, bool) {
+    match input {
+        Some(p) if !p.trim().is_empty() => (p.trim().to_string(), false),
+        _ => (generate_temp_password(), true),
+    }
+}
+
+/// Propage le nouveau hash à la collection `users` (login classique + IMAP/SMTP).
+/// Non-bloquant : seulement un log en cas d'erreur.
+async fn sync_users_password(
+    mongo: &Arc<mongodb::Client>,
+    email: &str,
+    hash: &str,
+) {
+    let users_coll = mongo
+        .database(&mongo_db_name())
+        .collection::<mongodb::bson::Document>("users");
+    if let Err(e) = users_coll
+        .update_one(
+            doc! { "username": email },
+            doc! { "$set": { "password": hash } },
+        )
+        .await
+    {
+        eprintln!("reset_password: users sync warning: {}", e);
+    }
+}
+
+/// Supprime toutes les sessions actives d'un user (best-effort).
+async fn revoke_all_sessions(mongo: &Arc<mongodb::Client>, user_id: &str) {
+    let sessions = mongo
+        .database(&mongo_db_name())
+        .collection::<admin_auth::AdminSession>(admin_auth::ADMIN_SESSIONS_COLL);
+    if let Err(e) = sessions.delete_many(doc! { "user_id": user_id }).await {
+        eprintln!("reset_password: revoke sessions error: {}", e);
+    }
+}
+
 /// POST /api/admin/users/{id}/reset-password
 ///
 /// Définit un nouveau mot de passe (bcrypt) sur l'AdminUserRecord.
@@ -180,35 +229,12 @@ pub(crate) async fn api_admin_user_reset_password(
         }
     };
 
-    // Si aucun mot de passe fourni, on génère un temporaire (16 chars,
-    // alphanumérique + 2 symboles insérés à des positions déterministes).
-    // Base: 2 UUID hex concaténés (32 chars aléatoires) tronqués à 14,
-    // puis '!' et '#' injectés pour satisfaire les politiques classiques.
-    let (new_password, generated) = match &body.new_password {
-        Some(p) if !p.trim().is_empty() => (p.trim().to_string(), false),
-        _ => {
-            let a = Uuid::new_v4().simple().to_string();
-            let b = Uuid::new_v4().simple().to_string();
-            let mixed = format!("{}{}", &a[..7], &b[..7]);
-            // Insertion de 2 symboles à positions fixes → 16 chars finaux.
-            let temp = format!("{}!{}#", &mixed[..7], &mixed[7..]);
-            (temp, true)
-        }
-    };
-
+    let (new_password, generated) = resolve_new_password(&body.new_password);
     if new_password.len() < 8 {
         return HttpResponse::BadRequest()
             .json(serde_json::json!({ "message": "password must be at least 8 chars" }));
     }
-
-    // Conserver la valeur en clair pour la réponse (uniquement dans le cas
-    // `generated=true` — pour un mot de passe fourni par l'admin, aucun
-    // intérêt à le lui renvoyer).
-    let clear_for_response = if generated {
-        Some(new_password.clone())
-    } else {
-        None
-    };
+    let clear_for_response = if generated { Some(new_password.clone()) } else { None };
 
     let hash = match web::block(move || bcrypt::hash(&new_password, 12)).await {
         Ok(Ok(h)) => h,
@@ -227,7 +253,6 @@ pub(crate) async fn api_admin_user_reset_password(
     let now = now_iso();
     user.password_hash = Some(hash.clone());
     user.updated_at = now.clone();
-    // Consommer un éventuel jeton d'invitation en cours.
     user.invite_token = None;
     user.invite_expires_at = None;
     let mut recent = user.recent_activity.clone();
@@ -256,35 +281,9 @@ pub(crate) async fn api_admin_user_reset_password(
             .json(serde_json::json!({ "message": "Failed to update password" }));
     }
 
-    // Propager le hash à la collection `users` (utilisée par
-    // `authenticate_user` pour le login classique + IMAP/SMTP). Sans cette
-    // synchro, l'admin définit un nouveau mot de passe côté `admin_users`
-    // mais l'utilisateur reste incapable de se connecter.
-    // Le match se fait sur `username = email` (convention Misfits Mail).
-    let users_coll = mongo
-        .database(&mongo_db_name())
-        .collection::<mongodb::bson::Document>("users");
-    if let Err(e) = users_coll
-        .update_one(
-            doc! { "username": &user.email },
-            doc! { "$set": { "password": &hash } },
-        )
-        .await
-    {
-        // Non-bloquant: on log mais on renvoie succès. Le hash reste
-        // désynchronisé si `users` ne contient pas encore ce username —
-        // c'est le cas si le compte a été créé UNIQUEMENT côté admin.
-        eprintln!("reset_password: users sync warning: {}", e);
-    }
-
-    // Révocation des sessions optionnelle.
+    sync_users_password(&mongo, &user.email, &hash).await;
     if body.revoke_sessions {
-        let sessions = mongo
-            .database(&mongo_db_name())
-            .collection::<admin_auth::AdminSession>(admin_auth::ADMIN_SESSIONS_COLL);
-        if let Err(e) = sessions.delete_many(doc! { "user_id": &id }).await {
-            eprintln!("reset_password: revoke sessions error: {}", e);
-        }
+        revoke_all_sessions(&mongo, &id).await;
     }
 
     log_admin_action(
@@ -302,9 +301,6 @@ pub(crate) async fn api_admin_user_reset_password(
         "reset": true,
         "user": user,
         "generated": generated,
-        // Mot de passe en clair — présent UNIQUEMENT si `generated=true`.
-        // L'admin doit le communiquer au propriétaire hors-bande puis
-        // exiger un changement à la prochaine connexion.
         "password": clear_for_response,
     }))
 }

--- a/src/bin/email_api_dir/startup.rs
+++ b/src/bin/email_api_dir/startup.rs
@@ -77,86 +77,91 @@ pub(crate) fn build_cors_layer() -> Cors {
         .max_age(3600)
 }
 
-/// Register all HTTP routes on the given ServiceConfig.
-///
-/// This mirrors the previous inline `.route(...)` chain in `main()`.
-#[allow(clippy::too_many_lines)]
-pub(crate) fn register_http_routes(cfg: &mut web::ServiceConfig) {
+/// Documentation & OpenAPI routes.
+fn register_docs_routes(cfg: &mut web::ServiceConfig) {
     cfg.route("/api/openapi.json", web::get().to(api_openapi_json))
         .route("/api/docs", web::get().to(api_swagger_ui))
         .route(
             "/api/openapi/external-imap.yaml",
             web::get().to(api_external_openapi),
-        )
-        .route(
-            "/api/external-accounts",
-            web::get().to(api_external_accounts_list),
-        )
-        .route(
-            "/api/external-accounts/probe-stream",
-            web::post().to(external_probe_handlers::api_external_probe_stream),
-        )
-        .route(
-            "/api/external-accounts",
-            web::post().to(api_external_accounts_create),
-        )
-        .route(
-            "/api/external-accounts/{id}",
-            web::get().to(api_external_account_get),
-        )
-        .route(
-            "/api/external-accounts/{id}",
-            web::patch().to(api_external_account_patch),
-        )
-        .route(
-            "/api/external-accounts/{id}",
-            web::delete().to(api_external_account_delete),
-        )
-        .route(
-            "/api/external-accounts/{id}/test",
-            web::post().to(api_external_account_test),
-        )
-        .route(
-            "/api/external-accounts/{id}/folders",
-            web::get().to(api_external_folders_list),
-        )
-        .route(
-            "/api/external-accounts/{id}/folders/discover",
-            web::post().to(api_external_folders_discover),
-        )
-        .route(
-            "/api/external-accounts/{id}/folders/{folder_id}/mapping",
-            web::put().to(api_external_folder_mapping_put),
-        )
-        .route(
-            "/api/external-accounts/{id}/sync",
-            web::post().to(api_external_sync_start),
-        )
-        .route(
-            "/api/external-accounts/{id}/sync/status",
-            web::get().to(api_external_sync_status),
-        )
-        .route(
-            "/api/external-accounts/{id}/sync/pause",
-            web::post().to(api_external_sync_pause),
-        )
-        .route(
-            "/api/external-accounts/{id}/sync/resume",
-            web::post().to(api_external_sync_resume),
-        )
-        .route(
-            "/api/external-sync-runs/{run_id}",
-            web::get().to(api_external_sync_run_get),
-        )
-        .route(
-            "/api/external-messages",
-            web::get().to(api_external_messages_list),
-        )
-        .route(
-            "/api/external-messages/{id}/action",
-            web::post().to(api_external_message_action),
-        )
-        .route("/api/auth/login", web::post().to(auth_login))
+        );
+}
+
+/// External IMAP account routes.
+fn register_external_routes(cfg: &mut web::ServiceConfig) {
+    cfg.route(
+        "/api/external-accounts",
+        web::get().to(api_external_accounts_list),
+    )
+    .route(
+        "/api/external-accounts/probe-stream",
+        web::post().to(external_probe_handlers::api_external_probe_stream),
+    )
+    .route(
+        "/api/external-accounts",
+        web::post().to(api_external_accounts_create),
+    )
+    .route(
+        "/api/external-accounts/{id}",
+        web::get().to(api_external_account_get),
+    )
+    .route(
+        "/api/external-accounts/{id}",
+        web::patch().to(api_external_account_patch),
+    )
+    .route(
+        "/api/external-accounts/{id}",
+        web::delete().to(api_external_account_delete),
+    )
+    .route(
+        "/api/external-accounts/{id}/test",
+        web::post().to(api_external_account_test),
+    )
+    .route(
+        "/api/external-accounts/{id}/folders",
+        web::get().to(api_external_folders_list),
+    )
+    .route(
+        "/api/external-accounts/{id}/folders/discover",
+        web::post().to(api_external_folders_discover),
+    )
+    .route(
+        "/api/external-accounts/{id}/folders/{folder_id}/mapping",
+        web::put().to(api_external_folder_mapping_put),
+    )
+    .route(
+        "/api/external-accounts/{id}/sync",
+        web::post().to(api_external_sync_start),
+    )
+    .route(
+        "/api/external-accounts/{id}/sync/status",
+        web::get().to(api_external_sync_status),
+    )
+    .route(
+        "/api/external-accounts/{id}/sync/pause",
+        web::post().to(api_external_sync_pause),
+    )
+    .route(
+        "/api/external-accounts/{id}/sync/resume",
+        web::post().to(api_external_sync_resume),
+    )
+    .route(
+        "/api/external-sync-runs/{run_id}",
+        web::get().to(api_external_sync_run_get),
+    )
+    .route(
+        "/api/external-messages",
+        web::get().to(api_external_messages_list),
+    )
+    .route(
+        "/api/external-messages/{id}/action",
+        web::post().to(api_external_message_action),
+    );
+}
+
+/// Auth & user session routes.
+fn register_auth_routes(cfg: &mut web::ServiceConfig) {
+    cfg.route("/api/auth/login", web::post().to(auth_login))
         .route("/api/auth/register", web::post().to(auth_register))
         .route("/api/auth/logout", web::post().to(auth_logout))
         .route("/api/auth/refresh", web::post().to(auth_refresh))
@@ -181,8 +186,12 @@ pub(crate) fn register_http_routes(cfg: &mut web::ServiceConfig) {
         .route(
             "/api/auth/oauth/{provider}/callback",
             web::get().to(auth_oauth_callback),
-        )
-        .route("/api/emails", web::get().to(api_emails))
+        );
+}
+
+/// Mailbox / send / drafts / templates / hermes / calendar routes.
+fn register_mailbox_routes(cfg: &mut web::ServiceConfig) {
+    cfg.route("/api/emails", web::get().to(api_emails))
         .route("/api/emails/{id}", web::get().to(api_email_by_id))
         .route(
             "/api/emails/{id}/attachments/{attachment_id}",
@@ -233,8 +242,12 @@ pub(crate) fn register_http_routes(cfg: &mut web::ServiceConfig) {
         .route(
             "/send-to-mailing-list",
             web::post().to(send_to_mailing_list),
-        )
-        .route("/api/events", web::get().to(api_events))
+        );
+}
+
+/// Monitoring / security / diagnostics routes.
+fn register_diag_routes(cfg: &mut web::ServiceConfig) {
+    cfg.route("/api/events", web::get().to(api_events))
         .route("/api/events/stream", web::get().to(api_events_stream))
         .route(
             "/api/monitoring/summary",
@@ -277,8 +290,12 @@ pub(crate) fn register_http_routes(cfg: &mut web::ServiceConfig) {
         .route(
             "/api/security/remediation/{alert_id}/rollback",
             web::post().to(api_security_rollback),
-        )
-        .route("/api/admin/users", web::get().to(api_admin_users_list))
+        );
+}
+
+/// Admin routes (users, change-requests, deliverability, observability).
+fn register_admin_routes(cfg: &mut web::ServiceConfig) {
+    cfg.route("/api/admin/users", web::get().to(api_admin_users_list))
         .route("/api/admin/users", web::post().to(api_admin_user_create))
         .route("/api/admin/whoami", web::get().to(api_admin_whoami))
         .route("/api/admin/audit-log", web::get().to(api_admin_audit_log))
@@ -343,4 +360,16 @@ pub(crate) fn register_http_routes(cfg: &mut web::ServiceConfig) {
             "/api/admin/observability/overview",
             web::get().to(api_admin_observability_overview),
         );
+}
+
+/// Register all HTTP routes on the given ServiceConfig.
+///
+/// Composed from domain-specific registrations to keep each helper small.
+pub(crate) fn register_http_routes(cfg: &mut web::ServiceConfig) {
+    register_docs_routes(cfg);
+    register_external_routes(cfg);
+    register_auth_routes(cfg);
+    register_mailbox_routes(cfg);
+    register_diag_routes(cfg);
+    register_admin_routes(cfg);
 }

--- a/src/logic/mongo_adapter/users.rs
+++ b/src/logic/mongo_adapter/users.rs
@@ -9,23 +9,32 @@ use mongodb::error::Result;
 #[allow(dead_code)]
 impl MongoDatabaseAdapter {
     pub async fn insert_user_impl(&self, user: User) -> Result<()> {
+        let username = user.username.clone();
+        let users = self.users_collection();
+        users.insert_one(user).await?;
+        self.ensure_default_mailboxes(&username).await?;
+        Ok(())
+    }
+
+    /// Retourne la collection MongoDB `users` (nom depuis env).
+    fn users_collection(&self) -> mongodb::Collection<User> {
         let db_name = Self::database_name();
         let coll_name = Self::users_collection_name();
-        let username = user.username.clone();
-
-        let users = self
-            .client
+        self.client
             .database(&db_name)
-            .collection::<User>(&coll_name);
-        users.insert_one(user).await?;
+            .collection::<User>(&coll_name)
+    }
 
-        // Créer les mailboxes standard (comportement historique de create_user).
+    /// Crée les mailboxes standard (inbox/sent/drafts/archive/trash) pour un user
+    /// si elles n'existent pas déjà — comportement historique de `create_user`.
+    async fn ensure_default_mailboxes(&self, username: &str) -> Result<()> {
+        let db_name = Self::database_name();
         let mailboxes = self
             .client
             .database(&db_name)
             .collection::<Mailbox>("mailboxes");
         for &name in &["inbox", "sent", "drafts", "archive", "trash"] {
-            let filter = doc! { "name": name, "user_id": &username };
+            let filter = doc! { "name": name, "user_id": username };
             if mailboxes.find_one(filter).await?.is_none() {
                 let mailbox = Mailbox {
                     name: name.to_string(),
@@ -36,7 +45,7 @@ impl MongoDatabaseAdapter {
                     permanent_flags: vec![],
                     uid_validity: 1,
                     uid_next: 1,
-                    user_id: username.clone(),
+                    user_id: username.to_string(),
                 };
                 mailboxes.insert_one(mailbox).await?;
             }

--- a/src/monitoring/alerts.rs
+++ b/src/monitoring/alerts.rs
@@ -40,112 +40,131 @@ pub struct ActiveAlert {
     pub ts: String,
 }
 
-pub async fn evaluate_alerts(
-    client: &Client,
+/// Contexte partagé pour chaque règle : accès mongo + fenêtre.
+struct AlertCtx<'a> {
+    client: &'a Client,
+    db: String,
+    since_str: String,
     window_minutes: i64,
-    config: &AlertConfig,
-) -> Vec<ActiveAlert> {
-    let since_str = (Utc::now() - ChronoDuration::minutes(window_minutes)).to_rfc3339();
-    let db = std::env::var("MONGODB_DATABASE").unwrap_or_else(|_| "mailserver".to_string());
-    let coll = client
-        .database(&db)
-        .collection::<mongodb::bson::Document>("smtp_events");
+    config: &'a AlertConfig,
+}
 
-    let mut alerts = Vec::new();
+impl<'a> AlertCtx<'a> {
+    fn events_coll(&self) -> mongodb::Collection<mongodb::bson::Document> {
+        self.client
+            .database(&self.db)
+            .collection::<mongodb::bson::Document>("smtp_events")
+    }
+}
 
-    // --- Bounce rate ---
+async fn check_bounce_rate(ctx: &AlertCtx<'_>) -> Option<ActiveAlert> {
+    let coll = ctx.events_coll();
     let total = coll
-        .count_documents(doc! { "ts": { "$gte": &since_str } })
+        .count_documents(doc! { "ts": { "$gte": &ctx.since_str } })
         .await
         .unwrap_or(0);
-    if total > 0 {
-        let bounced = coll
-            .count_documents(doc! { "ts": { "$gte": &since_str }, "status": "bounced" })
-            .await
-            .unwrap_or(0);
-        let rate = bounced as f32 / total as f32;
-        if rate > config.bounce_rate_threshold {
-            alerts.push(ActiveAlert {
-                kind: "bounce_rate".into(),
-                severity: "high".into(),
-                message: format!(
-                    "Bounce rate {:.1}% exceeds threshold {:.1}%",
-                    rate * 100.0,
-                    config.bounce_rate_threshold * 100.0
-                ),
-                value: serde_json::json!(rate),
-                threshold: serde_json::json!(config.bounce_rate_threshold),
-                ts: Utc::now().to_rfc3339(),
-            });
-        }
+    if total == 0 {
+        return None;
     }
+    let bounced = coll
+        .count_documents(doc! { "ts": { "$gte": &ctx.since_str }, "status": "bounced" })
+        .await
+        .unwrap_or(0);
+    let rate = bounced as f32 / total as f32;
+    if rate <= ctx.config.bounce_rate_threshold {
+        return None;
+    }
+    Some(ActiveAlert {
+        kind: "bounce_rate".into(),
+        severity: "high".into(),
+        message: format!(
+            "Bounce rate {:.1}% exceeds threshold {:.1}%",
+            rate * 100.0,
+            ctx.config.bounce_rate_threshold * 100.0
+        ),
+        value: serde_json::json!(rate),
+        threshold: serde_json::json!(ctx.config.bounce_rate_threshold),
+        ts: Utc::now().to_rfc3339(),
+    })
+}
 
-    // --- SMTP error code spikes (421, 450, 550, 554) ---
+async fn check_smtp_spikes(ctx: &AlertCtx<'_>) -> Vec<ActiveAlert> {
+    let coll = ctx.events_coll();
+    let mut out = Vec::new();
     for &code in &[421u32, 450, 550, 554] {
         let count = coll
             .count_documents(doc! {
-                "ts": { "$gte": &since_str },
+                "ts": { "$gte": &ctx.since_str },
                 "smtp_code": code as i32,
             })
             .await
             .unwrap_or(0);
-        if count >= config.smtp_spike_threshold {
+        if count >= ctx.config.smtp_spike_threshold {
             let severity = if code >= 550 { "critical" } else { "warning" };
-            alerts.push(ActiveAlert {
+            out.push(ActiveAlert {
                 kind: format!("smtp_spike_{}", code),
                 severity: severity.into(),
                 message: format!(
                     "SMTP {} errors: {} occurrences in {}m window (threshold: {})",
-                    code, count, window_minutes, config.smtp_spike_threshold
+                    code, count, ctx.window_minutes, ctx.config.smtp_spike_threshold
                 ),
                 value: serde_json::json!(count),
-                threshold: serde_json::json!(config.smtp_spike_threshold),
+                threshold: serde_json::json!(ctx.config.smtp_spike_threshold),
                 ts: Utc::now().to_rfc3339(),
             });
         }
     }
+    out
+}
 
-    // --- Forbidden countries ---
-    if !config.forbidden_countries.is_empty() {
-        let countries_bson: Vec<_> = config
-            .forbidden_countries
-            .iter()
-            .map(|c| mongodb::bson::Bson::String(c.clone()))
-            .collect();
-        let count = coll
-            .count_documents(doc! {
-                "ts": { "$gte": &since_str },
-                "country": { "$in": countries_bson },
-            })
-            .await
-            .unwrap_or(0);
-        if count > 0 {
-            alerts.push(ActiveAlert {
-                kind: "forbidden_country".into(),
-                severity: "critical".into(),
-                message: format!(
-                    "{} email(s) routed via forbidden countries {:?}",
-                    count, config.forbidden_countries
-                ),
-                value: serde_json::json!(count),
-                threshold: serde_json::json!(0),
-                ts: Utc::now().to_rfc3339(),
-            });
-        }
+async fn check_forbidden_countries(ctx: &AlertCtx<'_>) -> Option<ActiveAlert> {
+    if ctx.config.forbidden_countries.is_empty() {
+        return None;
     }
+    let countries_bson: Vec<_> = ctx
+        .config
+        .forbidden_countries
+        .iter()
+        .map(|c| mongodb::bson::Bson::String(c.clone()))
+        .collect();
+    let count = ctx
+        .events_coll()
+        .count_documents(doc! {
+            "ts": { "$gte": &ctx.since_str },
+            "country": { "$in": countries_bson },
+        })
+        .await
+        .unwrap_or(0);
+    if count == 0 {
+        return None;
+    }
+    Some(ActiveAlert {
+        kind: "forbidden_country".into(),
+        severity: "critical".into(),
+        message: format!(
+            "{} email(s) routed via forbidden countries {:?}",
+            count, ctx.config.forbidden_countries
+        ),
+        value: serde_json::json!(count),
+        threshold: serde_json::json!(0),
+        ts: Utc::now().to_rfc3339(),
+    })
+}
 
-    // --- Forbidden companies / infrastructure ---
-    for company in &config.forbidden_companies {
+async fn check_forbidden_companies(ctx: &AlertCtx<'_>) -> Vec<ActiveAlert> {
+    let coll = ctx.events_coll();
+    let mut out = Vec::new();
+    for company in &ctx.config.forbidden_companies {
         let count = coll
             .count_documents(doc! {
-                "ts": { "$gte": &since_str },
+                "ts": { "$gte": &ctx.since_str },
                 "company": { "$regex": company.as_str(), "$options": "i" },
             })
             .await
             .unwrap_or(0);
         if count > 0 {
-            alerts.push(ActiveAlert {
-                kind: format!("forbidden_company"),
+            out.push(ActiveAlert {
+                kind: "forbidden_company".to_string(),
                 severity: "critical".into(),
                 message: format!(
                     "{} email(s) routed via forbidden company '{}'",
@@ -157,62 +176,96 @@ pub async fn evaluate_alerts(
             });
         }
     }
+    out
+}
 
-    // --- Silent delivery failures: mail_events.sent with no smtp delivery ---
-    // Catches emails the API recorded as "sent" but that never reached send_outgoing_email.
-    let mail_coll = client
-        .database(&db)
+async fn check_silent_delivery_failures(ctx: &AlertCtx<'_>) -> Option<ActiveAlert> {
+    let mail_coll = ctx
+        .client
+        .database(&ctx.db)
         .collection::<mongodb::bson::Document>("mail_events");
     let api_sent = mail_coll
-        .count_documents(doc! { "timestamp": { "$gte": &since_str }, "kind": "sent" })
+        .count_documents(doc! { "timestamp": { "$gte": &ctx.since_str }, "kind": "sent" })
         .await
         .unwrap_or(0);
-    if api_sent > 0 {
-        let smtp_delivered = coll
-            .count_documents(doc! { "ts": { "$gte": &since_str }, "event_type": "delivered" })
-            .await
-            .unwrap_or(0);
-        let undelivered = api_sent.saturating_sub(smtp_delivered);
-        let ratio = undelivered as f32 / api_sent as f32;
-        if ratio > config.undelivered_ratio_threshold {
-            alerts.push(ActiveAlert {
-                kind: "silent_delivery_failure".into(),
-                severity: "critical".into(),
-                message: format!(
-                    "{} email(s) recorded as sent by API but no SMTP delivery event ({:.1}% undelivered)",
-                    undelivered,
-                    ratio * 100.0
-                ),
-                value: serde_json::json!(undelivered),
-                threshold: serde_json::json!(config.undelivered_ratio_threshold),
-                ts: Utc::now().to_rfc3339(),
-            });
-        }
+    if api_sent == 0 {
+        return None;
     }
+    let smtp_delivered = ctx
+        .events_coll()
+        .count_documents(doc! { "ts": { "$gte": &ctx.since_str }, "event_type": "delivered" })
+        .await
+        .unwrap_or(0);
+    let undelivered = api_sent.saturating_sub(smtp_delivered);
+    let ratio = undelivered as f32 / api_sent as f32;
+    if ratio <= ctx.config.undelivered_ratio_threshold {
+        return None;
+    }
+    Some(ActiveAlert {
+        kind: "silent_delivery_failure".into(),
+        severity: "critical".into(),
+        message: format!(
+            "{} email(s) recorded as sent by API but no SMTP delivery event ({:.1}% undelivered)",
+            undelivered,
+            ratio * 100.0
+        ),
+        value: serde_json::json!(undelivered),
+        threshold: serde_json::json!(ctx.config.undelivered_ratio_threshold),
+        ts: Utc::now().to_rfc3339(),
+    })
+}
 
-    // --- P95 latency ---
+async fn check_p95_latency(ctx: &AlertCtx<'_>) -> Option<ActiveAlert> {
     let p95 = super::storage::p95_total_ms(
-        client,
-        doc! { "ts": { "$gte": &since_str } },
+        ctx.client,
+        doc! { "ts": { "$gte": &ctx.since_str } },
         1000,
     )
-    .await;
-    if let Some(p95_ms) = p95 {
-        if p95_ms > config.p95_total_ms_threshold {
-            alerts.push(ActiveAlert {
-                kind: "p95_latency".into(),
-                severity: "warning".into(),
-                message: format!(
-                    "P95 total_ms {}ms exceeds threshold {}ms",
-                    p95_ms, config.p95_total_ms_threshold
-                ),
-                value: serde_json::json!(p95_ms),
-                threshold: serde_json::json!(config.p95_total_ms_threshold),
-                ts: Utc::now().to_rfc3339(),
-            });
-        }
+    .await?;
+    if p95 <= ctx.config.p95_total_ms_threshold {
+        return None;
     }
+    Some(ActiveAlert {
+        kind: "p95_latency".into(),
+        severity: "warning".into(),
+        message: format!(
+            "P95 total_ms {}ms exceeds threshold {}ms",
+            p95, ctx.config.p95_total_ms_threshold
+        ),
+        value: serde_json::json!(p95),
+        threshold: serde_json::json!(ctx.config.p95_total_ms_threshold),
+        ts: Utc::now().to_rfc3339(),
+    })
+}
 
+pub async fn evaluate_alerts(
+    client: &Client,
+    window_minutes: i64,
+    config: &AlertConfig,
+) -> Vec<ActiveAlert> {
+    let ctx = AlertCtx {
+        client,
+        db: std::env::var("MONGODB_DATABASE").unwrap_or_else(|_| "mailserver".to_string()),
+        since_str: (Utc::now() - ChronoDuration::minutes(window_minutes)).to_rfc3339(),
+        window_minutes,
+        config,
+    };
+
+    let mut alerts = Vec::new();
+    if let Some(a) = check_bounce_rate(&ctx).await {
+        alerts.push(a);
+    }
+    alerts.extend(check_smtp_spikes(&ctx).await);
+    if let Some(a) = check_forbidden_countries(&ctx).await {
+        alerts.push(a);
+    }
+    alerts.extend(check_forbidden_companies(&ctx).await);
+    if let Some(a) = check_silent_delivery_failures(&ctx).await {
+        alerts.push(a);
+    }
+    if let Some(a) = check_p95_latency(&ctx).await {
+        alerts.push(a);
+    }
     alerts
 }
 


### PR DESCRIPTION
Décompose 5 god functions Rust > 150 LOC.\n\n- [x] startup::register_http_routes 263→9 LOC (split par domaine)\n- [x] observability_overview 270→~50 LOC (5 helpers de collecte)\n- [ ] monitoring::alerts::evaluate_alerts 175 LOC\n- [ ] logic::traits (insert_user_impl) 162 LOC\n- [ ] admin_user_reset_password 156 LOC\n\nAucun changement comportemental. arch_guard OK.