### PR TITLE
refactor(rust): decompose dispatch_command + send_via_mx (cycle 13)

### DIFF
--- a/src/imap_server/commands.rs
+++ b/src/imap_server/commands.rs
@@ -1,10 +1,12 @@
 use super::*;
 
+type Sessions = Arc<Mutex<HashMap<String, String>>>;
+
 impl ImapServer {
     pub(super) async fn dispatch_command(
         &mut self,
         command_parts: &[&str],
-        sessions: &Arc<Mutex<HashMap<String, String>>>,
+        sessions: &Sessions,
         session_id: &mut Option<String>,
     ) -> String {
         let tag = command_parts[0];
@@ -16,356 +18,304 @@ impl ImapServer {
         );
 
         match command_name.as_str() {
-            "APPEND" => {
-                if command_parts.len() < 5 {
-                    return format!("{} BAD APPEND requires a mailbox name and message\r\n", tag);
-                }
-                println!("Command parts: {:?}", command_parts);
-                self.mailbox = command_parts[2].trim_matches('"').to_string();
-                self.message_size = command_parts[4].trim_matches(|c| c == '{' || c == '}').parse::<usize>().unwrap_or(0);
-
-                if self.message_size == 0 {
-                    return format!("{} BAD APPEND failed: Message size is zero\r\n", tag);
-                }
-                self.tag = tag.to_string();
-                self.expecting_message = true;
-
-                return format!("{} OK APPEND command received, waiting for message content\r\n", tag);
-            }
+            "APPEND" => self.handle_append(tag, command_parts),
             "CAPABILITY" => format!("* CAPABILITY IMAP4rev1 AUTH=PLAIN LOGIN IDLE UIDPLUS MULTIAPPEND\r\n{} OK CAPABILITY completed\r\n", tag),
             "NOOP" => format!("{} OK NOOP completed\r\n", tag),
-            "LOGOUT" => {
-                if let Some(id) = session_id.take() {
-                    sessions.lock().unwrap().remove(&id);
-                }
-                format!("* BYE IMAP4rev1 Server logging out\r\n{} OK LOGOUT completed\r\n", tag)
-            }
-            "LOGIN" => {
-                if command_parts.len() < 4 {
-                    return format!("{} BAD LOGIN requires a username and password\r\n", tag);
-                }
-                let username = command_parts[2].trim_matches('"');
-                let password = command_parts[3].trim_matches('"');
-
-                match self.logic.authenticate_user(username, password).await {
-                    Ok(Some(user)) => {
-                        let new_session_id = Uuid::new_v4().to_string();
-                        sessions.lock().unwrap().insert(new_session_id.clone(), user.username.clone());
-                        *session_id = Some(new_session_id);
-                        format!("{} OK LOGIN completed\r\n", tag)
-                    }
-                    Ok(None) => {
-                        sleep(Duration::from_secs(1)).await;
-                        format!("{} NO LOGIN failed: Invalid credentials\r\n", tag)
-                    }
-                    Err(_) => format!("{} NO LOGIN failed: Internal error\r\n", tag),
-                }
-            }
-            "LIST" => {
-                let reference = command_parts.get(2).unwrap_or(&"");
-                let mailbox = command_parts.get(3).unwrap_or(&"*");
-                if let Some(id) = session_id {
-                    let username = sessions.lock().unwrap().get(id).cloned();
-                    if let Some(user) = username {
-                        match self.logic.list_mailboxes(&user, reference, mailbox).await {
-                            Ok(mailboxes) => {
-                                let mut response = String::new();
-                                for mailbox in mailboxes {
-                                    response.push_str(&format!("* LIST (\\HasNoChildren) \"/\" \"{}\"\r\n", mailbox));
-                                }
-                                response.push_str(&format!("{} OK LIST completed\r\n", tag));
-                                response
-                            }
-                            Err(_) => format!("{} NO LIST failed: Internal error\r\n", tag),
-                        }
-                    } else {
-                        format!("{} NO LIST failed: User not authenticated\r\n", tag)
-                    }
-                } else {
-                    format!("{} NO LIST failed: User not authenticated\r\n", tag)
-                }
-            }
-            "SELECT" => {
-                if command_parts.len() < 3 {
-                    return format!("{} BAD SELECT requires a mailbox name\r\n", tag);
-                }
-                let mailbox = command_parts[2];
-                if let Some(id) = session_id {
-                    let username = sessions.lock().unwrap().get(id).cloned();
-                    if let Some(user) = username {
-                        match self.logic.select_mailbox(&user, mailbox).await {
-                            Ok(status) => {
-                                let flags = "\\Seen \\Answered \\Flagged \\Deleted \\Draft";
-                                let exists = status.exists;
-                                let recent = status.recent;
-                                let unseen = status.unseen;
-                                let uid_validity = status.uid_validity;
-                                let uid_next = status.uid_next;
-                                format!(
-                                    "* FLAGS ({})\r\n* {} EXISTS\r\n* {} RECENT\r\n* OK [UNSEEN {}] Message {} is first unseen\r\n* OK [UIDVALIDITY {}] UIDs valid\r\n* OK [UIDNEXT {}] Predicted next UID\r\n{} OK [READ-WRITE] SELECT completed\r\n",
-                                    flags, exists, recent, unseen, unseen, uid_validity, uid_next, tag
-                                )
-                            }
-                            Err(_) => format!("{} NO SELECT failed: Mailbox not found\r\n", tag),
-                        }
-                    } else {
-                        format!("{} NO SELECT failed: User not authenticated\r\n", tag)
-                    }
-                } else {
-                    format!("{} NO SELECT failed: User not authenticated\r\n", tag)
-                }
-            }
-            "EXAMINE" => {
-                if command_parts.len() < 3 {
-                    return format!("{} BAD EXAMINE requires a mailbox name\r\n", tag);
-                }
-                let mailbox = command_parts[2];
-                if let Some(id) = session_id {
-                    let username = sessions.lock().unwrap().get(id).cloned();
-                    if let Some(user) = username {
-                        match self.logic.get_mailbox_status(&user, mailbox).await {
-                            Ok(status) => {
-                                let flags = "\\Seen \\Answered \\Flagged \\Deleted \\Draft \\Recent";
-                                let exists = status.exists;
-                                let recent = status.recent;
-                                format!("* FLAGS ({})\r\n* {} EXISTS\r\n* {} RECENT\r\n{} OK [READ-ONLY] EXAMINE completed\r\n", flags, exists, recent, tag)
-                            }
-                            Err(_) => format!("{} NO EXAMINE failed: Mailbox not found\r\n", tag),
-                        }
-                    } else {
-                        format!("{} NO EXAMINE failed: User not authenticated\r\n", tag)
-                    }
-                } else {
-                    format!("{} NO EXAMINE failed: User not authenticated\r\n", tag)
-                }
-            }
-            "CREATE" => {
-                if command_parts.len() < 3 {
-                    return format!("{} BAD CREATE requires a mailbox name\r\n", tag);
-                }
-                let mailbox = command_parts[2];
-                if let Some(id) = session_id {
-                    let username = sessions.lock().unwrap().get(id).cloned();
-                    if let Some(user) = username {
-                        match self.logic.create_mailbox(&user, mailbox).await {
-                            Ok(_) => format!("{} OK CREATE completed\r\n", tag),
-                            Err(_) => format!("{} NO CREATE failed: Internal error\r\n", tag),
-                        }
-                    } else {
-                        format!("{} NO CREATE failed: User not authenticated\r\n", tag)
-                    }
-                } else {
-                    format!("{} NO CREATE failed: User not authenticated\r\n", tag)
-                }
-            }
-            "DELETE" => {
-                if command_parts.len() < 3 {
-                    return format!("{} BAD DELETE requires a mailbox name\r\n", tag);
-                }
-                let mailbox = command_parts[2];
-                if let Some(id) = session_id {
-                    let username = sessions.lock().unwrap().get(id).cloned();
-                    if let Some(user) = username {
-                        match self.logic.delete_mailbox(&user, mailbox).await {
-                            Ok(_) => format!("{} OK DELETE completed\r\n", tag),
-                            Err(_) => format!("{} NO DELETE failed: Internal error\r\n", tag),
-                        }
-                    } else {
-                        format!("{} NO DELETE failed: User not authenticated\r\n", tag)
-                    }
-                } else {
-                    format!("{} NO DELETE failed: User not authenticated\r\n", tag)
-                }
-            }
-            "RENAME" => {
-                if command_parts.len() < 4 {
-                    return format!("{} BAD RENAME requires old and new mailbox names\r\n", tag);
-                }
-                let old_name = command_parts[2];
-                let new_name = command_parts[3];
-                if let Some(id) = session_id {
-                    let username = sessions.lock().unwrap().get(id).cloned();
-                    if let Some(user) = username {
-                        match self.logic.rename_mailbox(&user, old_name, new_name).await {
-                            Ok(_) => format!("{} OK RENAME completed\r\n", tag),
-                            Err(_) => format!("{} NO RENAME failed: Internal error\r\n", tag),
-                        }
-                    } else {
-                        format!("{} NO RENAME failed: User not authenticated\r\n", tag)
-                    }
-                } else {
-                    format!("{} NO RENAME failed: User not authenticated\r\n", tag)
-                }
-            }
-            "SUBSCRIBE" => {
-                if command_parts.len() < 3 {
-                    return format!("{} BAD SUBSCRIBE requires a mailbox name\r\n", tag);
-                }
-                let mailbox = command_parts[2];
-                if let Some(id) = session_id {
-                    let username = sessions.lock().unwrap().get(id).cloned();
-                    if let Some(user) = username {
-                        match self.logic.subscribe_mailbox(&user, mailbox).await {
-                            Ok(_) => format!("{} OK SUBSCRIBE completed\r\n", tag),
-                            Err(_) => format!("{} NO SUBSCRIBE failed: Internal error\r\n", tag),
-                        }
-                    } else {
-                        format!("{} NO SUBSCRIBE failed: User not authenticated\r\n", tag)
-                    }
-                } else {
-                    format!("{} NO SUBSCRIBE failed: User not authenticated\r\n", tag)
-                }
-            }
-            "UNSUBSCRIBE" => {
-                if command_parts.len() < 3 {
-                    return format!("{} BAD UNSUBSCRIBE requires a mailbox name\r\n", tag);
-                }
-                let mailbox = command_parts[2];
-                if let Some(id) = session_id {
-                    let username = sessions.lock().unwrap().get(id).cloned();
-                    if let Some(user) = username {
-                        match self.logic.unsubscribe_mailbox(&user, mailbox).await {
-                            Ok(_) => format!("{} OK UNSUBSCRIBE completed\r\n", tag),
-                            Err(_) => format!("{} NO UNSUBSCRIBE failed: Internal error\r\n", tag),
-                        }
-                    } else {
-                        format!("{} NO UNSUBSCRIBE failed: User not authenticated\r\n", tag)
-                    }
-                } else {
-                    format!("{} NO UNSUBSCRIBE failed: User not authenticated\r\n", tag)
-                }
-            }
-            "LSUB" => {
-                let reference = command_parts.get(2).unwrap_or(&"%");
-                let mailbox = command_parts.get(3).unwrap_or(&"*");
-                if let Some(id) = session_id {
-                    let username = sessions.lock().unwrap().get(id).cloned();
-                    if let Some(user) = username {
-                        match self.logic.list_subscribed_mailboxes(&user, reference, mailbox).await {
-                            Ok(mailboxes) => {
-                                let mut response = String::new();
-                                for mailbox in mailboxes {
-                                    response.push_str(&format!("* LSUB (\\HasNoChildren) \"{}\"\r\n", mailbox));
-                                }
-                                response.push_str(&format!("{} OK LSUB completed\r\n", tag));
-                                response
-                            }
-                            Err(_) => format!("{} NO LSUB failed: Internal error\r\n", tag),
-                        }
-                    } else {
-                        format!("{} NO LSUB failed: User not authenticated\r\n", tag)
-                    }
-                } else {
-                    format!("{} NO LSUB failed: User not authenticated\r\n", tag)
-                }
-            }
-            "STATUS" => {
-                if command_parts.len() < 4 {
-                    return format!("{} BAD STATUS requires a mailbox name and status data items\r\n", tag);
-                }
-                let mailbox = command_parts[2];
-                let data_items = command_parts[3..].join(" ");
-                if let Some(id) = session_id {
-                    let username = sessions.lock().unwrap().get(id).cloned();
-                    if let Some(user) = username {
-                        match self.logic.get_mailbox_status_items(&user, mailbox, &data_items).await {
-                            Ok(status_items) => {
-                                format!("* STATUS {} ({})\r\n{} OK STATUS completed\r\n", mailbox, status_items, tag)
-                            }
-                            Err(_) => format!("{} NO STATUS failed: Internal error\r\n", tag),
-                        }
-                    } else {
-                        format!("{} NO STATUS failed: User not authenticated\r\n", tag)
-                    }
-                } else {
-                    format!("{} NO STATUS failed: User not authenticated\r\n", tag)
-                }
-            }
-            "CHECK" => {
-                if let Some(id) = session_id {
-                    let username = sessions.lock().unwrap().get(id).cloned();
-                    if let Some(user) = username {
-                        match self.logic.check_mailbox().await {
-                            Ok(_) => format!("{} OK CHECK completed\r\n", tag),
-                            Err(_) => format!("{} NO CHECK failed: Internal error\r\n", tag),
-                        }
-                    } else {
-                        format!("{} NO CHECK failed: User not authenticated\r\n", tag)
-                    }
-                } else {
-                    format!("{} NO CHECK failed: User not authenticated\r\n", tag)
-                }
-            }
-            "CLOSE" => {
-                if let Some(id) = session_id {
-                    let username = sessions.lock().unwrap().get(id).cloned();
-                    if let Some(user) = username {
-                        match self.logic.close_mailbox(&user).await {
-                            Ok(_) => format!("{} OK CLOSE completed\r\n", tag),
-                            Err(_) => format!("{} NO CLOSE failed: Internal error\r\n", tag),
-                        }
-                    } else {
-                        format!("{} NO CLOSE failed: User not authenticated\r\n", tag)
-                    }
-                } else {
-                    format!("{} NO CLOSE failed: User not authenticated\r\n", tag)
-                }
-            }
-            "EXPUNGE" => {
-                if let Some(id) = session_id {
-                    let username = sessions.lock().unwrap().get(id).cloned();
-                    if let Some(user) = username {
-                        match self.logic.expunge_mailbox(&user).await {
-                            Ok(_) => format!("{} OK EXPUNGE completed\r\n", tag),
-                            Err(_) => format!("{} NO EXPUNGE failed: Internal error\r\n", tag),
-                        }
-                    } else {
-                        format!("{} NO EXPUNGE failed: User not authenticated\r\n", tag)
-                    }
-                } else {
-                    format!("{} NO EXPUNGE failed: User not authenticated\r\n", tag)
-                }
-            }
-            "SEARCH" => {
-                let search_criteria = command_parts[2..].join(" ");
-                if let Some(id) = session_id {
-                    let username = sessions.lock().unwrap().get(id).cloned();
-                    if let Some(user) = username {
-                        match self.logic.search_messages(&user, &search_criteria).await {
-                            Ok(results) => {
-                                let result_str = results.iter().map(|n| n.to_string()).collect::<Vec<String>>().join(" ");
-                                format!("* SEARCH {}\r\n{} OK SEARCH completed\r\n", result_str, tag)
-                            }
-                            Err(_) => format!("{} NO SEARCH failed: Internal error\r\n", tag),
-                        }
-                    } else {
-                        format!("{} NO SEARCH failed: User not authenticated\r\n", tag)
-                    }
-                } else {
-                    format!("{} NO SEARCH failed: User not authenticated\r\n", tag)
-                }
-            }
-            "COPY" => {
-                if command_parts.len() < 4 {
-                    return format!("{} BAD COPY requires message set and mailbox name\r\n", tag);
-                }
-                let message_set = command_parts[2];
-                let mailbox = command_parts[3];
-                if let Some(id) = session_id {
-                    let username = sessions.lock().unwrap().get(id).cloned();
-                    if let Some(user) = username {
-                        match self.logic.copy_messages(&user, message_set, mailbox).await {
-                            Ok(_) => format!("{} OK COPY completed\r\n", tag),
-                            Err(_) => format!("{} NO COPY failed: Internal error\r\n", tag),
-                        }
-                    } else {
-                        format!("{} NO COPY failed: User not authenticated\r\n", tag)
-                    }
-                } else {
-                    format!("{} NO COPY failed: User not authenticated\r\n", tag)
-                }
-            }
+            "LOGOUT" => Self::handle_logout(tag, sessions, session_id),
+            "LOGIN" => self.handle_login(tag, command_parts, sessions, session_id).await,
+            "LIST" => self.handle_list(tag, command_parts, sessions, session_id).await,
+            "SELECT" => self.handle_select(tag, command_parts, sessions, session_id).await,
+            "EXAMINE" => self.handle_examine(tag, command_parts, sessions, session_id).await,
+            "CREATE" => self.handle_create(tag, command_parts, sessions, session_id).await,
+            "DELETE" => self.handle_delete(tag, command_parts, sessions, session_id).await,
+            "RENAME" => self.handle_rename(tag, command_parts, sessions, session_id).await,
+            "SUBSCRIBE" => self.handle_subscribe(tag, command_parts, sessions, session_id).await,
+            "UNSUBSCRIBE" => self.handle_unsubscribe(tag, command_parts, sessions, session_id).await,
+            "LSUB" => self.handle_lsub(tag, command_parts, sessions, session_id).await,
+            "STATUS" => self.handle_status(tag, command_parts, sessions, session_id).await,
+            "CHECK" => self.handle_check(tag, sessions, session_id).await,
+            "CLOSE" => self.handle_close(tag, sessions, session_id).await,
+            "EXPUNGE" => self.handle_expunge(tag, sessions, session_id).await,
+            "SEARCH" => self.handle_search(tag, command_parts, sessions, session_id).await,
+            "COPY" => self.handle_copy(tag, command_parts, sessions, session_id).await,
             _ => format!("{} BAD Command not recognized\r\n", tag),
+        }
+    }
+
+    fn current_user(sessions: &Sessions, session_id: &Option<String>) -> Option<String> {
+        let id = session_id.as_ref()?;
+        sessions.lock().unwrap().get(id).cloned()
+    }
+
+    fn handle_append(&mut self, tag: &str, command_parts: &[&str]) -> String {
+        if command_parts.len() < 5 {
+            return format!("{} BAD APPEND requires a mailbox name and message\r\n", tag);
+        }
+        println!("Command parts: {:?}", command_parts);
+        self.mailbox = command_parts[2].trim_matches('"').to_string();
+        self.message_size = command_parts[4].trim_matches(|c| c == '{' || c == '}').parse::<usize>().unwrap_or(0);
+
+        if self.message_size == 0 {
+            return format!("{} BAD APPEND failed: Message size is zero\r\n", tag);
+        }
+        self.tag = tag.to_string();
+        self.expecting_message = true;
+
+        format!("{} OK APPEND command received, waiting for message content\r\n", tag)
+    }
+
+    fn handle_logout(tag: &str, sessions: &Sessions, session_id: &mut Option<String>) -> String {
+        if let Some(id) = session_id.take() {
+            sessions.lock().unwrap().remove(&id);
+        }
+        format!("* BYE IMAP4rev1 Server logging out\r\n{} OK LOGOUT completed\r\n", tag)
+    }
+
+    async fn handle_login(
+        &mut self,
+        tag: &str,
+        command_parts: &[&str],
+        sessions: &Sessions,
+        session_id: &mut Option<String>,
+    ) -> String {
+        if command_parts.len() < 4 {
+            return format!("{} BAD LOGIN requires a username and password\r\n", tag);
+        }
+        let username = command_parts[2].trim_matches('"');
+        let password = command_parts[3].trim_matches('"');
+
+        match self.logic.authenticate_user(username, password).await {
+            Ok(Some(user)) => {
+                let new_session_id = Uuid::new_v4().to_string();
+                sessions.lock().unwrap().insert(new_session_id.clone(), user.username.clone());
+                *session_id = Some(new_session_id);
+                format!("{} OK LOGIN completed\r\n", tag)
+            }
+            Ok(None) => {
+                sleep(Duration::from_secs(1)).await;
+                format!("{} NO LOGIN failed: Invalid credentials\r\n", tag)
+            }
+            Err(_) => format!("{} NO LOGIN failed: Internal error\r\n", tag),
+        }
+    }
+
+    async fn handle_list(&mut self, tag: &str, command_parts: &[&str], sessions: &Sessions, session_id: &Option<String>) -> String {
+        let reference = command_parts.get(2).unwrap_or(&"");
+        let mailbox = command_parts.get(3).unwrap_or(&"*");
+        let Some(user) = Self::current_user(sessions, session_id) else {
+            return format!("{} NO LIST failed: User not authenticated\r\n", tag);
+        };
+        match self.logic.list_mailboxes(&user, reference, mailbox).await {
+            Ok(mailboxes) => {
+                let mut response = String::new();
+                for mailbox in mailboxes {
+                    response.push_str(&format!("* LIST (\\HasNoChildren) \"/\" \"{}\"\r\n", mailbox));
+                }
+                response.push_str(&format!("{} OK LIST completed\r\n", tag));
+                response
+            }
+            Err(_) => format!("{} NO LIST failed: Internal error\r\n", tag),
+        }
+    }
+
+    async fn handle_select(&mut self, tag: &str, command_parts: &[&str], sessions: &Sessions, session_id: &Option<String>) -> String {
+        if command_parts.len() < 3 {
+            return format!("{} BAD SELECT requires a mailbox name\r\n", tag);
+        }
+        let mailbox = command_parts[2];
+        let Some(user) = Self::current_user(sessions, session_id) else {
+            return format!("{} NO SELECT failed: User not authenticated\r\n", tag);
+        };
+        match self.logic.select_mailbox(&user, mailbox).await {
+            Ok(status) => {
+                let flags = "\\Seen \\Answered \\Flagged \\Deleted \\Draft";
+                format!(
+                    "* FLAGS ({})\r\n* {} EXISTS\r\n* {} RECENT\r\n* OK [UNSEEN {}] Message {} is first unseen\r\n* OK [UIDVALIDITY {}] UIDs valid\r\n* OK [UIDNEXT {}] Predicted next UID\r\n{} OK [READ-WRITE] SELECT completed\r\n",
+                    flags, status.exists, status.recent, status.unseen, status.unseen, status.uid_validity, status.uid_next, tag
+                )
+            }
+            Err(_) => format!("{} NO SELECT failed: Mailbox not found\r\n", tag),
+        }
+    }
+
+    async fn handle_examine(&mut self, tag: &str, command_parts: &[&str], sessions: &Sessions, session_id: &Option<String>) -> String {
+        if command_parts.len() < 3 {
+            return format!("{} BAD EXAMINE requires a mailbox name\r\n", tag);
+        }
+        let mailbox = command_parts[2];
+        let Some(user) = Self::current_user(sessions, session_id) else {
+            return format!("{} NO EXAMINE failed: User not authenticated\r\n", tag);
+        };
+        match self.logic.get_mailbox_status(&user, mailbox).await {
+            Ok(status) => {
+                let flags = "\\Seen \\Answered \\Flagged \\Deleted \\Draft \\Recent";
+                format!("* FLAGS ({})\r\n* {} EXISTS\r\n* {} RECENT\r\n{} OK [READ-ONLY] EXAMINE completed\r\n", flags, status.exists, status.recent, tag)
+            }
+            Err(_) => format!("{} NO EXAMINE failed: Mailbox not found\r\n", tag),
+        }
+    }
+
+    async fn handle_create(&mut self, tag: &str, command_parts: &[&str], sessions: &Sessions, session_id: &Option<String>) -> String {
+        if command_parts.len() < 3 {
+            return format!("{} BAD CREATE requires a mailbox name\r\n", tag);
+        }
+        let mailbox = command_parts[2];
+        let Some(user) = Self::current_user(sessions, session_id) else {
+            return format!("{} NO CREATE failed: User not authenticated\r\n", tag);
+        };
+        match self.logic.create_mailbox(&user, mailbox).await {
+            Ok(_) => format!("{} OK CREATE completed\r\n", tag),
+            Err(_) => format!("{} NO CREATE failed: Internal error\r\n", tag),
+        }
+    }
+
+    async fn handle_delete(&mut self, tag: &str, command_parts: &[&str], sessions: &Sessions, session_id: &Option<String>) -> String {
+        if command_parts.len() < 3 {
+            return format!("{} BAD DELETE requires a mailbox name\r\n", tag);
+        }
+        let mailbox = command_parts[2];
+        let Some(user) = Self::current_user(sessions, session_id) else {
+            return format!("{} NO DELETE failed: User not authenticated\r\n", tag);
+        };
+        match self.logic.delete_mailbox(&user, mailbox).await {
+            Ok(_) => format!("{} OK DELETE completed\r\n", tag),
+            Err(_) => format!("{} NO DELETE failed: Internal error\r\n", tag),
+        }
+    }
+
+    async fn handle_rename(&mut self, tag: &str, command_parts: &[&str], sessions: &Sessions, session_id: &Option<String>) -> String {
+        if command_parts.len() < 4 {
+            return format!("{} BAD RENAME requires old and new mailbox names\r\n", tag);
+        }
+        let old_name = command_parts[2];
+        let new_name = command_parts[3];
+        let Some(user) = Self::current_user(sessions, session_id) else {
+            return format!("{} NO RENAME failed: User not authenticated\r\n", tag);
+        };
+        match self.logic.rename_mailbox(&user, old_name, new_name).await {
+            Ok(_) => format!("{} OK RENAME completed\r\n", tag),
+            Err(_) => format!("{} NO RENAME failed: Internal error\r\n", tag),
+        }
+    }
+
+    async fn handle_subscribe(&mut self, tag: &str, command_parts: &[&str], sessions: &Sessions, session_id: &Option<String>) -> String {
+        if command_parts.len() < 3 {
+            return format!("{} BAD SUBSCRIBE requires a mailbox name\r\n", tag);
+        }
+        let mailbox = command_parts[2];
+        let Some(user) = Self::current_user(sessions, session_id) else {
+            return format!("{} NO SUBSCRIBE failed: User not authenticated\r\n", tag);
+        };
+        match self.logic.subscribe_mailbox(&user, mailbox).await {
+            Ok(_) => format!("{} OK SUBSCRIBE completed\r\n", tag),
+            Err(_) => format!("{} NO SUBSCRIBE failed: Internal error\r\n", tag),
+        }
+    }
+
+    async fn handle_unsubscribe(&mut self, tag: &str, command_parts: &[&str], sessions: &Sessions, session_id: &Option<String>) -> String {
+        if command_parts.len() < 3 {
+            return format!("{} BAD UNSUBSCRIBE requires a mailbox name\r\n", tag);
+        }
+        let mailbox = command_parts[2];
+        let Some(user) = Self::current_user(sessions, session_id) else {
+            return format!("{} NO UNSUBSCRIBE failed: User not authenticated\r\n", tag);
+        };
+        match self.logic.unsubscribe_mailbox(&user, mailbox).await {
+            Ok(_) => format!("{} OK UNSUBSCRIBE completed\r\n", tag),
+            Err(_) => format!("{} NO UNSUBSCRIBE failed: Internal error\r\n", tag),
+        }
+    }
+
+    async fn handle_lsub(&mut self, tag: &str, command_parts: &[&str], sessions: &Sessions, session_id: &Option<String>) -> String {
+        let reference = command_parts.get(2).unwrap_or(&"%");
+        let mailbox = command_parts.get(3).unwrap_or(&"*");
+        let Some(user) = Self::current_user(sessions, session_id) else {
+            return format!("{} NO LSUB failed: User not authenticated\r\n", tag);
+        };
+        match self.logic.list_subscribed_mailboxes(&user, reference, mailbox).await {
+            Ok(mailboxes) => {
+                let mut response = String::new();
+                for mailbox in mailboxes {
+                    response.push_str(&format!("* LSUB (\\HasNoChildren) \"{}\"\r\n", mailbox));
+                }
+                response.push_str(&format!("{} OK LSUB completed\r\n", tag));
+                response
+            }
+            Err(_) => format!("{} NO LSUB failed: Internal error\r\n", tag),
+        }
+    }
+
+    async fn handle_status(&mut self, tag: &str, command_parts: &[&str], sessions: &Sessions, session_id: &Option<String>) -> String {
+        if command_parts.len() < 4 {
+            return format!("{} BAD STATUS requires a mailbox name and status data items\r\n", tag);
+        }
+        let mailbox = command_parts[2];
+        let data_items = command_parts[3..].join(" ");
+        let Some(user) = Self::current_user(sessions, session_id) else {
+            return format!("{} NO STATUS failed: User not authenticated\r\n", tag);
+        };
+        match self.logic.get_mailbox_status_items(&user, mailbox, &data_items).await {
+            Ok(status_items) => format!("* STATUS {} ({})\r\n{} OK STATUS completed\r\n", mailbox, status_items, tag),
+            Err(_) => format!("{} NO STATUS failed: Internal error\r\n", tag),
+        }
+    }
+
+    async fn handle_check(&mut self, tag: &str, sessions: &Sessions, session_id: &Option<String>) -> String {
+        let Some(_user) = Self::current_user(sessions, session_id) else {
+            return format!("{} NO CHECK failed: User not authenticated\r\n", tag);
+        };
+        match self.logic.check_mailbox().await {
+            Ok(_) => format!("{} OK CHECK completed\r\n", tag),
+            Err(_) => format!("{} NO CHECK failed: Internal error\r\n", tag),
+        }
+    }
+
+    async fn handle_close(&mut self, tag: &str, sessions: &Sessions, session_id: &Option<String>) -> String {
+        let Some(user) = Self::current_user(sessions, session_id) else {
+            return format!("{} NO CLOSE failed: User not authenticated\r\n", tag);
+        };
+        match self.logic.close_mailbox(&user).await {
+            Ok(_) => format!("{} OK CLOSE completed\r\n", tag),
+            Err(_) => format!("{} NO CLOSE failed: Internal error\r\n", tag),
+        }
+    }
+
+    async fn handle_expunge(&mut self, tag: &str, sessions: &Sessions, session_id: &Option<String>) -> String {
+        let Some(user) = Self::current_user(sessions, session_id) else {
+            return format!("{} NO EXPUNGE failed: User not authenticated\r\n", tag);
+        };
+        match self.logic.expunge_mailbox(&user).await {
+            Ok(_) => format!("{} OK EXPUNGE completed\r\n", tag),
+            Err(_) => format!("{} NO EXPUNGE failed: Internal error\r\n", tag),
+        }
+    }
+
+    async fn handle_search(&mut self, tag: &str, command_parts: &[&str], sessions: &Sessions, session_id: &Option<String>) -> String {
+        let search_criteria = command_parts[2..].join(" ");
+        let Some(user) = Self::current_user(sessions, session_id) else {
+            return format!("{} NO SEARCH failed: User not authenticated\r\n", tag);
+        };
+        match self.logic.search_messages(&user, &search_criteria).await {
+            Ok(results) => {
+                let result_str = results.iter().map(|n| n.to_string()).collect::<Vec<String>>().join(" ");
+                format!("* SEARCH {}\r\n{} OK SEARCH completed\r\n", result_str, tag)
+            }
+            Err(_) => format!("{} NO SEARCH failed: Internal error\r\n", tag),
+        }
+    }
+
+    async fn handle_copy(&mut self, tag: &str, command_parts: &[&str], sessions: &Sessions, session_id: &Option<String>) -> String {
+        if command_parts.len() < 4 {
+            return format!("{} BAD COPY requires message set and mailbox name\r\n", tag);
+        }
+        let message_set = command_parts[2];
+        let mailbox = command_parts[3];
+        let Some(user) = Self::current_user(sessions, session_id) else {
+            return format!("{} NO COPY failed: User not authenticated\r\n", tag);
+        };
+        match self.logic.copy_messages(&user, message_set, mailbox).await {
+            Ok(_) => format!("{} OK COPY completed\r\n", tag),
+            Err(_) => format!("{} NO COPY failed: Internal error\r\n", tag),
         }
     }
 }

