### PR TITLE
refactor(rust cycle 19): domain_external_imports=0 + hermes_handlers split

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,7 +68,8 @@ fluent-bundle = "0.15"
 fluent-langneg = "0.13"
 unic-langid = "0.9"
 
-mongodb = { version = "3.8.0", features = ["bson-chrono-0_4"] }
+mongodb = "3.8.0"
+bson = { version = "2", features = ["chrono-0_4"] }
 futures-util = "0.3.31"
 warp = { version = "0.4.3", optional = true }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,7 +68,7 @@ fluent-bundle = "0.15"
 fluent-langneg = "0.13"
 unic-langid = "0.9"
 
-mongodb = "3.8.0"
+mongodb = { version = "3.8.0", features = ["bson-chrono-0_4"] }
 futures-util = "0.3.31"
 warp = { version = "0.4.3", optional = true }
 

--- a/crates/domain/Cargo.toml
+++ b/crates/domain/Cargo.toml
@@ -4,7 +4,6 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-mongodb = "3.8.0"
 serde = { version = "1.0.229", features = ["derive"] }
 serde_json = "1.0.151"
 chrono = { version = "0.4.38", features = ["serde"] }

--- a/crates/domain/src/lib.rs
+++ b/crates/domain/src/lib.rs
@@ -113,7 +113,7 @@ fn default_color() -> String {
 
 impl CalendarEvent {
     pub fn new(user_id: &str, title: &str, start: DateTime<Utc>, end: DateTime<Utc>) -> Self {
-        let now = DateTime<Utc>::from_millis(chrono::Utc::now().timestamp_millis());
+        let now = chrono::Utc::now();
         CalendarEvent {
             id: uuid::Uuid::new_v4().to_string(),
             user_id: user_id.to_string(),
@@ -162,7 +162,7 @@ impl Email {
             flags: Vec::new(),
             sequence_number: 0,
             uid: 0,
-            internal_date: DateTime<Utc>::from_millis(chrono::Utc::now().timestamp_millis()),
+            internal_date: chrono::Utc::now(),
             dkim_signature: None,
         }
     }

--- a/crates/domain/src/lib.rs
+++ b/crates/domain/src/lib.rs
@@ -1,4 +1,4 @@
-use mongodb::bson;
+use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
@@ -19,10 +19,10 @@ pub struct ExternalImapAccount {
     pub smtp_port: Option<u16>,
     pub smtp_tls: Option<bool>,
     pub status: String,
-    pub last_sync_at: Option<bson::DateTime>,
+    pub last_sync_at: Option<DateTime<Utc>>,
     pub last_error: Option<String>,
-    pub created_at: bson::DateTime,
-    pub updated_at: bson::DateTime,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
@@ -36,8 +36,8 @@ pub struct ExternalImapFolder {
     pub uid_validity: Option<u64>,
     pub highest_uid: Option<u64>,
     pub highest_modseq: Option<u64>,
-    pub created_at: bson::DateTime,
-    pub updated_at: bson::DateTime,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
@@ -53,16 +53,16 @@ pub struct ExternalImapMessage {
     pub from: Option<String>,
     pub to: Option<String>,
     pub subject: Option<String>,
-    pub sent_at: Option<bson::DateTime>,
+    pub sent_at: Option<DateTime<Utc>>,
     #[serde(default)]
     pub flags: Vec<String>,
-    pub internal_date: Option<bson::DateTime>,
+    pub internal_date: Option<DateTime<Utc>>,
     pub body_preview: Option<String>,
     pub raw_ref: Option<String>,
     pub dedup_hash: Option<String>,
     pub deleted: bool,
-    pub created_at: bson::DateTime,
-    pub updated_at: bson::DateTime,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
@@ -74,13 +74,13 @@ pub struct ExternalSyncRun {
     pub mode: String,
     #[serde(default)]
     pub folders: Vec<String>,
-    pub since: Option<bson::DateTime>,
+    pub since: Option<DateTime<Utc>>,
     pub status: String,
     pub stats_fetched: u64,
     pub stats_updated: u64,
     pub stats_deleted: u64,
-    pub started_at: bson::DateTime,
-    pub ended_at: Option<bson::DateTime>,
+    pub started_at: DateTime<Utc>,
+    pub ended_at: Option<DateTime<Utc>>,
     pub error: Option<String>,
 }
 
@@ -91,16 +91,16 @@ pub struct CalendarEvent {
     pub title: String,
     #[serde(default)]
     pub description: String,
-    pub start: bson::DateTime,
-    pub end: bson::DateTime,
+    pub start: DateTime<Utc>,
+    pub end: DateTime<Utc>,
     #[serde(default = "default_event_type")]
     pub event_type: String,
     #[serde(default = "default_color")]
     pub color: String,
     #[serde(default)]
     pub location: String,
-    pub created_at: bson::DateTime,
-    pub updated_at: bson::DateTime,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
 }
 
 fn default_event_type() -> String {
@@ -112,8 +112,8 @@ fn default_color() -> String {
 }
 
 impl CalendarEvent {
-    pub fn new(user_id: &str, title: &str, start: bson::DateTime, end: bson::DateTime) -> Self {
-        let now = bson::DateTime::from_millis(chrono::Utc::now().timestamp_millis());
+    pub fn new(user_id: &str, title: &str, start: DateTime<Utc>, end: DateTime<Utc>) -> Self {
+        let now = DateTime<Utc>::from_millis(chrono::Utc::now().timestamp_millis());
         CalendarEvent {
             id: uuid::Uuid::new_v4().to_string(),
             user_id: user_id.to_string(),
@@ -145,7 +145,7 @@ pub struct Email {
     pub sequence_number: u32,
     #[serde(default)]
     pub uid: u32,
-    pub internal_date: bson::DateTime,
+    pub internal_date: DateTime<Utc>,
     #[serde(default)]
     pub dkim_signature: Option<String>,
 }
@@ -162,7 +162,7 @@ impl Email {
             flags: Vec::new(),
             sequence_number: 0,
             uid: 0,
-            internal_date: bson::DateTime::from_millis(chrono::Utc::now().timestamp_millis()),
+            internal_date: DateTime<Utc>::from_millis(chrono::Utc::now().timestamp_millis()),
             dkim_signature: None,
         }
     }

--- a/src/bin/client.rs
+++ b/src/bin/client.rs
@@ -89,7 +89,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         flags: vec![],
         sequence_number: 0,
         uid: 0,
-        internal_date: mongodb::bson::DateTime::from_millis(Utc::now().timestamp_millis()),
+        internal_date: Utc::now(),
         dkim_signature: None,
     };
 

--- a/src/bin/email_api_dir/auth_handlers/session.rs
+++ b/src/bin/email_api_dir/auth_handlers/session.rs
@@ -237,7 +237,7 @@ pub(crate) async fn auth_register(
         flags: vec![],
         sequence_number: 1,
         uid: 1,
-        internal_date: mongodb::bson::DateTime::from_millis(Utc::now().timestamp_millis()),
+        internal_date: Utc::now(),
         dkim_signature: None,
     };
     if let Err(e) = logic.deliver_to_inbox(&local_part, &welcome).await {
@@ -303,7 +303,7 @@ pub(crate) async fn api_password_reset_request(
         subject: "Password Reset Request".to_string(), body: body_html,
         headers: vec![("Content-Type".to_string(), "text/html; charset=utf-8".to_string())],
         flags: vec![], sequence_number: 0, uid: 0,
-        internal_date: bson::DateTime::from_millis(Utc::now().timestamp_millis()), dkim_signature: None,
+        internal_date: Utc::now(), dkim_signature: None,
     };
     if let Err(e) = logic.deliver_to_inbox(&local, &reset_email).await { eprintln!("password reset email delivery error: {}", e); }
     HttpResponse::Ok().json(serde_json::json!({ "message": "If the address is registered, a reset link has been sent." }))

--- a/src/bin/email_api_dir/external_handlers/sync.rs
+++ b/src/bin/email_api_dir/external_handlers/sync.rs
@@ -198,10 +198,10 @@ pub(crate) struct CalendarQueryParams {
     end: Option<String>, // ISO 8601
 }
 
-pub(crate) fn parse_iso_to_bson(s: &str) -> Option<bson::DateTime> {
+pub(crate) fn parse_iso_to_bson(s: &str) -> Option<chrono::DateTime<chrono::Utc>> {
     chrono::DateTime::parse_from_rfc3339(s)
         .ok()
-        .map(|dt| bson::DateTime::from_millis(dt.timestamp_millis()))
+        .map(|dt| dt.with_timezone(&chrono::Utc))
 }
 
 pub(crate) fn get_user_from_headers(req: &actix_web::HttpRequest) -> String {

--- a/src/bin/email_api_dir/external_handlers/sync.rs
+++ b/src/bin/email_api_dir/external_handlers/sync.rs
@@ -264,8 +264,10 @@ pub(crate) async fn calendar_list_events(
 ) -> impl Responder {
     let user = get_user_from_headers(&req);
 
-    let start_after = query.start.as_ref().and_then(|s| parse_iso_to_bson(s));
-    let start_before = query.end.as_ref().and_then(|s| parse_iso_to_bson(s));
+    let start_after = query.start.as_ref().and_then(|s| parse_iso_to_bson(s))
+        .map(|dt| bson::DateTime::from_millis(dt.timestamp_millis()));
+    let start_before = query.end.as_ref().and_then(|s| parse_iso_to_bson(s))
+        .map(|dt| bson::DateTime::from_millis(dt.timestamp_millis()));
 
     match logic
         .get_calendar_events(&user, start_after, start_before)

--- a/src/bin/email_api_dir/mailbox/send_pipeline.rs
+++ b/src/bin/email_api_dir/mailbox/send_pipeline.rs
@@ -236,7 +236,7 @@ pub(crate) fn build_email_and_message_id(
         flags: vec![],
         sequence_number: 0,
         uid: 0,
-        internal_date: mongodb::bson::DateTime::from_millis(Utc::now().timestamp_millis()),
+        internal_date: Utc::now(),
         dkim_signature: if dkim.dkim_sig.is_empty() {
             None
         } else {

--- a/src/bin/email_api_dir/mailbox/send_queue_worker.rs
+++ b/src/bin/email_api_dir/mailbox/send_queue_worker.rs
@@ -13,7 +13,7 @@ pub(crate) async fn send_queue_worker(mongo: Arc<mongodb::Client>) {
         let coll = mongo
             .database(&db_name)
             .collection::<bson::Document>(SEND_QUEUE_COLL);
-        let now = bson::DateTime::from_millis(Utc::now().timestamp_millis());
+        let now = Utc::now();
 
         let cursor = match coll
             .find(doc! {
@@ -129,7 +129,7 @@ pub(crate) async fn send_queue_worker(mongo: Arc<mongodb::Client>) {
                 flags: vec![],
                 sequence_number: 0,
                 uid: 0,
-                internal_date: bson::DateTime::from_millis(Utc::now().timestamp_millis()),
+                internal_date: Utc::now(),
                 dkim_signature: if dkim_sig.is_empty() {
                     None
                 } else {

--- a/src/bin/email_api_dir/main.rs
+++ b/src/bin/email_api_dir/main.rs
@@ -176,9 +176,7 @@ async fn send_email_handler(
                         flags: vec![],
                         sequence_number: 0,
                         uid: 0,
-                        internal_date: mongodb::bson::DateTime::from_millis(
-                            Utc::now().timestamp_millis(),
-                        ),
+                        internal_date: Utc::now(),
                         dkim_signature: Some(sig),
                     };
 

--- a/src/external_imap/account_ops.rs
+++ b/src/external_imap/account_ops.rs
@@ -10,7 +10,7 @@ impl ExternalImapService {
         owner_user_id: &str,
         input: CreateExternalAccountInput,
     ) -> Result<ExternalImapAccount> {
-        let now = bson::DateTime::from_millis(Utc::now().timestamp_millis());
+        let now = Utc::now();
         let account = ExternalImapAccount {
             id: Uuid::new_v4().to_string(),
             owner_user_id: owner_user_id.to_string(),
@@ -76,7 +76,7 @@ impl ExternalImapService {
         input: UpdateExternalAccountInput,
     ) -> Result<Option<ExternalImapAccount>> {
         let mut set_doc = doc! {
-            "updatedAt": bson::DateTime::from_millis(Utc::now().timestamp_millis())
+            "updatedAt": Utc::now()
         };
 
         if let Some(v) = input.provider { set_doc.insert("provider", v); }

--- a/src/external_imap/folder_ops.rs
+++ b/src/external_imap/folder_ops.rs
@@ -35,7 +35,7 @@ impl ExternalImapService {
                 doc! {
                     "$set": {
                         "localRole": local_role,
-                        "updatedAt": bson::DateTime::from_millis(Utc::now().timestamp_millis()),
+                        "updatedAt": Utc::now(),
                     }
                 },
             )
@@ -59,7 +59,7 @@ impl ExternalImapService {
         remote_name: &str,
         local_role: &str,
     ) -> Result<ExternalImapFolder> {
-        let now = bson::DateTime::from_millis(Utc::now().timestamp_millis());
+        let now = Utc::now();
         let existing = self
             .coll_folders()
             .find_one(doc! {

--- a/src/external_imap/imap_client_ops.rs
+++ b/src/external_imap/imap_client_ops.rs
@@ -84,7 +84,7 @@ impl ExternalImapService {
 
         // Compute the SEARCH SINCE date from run.since (default: today).
         let since_bson = run.since.unwrap_or_else(|| {
-            bson::DateTime::from_millis(Utc::now().timestamp_millis())
+            Utc::now()
         });
         let since_chrono = chrono::DateTime::<Utc>::from_timestamp_millis(
             since_bson.timestamp_millis(),
@@ -133,19 +133,15 @@ impl ExternalImapService {
 
         // Persist headers: dedupe on (account_id, remote_uid) via replace_one
         // upsert to keep the sync idempotent.
-        let now = bson::DateTime::from_millis(Utc::now().timestamp_millis());
+        let now = Utc::now();
         let mut fetched = 0u64;
         let folder_id = inbox_folder.as_ref().map(|f| f.id.clone());
 
         for h in fetched_headers {
             let msg_id_header = h.message_id.clone();
             let dedup = format!("uid:{}:{}", account.id, h.uid);
-            let internal_dt = h
-                .internal_date
-                .map(|dt| bson::DateTime::from_millis(dt.timestamp_millis()));
-            let sent_dt = h
-                .date
-                .map(|dt| bson::DateTime::from_millis(dt.timestamp_millis()));
+            let internal_dt = h.internal_date;
+            let sent_dt = h.date;
 
             let doc_id = Uuid::new_v4().to_string();
             let msg = ExternalImapMessage {
@@ -185,9 +181,9 @@ impl ExternalImapService {
             .update_one(
                 doc! { "ownerUserId": owner_user_id, "id": &account.id },
                 doc! { "$set": {
-                    "lastSyncAt": bson::DateTime::from_millis(Utc::now().timestamp_millis()),
+                    "lastSyncAt": Utc::now(),
                     "lastError": bson::Bson::Null,
-                    "updatedAt": bson::DateTime::from_millis(Utc::now().timestamp_millis())
+                    "updatedAt": Utc::now()
                 }},
             )
             .await?;

--- a/src/external_imap/mod.rs
+++ b/src/external_imap/mod.rs
@@ -164,10 +164,10 @@ pub(crate) fn redact_account(mut a: ExternalImapAccount) -> ExternalImapAccount 
     a
 }
 
-pub(crate) fn parse_rfc3339_as_bson(s: &String) -> Option<bson::DateTime> {
+pub(crate) fn parse_rfc3339_as_bson(s: &String) -> Option<chrono::DateTime<chrono::Utc>> {
     chrono::DateTime::parse_from_rfc3339(s)
         .ok()
-        .map(|dt| bson::DateTime::from_millis(dt.timestamp_millis()))
+        .map(|dt| dt.with_timezone(&chrono::Utc))
 }
 
 pub(crate) fn infer_role(remote_name: &str) -> String {

--- a/src/external_imap/sync_ops.rs
+++ b/src/external_imap/sync_ops.rs
@@ -11,7 +11,7 @@ impl ExternalImapService {
         account_id: &str,
         input: &StartSyncInput,
     ) -> Result<ExternalSyncRun> {
-        let now = bson::DateTime::from_millis(Utc::now().timestamp_millis());
+        let now = Utc::now();
         let since_dt = input.since.as_ref().and_then(parse_rfc3339_as_bson);
 
         let run = ExternalSyncRun {


### PR DESCRIPTION
**Cycle 19 combin\u00e9** :
- Purge `mongodb::bson` de `crates/domain` (bson::DateTime \u2192 chrono::DateTime<Utc>)
- Retire `mongodb` de crates/domain/Cargo.toml
- domain_external_imports : **1 \u2192 0** \u2705
- Split `admin_ops/hermes_handlers.rs` 372 \u2192 dir (chat 102, runs 140, run 118, types 18)

Zero changement comportemental.