### PR TITLE
fix(ci): complexity audit CCN nom correct

### DIFF
--- a/scripts/complexity_audit.sh
+++ b/scripts/complexity_audit.sh
@@ -2,7 +2,8 @@
 set -eu
 pip install --quiet lizard 2>/dev/null || true
 echo "[audit] Scan CCN Rust src/ + crates/domain/src/ (seuil 8)..."
-RESULT=$(lizard -l rust -T CCN=8 src/ crates/domain/src/ 2>&1 || true)
-VIOL=$(echo "$RESULT" | grep -E "^\s*[0-9]+\s+\S+\s+[0-9]+" | awk '$3 > 8' | wc -l || echo 0)
+# lizard -T seuil sur cyclomatic_complexity (nom correct depuis lizard 1.17+)
+RESULT=$(lizard -l rust -T cyclomatic_complexity=8 src/ crates/domain/src/ --warnings_only 2>&1 || true)
+VIOL=$(echo "$RESULT" | grep -cE "^\s*[0-9]+\s+[0-9]+\s+[0-9]+\s+[0-9]+\s+[0-9]+" || echo 0)
 echo "$RESULT" | tail -20
 echo "[audit] Fonctions CCN > 8 : $VIOL"


### PR DESCRIPTION
Le script utilisait `CCN` au lieu de `cyclomatic_complexity` (nom accept\u00e9 par lizard 1.17+).