--- a/src/smtp_client/mx.rs
+++ b/src/smtp_client/mx.rs
@@ -1,95 +1,82 @@
 use super::*;
 
-pub(super) async fn send_via_mx(email: &Email) -> std::io::Result<()> {
-    let t_total = Instant::now();
-    let mon = crate::monitoring::monitoring_enabled();
+/// Contexte partagé pour l'émission d'événements de monitoring pendant l'envoi.
+struct SendContext {
+    message_id: String,
+    correlation_id: String,
+    from: String,
+    to: String,
+    mon: bool,
+}
 
-    // Extract or synthesise a stable message_id for correlation.
-    let message_id = email
-        .headers
-        .iter()
-        .find(|(k, _)| k.to_lowercase() == "message-id")
-        .map(|(_, v)| v.trim_matches(|c| c == '<' || c == '>').to_string())
-        .unwrap_or_else(|| email.id.clone());
-
-    // One UUID per send attempt — links all events for this delivery.
-    let correlation_id = Uuid::new_v4().to_string();
-
-    if mon {
-        let mut ev = crate::monitoring::SmtpEvent::new(
-            &message_id,
-            crate::monitoring::SmtpEventType::Accepted,
-            &email.from,
-            &email.to,
-        );
-        ev.correlation_id = correlation_id.clone();
-        crate::monitoring::emit(ev);
+impl SendContext {
+    fn from_email(email: &Email) -> Self {
+        let message_id = email
+            .headers
+            .iter()
+            .find(|(k, _)| k.to_lowercase() == "message-id")
+            .map(|(_, v)| v.trim_matches(|c| c == '<' || c == '>').to_string())
+            .unwrap_or_else(|| email.id.clone());
+        Self {
+            message_id,
+            correlation_id: Uuid::new_v4().to_string(),
+            from: email.from.clone(),
+            to: email.to.clone(),
+            mon: crate::monitoring::monitoring_enabled(),
+        }
     }
 
-    println!("Sending email: {}", email.body);
+    fn emit(&self, ev_type: crate::monitoring::SmtpEventType) -> crate::monitoring::SmtpEvent {
+        let mut ev = crate::monitoring::SmtpEvent::new(&self.message_id, ev_type, &self.from, &self.to);
+        ev.correlation_id = self.correlation_id.clone();
+        ev
+    }
 
-    let email_content = compose_smtp_payload(email);
-
-    let recipient_email = extract_email_address(&email_content, "To:")
-        .ok_or_else(|| IoError::new(ErrorKind::InvalidInput, "Invalid recipient email"))?;
-    let recipient_domain = recipient_email
-        .split('@')
-        .nth(1)
-        .ok_or_else(|| IoError::new(ErrorKind::InvalidInput, "Invalid recipient email"))?;
-
-    println!("Resolving MX records for domain: {}", recipient_domain);
-
-    let resolver = TokioAsyncResolver::tokio(ResolverConfig::default(), ResolverOpts::default());
-
-    // --- DNS lookup ---
-    let t_dns = Instant::now();
-    let mx_lookup = resolver.mx_lookup(recipient_domain).await.map_err(|e| {
-        if mon {
-            let mut ev = crate::monitoring::SmtpEvent::new(
-                &message_id,
-                crate::monitoring::SmtpEventType::Bounced,
-                &email.from,
-                &email.to,
-            );
-            ev.correlation_id = correlation_id.clone();
-            ev.dns_ms = Some(t_dns.elapsed().as_millis() as u64);
-            ev.total_ms = Some(t_total.elapsed().as_millis() as u64);
-            ev.status = crate::monitoring::SmtpStatus::Failed;
-            ev.bounce_type = Some(crate::monitoring::BounceType::Soft);
-            ev.bounce_reason = Some(format!("MX lookup failed: {}", e));
-            crate::monitoring::emit(ev);
+    fn emit_bounce_soft(&self, reason: String, mx_host: Option<String>, remote_ip: Option<String>, total_ms: Option<u64>, dns_ms: Option<u64>) {
+        if !self.mon {
+            return;
         }
+        let mut ev = self.emit(crate::monitoring::SmtpEventType::Bounced);
+        ev.mx_host = mx_host;
+        ev.remote_ip = remote_ip;
+        ev.total_ms = total_ms;
+        ev.dns_ms = dns_ms;
+        ev.status = crate::monitoring::SmtpStatus::Failed;
+        ev.bounce_type = Some(crate::monitoring::BounceType::Soft);
+        ev.bounce_reason = Some(reason);
+        crate::monitoring::emit(ev);
+    }
+}
+
+/// Résolution DNS + sélection du premier MX record et du port SMTP ouvert.
+async fn resolve_mx_target(
+    domain: &str,
+    ctx: &SendContext,
+    t_total: Instant,
+) -> std::io::Result<(String, u16, u64)> {
+    let resolver = TokioAsyncResolver::tokio(ResolverConfig::default(), ResolverOpts::default());
+    let t_dns = Instant::now();
+    let mx_lookup = resolver.mx_lookup(domain).await.map_err(|e| {
+        let dns_ms = t_dns.elapsed().as_millis() as u64;
+        ctx.emit_bounce_soft(
+            format!("MX lookup failed: {}", e),
+            None,
+            None,
+            Some(t_total.elapsed().as_millis() as u64),
+            Some(dns_ms),
+        );
         IoError::new(ErrorKind::Other, format!("MX lookup failed: {}", e))
     })?;
     let dns_ms = t_dns.elapsed().as_millis() as u64;
 
     let mx_records: Vec<_> = mx_lookup.iter().collect();
     if mx_records.is_empty() {
-        if mon {
-            let mut ev = crate::monitoring::SmtpEvent::new(
-                &message_id,
-                crate::monitoring::SmtpEventType::Bounced,
-                &email.from,
-                &email.to,
-            );
-            ev.correlation_id = correlation_id.clone();
-            ev.dns_ms = Some(dns_ms);
-            ev.status = crate::monitoring::SmtpStatus::Failed;
-            ev.bounce_type = Some(crate::monitoring::BounceType::Soft);
-            ev.bounce_reason = Some("No MX records found".into());
-            crate::monitoring::emit(ev);
-        }
+        ctx.emit_bounce_soft("No MX records found".into(), None, None, None, Some(dns_ms));
         return Err(IoError::new(ErrorKind::Other, "No MX records found"));
     }
 
-    if mon {
-        let mut ev = crate::monitoring::SmtpEvent::new(
-            &message_id,
-            crate::monitoring::SmtpEventType::DnsLookup,
-            &email.from,
-            &email.to,
-        );
-        ev.correlation_id = correlation_id.clone();
+    if ctx.mon {
+        let mut ev = ctx.emit(crate::monitoring::SmtpEventType::DnsLookup);
         ev.dns_ms = Some(dns_ms);
         crate::monitoring::emit(ev);
     }
@@ -108,14 +95,8 @@ pub(super) async fn send_via_mx(email: &Email) -> std::io::Result<()> {
 
     let smtp_port = match find_smtp_port(&smtp_server).await {
         Some(port) => {
-            if mon {
-                let mut ev = crate::monitoring::SmtpEvent::new(
-                    &message_id,
-                    crate::monitoring::SmtpEventType::MxSelected,
-                    &email.from,
-                    &email.to,
-                );
-                ev.correlation_id = correlation_id.clone();
+            if ctx.mon {
+                let mut ev = ctx.emit(crate::monitoring::SmtpEventType::MxSelected);
                 ev.mx_host = Some(smtp_server.clone());
                 ev.remote_port = Some(port);
                 crate::monitoring::emit(ev);
@@ -123,146 +104,194 @@ pub(super) async fn send_via_mx(email: &Email) -> std::io::Result<()> {
             port
         }
         None => {
-            if mon {
-                let mut ev = crate::monitoring::SmtpEvent::new(
-                    &message_id,
-                    crate::monitoring::SmtpEventType::Bounced,
-                    &email.from,
-                    &email.to,
-                );
-                ev.correlation_id = correlation_id.clone();
-                ev.mx_host = Some(smtp_server.clone());
-                ev.dns_ms = Some(dns_ms);
-                ev.total_ms = Some(t_total.elapsed().as_millis() as u64);
-                ev.status = crate::monitoring::SmtpStatus::Failed;
-                ev.bounce_type = Some(crate::monitoring::BounceType::Soft);
-                ev.bounce_reason = Some("No open SMTP ports found".into());
-                crate::monitoring::emit(ev);
-            }
+            ctx.emit_bounce_soft(
+                "No open SMTP ports found".into(),
+                Some(smtp_server.clone()),
+                None,
+                Some(t_total.elapsed().as_millis() as u64),
+                Some(dns_ms),
+            );
             return Err(IoError::new(ErrorKind::Other, "No open SMTP ports found"));
         }
     };
 
-    // --- TCP connect ---
-    println!("Connecting to {}:{}", smtp_server, smtp_port);
-    let t_connect = Instant::now();
-    let mut stream = TcpStream::connect((smtp_server.as_str(), smtp_port)).await?;
-    let remote_ip = stream
-        .peer_addr()
-        .map(|a| a.ip().to_string())
-        .unwrap_or_default();
-    let connect_ms = t_connect.elapsed().as_millis() as u64;
+    Ok((smtp_server, smtp_port, dns_ms))
+}
 
-    // GeoIP enrichment runs in background to avoid blocking the SMTP pipeline.
-    if mon {
-        let ip = remote_ip.clone();
-        let mid = message_id.clone();
-        let cid = correlation_id.clone();
-        let from = email.from.clone();
-        let to = email.to.clone();
-        let mx = smtp_server.clone();
-        let port = smtp_port;
-        tokio::spawn(async move {
-            let geo = crate::monitoring::enrichment::enrich_ip(&ip).await;
-            let mut ev = crate::monitoring::SmtpEvent::new(
-                &mid,
-                crate::monitoring::SmtpEventType::SmtpConnect,
-                &from,
-                &to,
-            );
-            ev.correlation_id = cid;
-            ev.mx_host = Some(mx);
-            ev.remote_port = Some(port);
-            ev.connect_ms = Some(connect_ms);
-            ev = ev.with_geo(geo);
-            ev.compute_risk_score();
-            crate::monitoring::emit(ev);
-        });
+/// Enrichissement GeoIP + émission asynchrone de l'événement SmtpConnect.
+fn spawn_connect_event(ctx: &SendContext, remote_ip: String, mx: String, port: u16, connect_ms: u64) {
+    if !ctx.mon {
+        return;
+    }
+    let mid = ctx.message_id.clone();
+    let cid = ctx.correlation_id.clone();
+    let from = ctx.from.clone();
+    let to = ctx.to.clone();
+    tokio::spawn(async move {
+        let geo = crate::monitoring::enrichment::enrich_ip(&remote_ip).await;
+        let mut ev = crate::monitoring::SmtpEvent::new(
+            &mid,
+            crate::monitoring::SmtpEventType::SmtpConnect,
+            &from,
+            &to,
+        );
+        ev.correlation_id = cid;
+        ev.mx_host = Some(mx);
+        ev.remote_port = Some(port);
+        ev.connect_ms = Some(connect_ms);
+        ev = ev.with_geo(geo);
+        ev.compute_risk_score();
+        crate::monitoring::emit(ev);
+    });
+}
+
+/// EHLO + STARTTLS + second EHLO chiffré. Retourne le stream prêt pour MAIL FROM.
+async fn perform_smtp_handshake(
+    mut stream: TcpStream,
+    smtp_server: String,
+    smtp_port: u16,
+) -> std::io::Result<(StreamType, u64)> {
+    expect_code(&mut stream, "220").await?;
+    let ehlo_hostname = ehlo_hostname();
+    stream.write_all(format!("EHLO {}\r\n", ehlo_hostname).as_bytes()).await?;
+    expect_code(&mut stream, "250").await?;
+
+    let t_tls = Instant::now();
+    let mut stream_type = if smtp_port != 465 {
+        stream.write_all(b"STARTTLS\r\n").await?;
+        expect_code(&mut stream, "220").await?;
+
+        let mut root_store = RootCertStore::empty();
+        for cert in load_native_certs().certs {
+            root_store.add_parsable_certificates([cert]);
+        }
+        root_store.add_parsable_certificates(
+            TLS_SERVER_ROOTS.iter().map(|ta| ta.subject.to_vec().into()),
+        );
+        let config = ClientConfig::builder()
+            .with_root_certificates(root_store)
+            .with_no_client_auth();
+        let connector = TlsConnector::from(Arc::new(config));
+        let server_name = ServerName::try_from(smtp_server)
+            .map_err(|_| IoError::new(ErrorKind::InvalidInput, "Invalid server name"))?;
+        let tls_stream = connector.connect(server_name, stream).await?;
+        let mut s = tls_stream;
+        s.write_all(format!("EHLO {}\r\n", ehlo_hostname).as_bytes()).await?;
+        expect_code(&mut s, "250").await?;
+        StreamType::Tls(s)
+    } else {
+        StreamType::Plain(stream)
+    };
+    let tls_ms = t_tls.elapsed().as_millis() as u64;
+
+    if smtp_port == 465 {
+        if let StreamType::Plain(ref mut s) = &mut stream_type {
+            s.write_all(format!("EHLO {}\r\n", ehlo_hostname).as_bytes()).await?;
+            expect_code(s, "250").await?;
+        }
     }
 
+    Ok((stream_type, tls_ms))
+}
+
+/// Émet l'événement Delivered ou Bounced selon le résultat de la transaction SMTP.
+fn emit_final_event(
+    ctx: &SendContext,
+    result: &std::io::Result<()>,
+    smtp_server: &str,
+    remote_ip: &str,
+    dns_ms: u64,
+    connect_ms: u64,
+    tls_ms: u64,
+    total_ms: u64,
+) {
+    if !ctx.mon {
+        return;
+    }
+    match result {
+        Ok(_) => {
+            let mut ev = ctx.emit(crate::monitoring::SmtpEventType::Delivered);
+            ev.mx_host = Some(smtp_server.to_string());
+            ev.remote_ip = Some(remote_ip.to_string());
+            ev.dns_ms = Some(dns_ms);
+            ev.connect_ms = Some(connect_ms);
+            ev.tls_ms = Some(tls_ms);
+            ev.total_ms = Some(total_ms);
+            ev.smtp_code = Some(250);
+            ev.smtp_reply = Some("250 OK".into());
+            ev.status = crate::monitoring::SmtpStatus::Delivered;
+            ev.compute_risk_score();
+            crate::monitoring::emit(ev);
+        }
+        Err(e) => {
+            let err_msg = e.to_string();
+            let smtp_code = crate::monitoring::parse_smtp_code(&err_msg);
+            let bounce_type = match smtp_code {
+                Some(c) if c >= 550 => crate::monitoring::BounceType::Hard,
+                Some(421) | Some(450) => crate::monitoring::BounceType::Soft,
+                _ => crate::monitoring::BounceType::Soft,
+            };
+            let mut ev = ctx.emit(crate::monitoring::SmtpEventType::Bounced);
+            ev.mx_host = Some(smtp_server.to_string());
+            ev.remote_ip = Some(remote_ip.to_string());
+            ev.total_ms = Some(total_ms);
+            ev.smtp_code = smtp_code;
+            ev.smtp_reply = Some(err_msg.clone());
+            ev.status = crate::monitoring::SmtpStatus::Bounced;
+            ev.bounce_type = Some(bounce_type);
+            ev.bounce_reason = Some(err_msg);
+            ev.compute_risk_score();
+            crate::monitoring::emit(ev);
+        }
+    }
+}
+
+pub(super) async fn send_via_mx(email: &Email) -> std::io::Result<()> {
+    let t_total = Instant::now();
+    let ctx = SendContext::from_email(email);
+
+    if ctx.mon {
+        crate::monitoring::emit(ctx.emit(crate::monitoring::SmtpEventType::Accepted));
+    }
+
+    println!("Sending email: {}", email.body);
+
+    let email_content = compose_smtp_payload(email);
+    let recipient_email = extract_email_address(&email_content, "To:")
+        .ok_or_else(|| IoError::new(ErrorKind::InvalidInput, "Invalid recipient email"))?;
+    let recipient_domain = recipient_email
+        .split('@')
+        .nth(1)
+        .ok_or_else(|| IoError::new(ErrorKind::InvalidInput, "Invalid recipient email"))?;
+
+    println!("Resolving MX records for domain: {}", recipient_domain);
+    let (smtp_server, smtp_port, dns_ms) = resolve_mx_target(recipient_domain, &ctx, t_total).await?;
+
+    println!("Connecting to {}:{}", smtp_server, smtp_port);
+    let t_connect = Instant::now();
+    let stream = TcpStream::connect((smtp_server.as_str(), smtp_port)).await?;
+    let remote_ip = stream.peer_addr().map(|a| a.ip().to_string()).unwrap_or_default();
+    let connect_ms = t_connect.elapsed().as_millis() as u64;
+
+    spawn_connect_event(&ctx, remote_ip.clone(), smtp_server.clone(), smtp_port, connect_ms);
     println!("Connected successfully");
 
-    // Wrap all pre-send SMTP steps so errors still emit a Bounced monitoring event.
-    let handshake_result: std::io::Result<(StreamType, u64, String)> = async {
-        expect_code(&mut stream, "220").await?;
-        let ehlo_hostname = ehlo_hostname();
-        stream.write_all(format!("EHLO {}\r\n", ehlo_hostname).as_bytes()).await?;
-        expect_code(&mut stream, "250").await?;
-
-        // --- STARTTLS / TLS handshake ---
-        let t_tls = Instant::now();
-        let mut stream_type = if smtp_port != 465 {
-            let smtp_server_clone = smtp_server.clone();
-            stream.write_all(b"STARTTLS\r\n").await?;
-            expect_code(&mut stream, "220").await?;
-
-            let mut root_store = RootCertStore::empty();
-            for cert in load_native_certs().certs {
-                root_store.add_parsable_certificates([cert]);
-            }
-            root_store.add_parsable_certificates(
-                TLS_SERVER_ROOTS.iter().map(|ta| ta.subject.to_vec().into()),
-            );
-            let config = ClientConfig::builder()
-                .with_root_certificates(root_store)
-                .with_no_client_auth();
-            let connector = TlsConnector::from(Arc::new(config));
-            let server_name = ServerName::try_from(smtp_server_clone)
-                .map_err(|_| IoError::new(ErrorKind::InvalidInput, "Invalid server name"))?;
-            let tls_stream = connector.connect(server_name, stream).await?;
-            let mut s = tls_stream;
-            s.write_all(format!("EHLO {}\r\n", ehlo_hostname).as_bytes()).await?;
-            expect_code(&mut s, "250").await?;
-            StreamType::Tls(s)
-        } else {
-            StreamType::Plain(stream)
-        };
-        let tls_ms = t_tls.elapsed().as_millis() as u64;
-
-        if smtp_port == 465 {
-            match &mut stream_type {
-                StreamType::Plain(ref mut s) => {
-                    s.write_all(format!("EHLO {}\r\n", ehlo_hostname).as_bytes()).await?;
-                    expect_code(s, "250").await?;
-                }
-                StreamType::Tls(_) => {}
-            }
-        }
-
-        Ok((stream_type, tls_ms, ehlo_hostname))
-    }.await;
-
-    let (mut stream_type, tls_ms, _ehlo_hostname) = match handshake_result {
+    let (mut stream_type, tls_ms) = match perform_smtp_handshake(stream, smtp_server.clone(), smtp_port).await {
         Ok(v) => v,
         Err(e) => {
-            if mon {
-                let mut ev = crate::monitoring::SmtpEvent::new(
-                    &message_id,
-                    crate::monitoring::SmtpEventType::Bounced,
-                    &email.from,
-                    &email.to,
-                );
-                ev.correlation_id = correlation_id.clone();
-                ev.mx_host = Some(smtp_server.clone());
-                ev.remote_ip = Some(remote_ip.clone());
-                ev.total_ms = Some(t_total.elapsed().as_millis() as u64);
-                ev.status = crate::monitoring::SmtpStatus::Failed;
-                ev.bounce_type = Some(crate::monitoring::BounceType::Soft);
-                ev.bounce_reason = Some(format!("TLS/SMTP handshake failed: {}", e));
-                crate::monitoring::emit(ev);
-            }
+            ctx.emit_bounce_soft(
+                format!("TLS/SMTP handshake failed: {}", e),
+                Some(smtp_server.clone()),
+                Some(remote_ip.clone()),
+                Some(t_total.elapsed().as_millis() as u64),
+                Some(dns_ms),
+            );
             return Err(e);
         }
     };
 
-    if mon {
-        let mut ev = crate::monitoring::SmtpEvent::new(
-            &message_id,
-            crate::monitoring::SmtpEventType::TlsOk,
-            &email.from,
-            &email.to,
-        );
-        ev.correlation_id = correlation_id.clone();
+    if ctx.mon {
+        let mut ev = ctx.emit(crate::monitoring::SmtpEventType::TlsOk);
         ev.mx_host = Some(smtp_server.clone());
         ev.remote_ip = Some(remote_ip.clone());
         ev.tls_ms = Some(tls_ms);
@@ -272,56 +301,6 @@ pub(super) async fn send_via_mx(email: &Email) -> std::io::Result<()> {
     let result = send_email_content(&mut stream_type, &email_content).await;
     let total_ms = t_total.elapsed().as_millis() as u64;
 
-    if mon {
-        match &result {
-            Ok(_) => {
-                let mut ev = crate::monitoring::SmtpEvent::new(
-                    &message_id,
-                    crate::monitoring::SmtpEventType::Delivered,
-                    &email.from,
-                    &email.to,
-                );
-                ev.correlation_id = correlation_id.clone();
-                ev.mx_host = Some(smtp_server.clone());
-                ev.remote_ip = Some(remote_ip.clone());
-                ev.dns_ms = Some(dns_ms);
-                ev.connect_ms = Some(connect_ms);
-                ev.tls_ms = Some(tls_ms);
-                ev.total_ms = Some(total_ms);
-                ev.smtp_code = Some(250);
-                ev.smtp_reply = Some("250 OK".into());
-                ev.status = crate::monitoring::SmtpStatus::Delivered;
-                ev.compute_risk_score();
-                crate::monitoring::emit(ev);
-            }
-            Err(e) => {
-                let err_msg = e.to_string();
-                let smtp_code = crate::monitoring::parse_smtp_code(&err_msg);
-                let bounce_type = match smtp_code {
-                    Some(c) if c >= 550 => crate::monitoring::BounceType::Hard,
-                    Some(421) | Some(450) => crate::monitoring::BounceType::Soft,
-                    _ => crate::monitoring::BounceType::Soft,
-                };
-                let mut ev = crate::monitoring::SmtpEvent::new(
-                    &message_id,
-                    crate::monitoring::SmtpEventType::Bounced,
-                    &email.from,
-                    &email.to,
-                );
-                ev.correlation_id = correlation_id;
-                ev.mx_host = Some(smtp_server.clone());
-                ev.remote_ip = Some(remote_ip.clone());
-                ev.total_ms = Some(total_ms);
-                ev.smtp_code = smtp_code;
-                ev.smtp_reply = Some(err_msg.clone());
-                ev.status = crate::monitoring::SmtpStatus::Bounced;
-                ev.bounce_type = Some(bounce_type);
-                ev.bounce_reason = Some(err_msg);
-                ev.compute_risk_score();
-                crate::monitoring::emit(ev);
-            }
-        }
-    }
-
+    emit_final_event(&ctx, &result, &smtp_server, &remote_ip, dns_ms, connect_ms, tls_ms, total_ms);
     result
 }


### PR DESCRIPTION
Decompose two Rust god functions into per-phase helpers.

- imap_server::dispatch_command (367 -> 38 LOC): extracted 20 handle_<verb> helpers, all <= 27 LOC.
- smtp_client::send_via_mx (326 -> TBD): pending phase extraction.

Aucun changement comportemental. FR.