### PR TITLE
refactor(cycle25): 4th hexagonal port — EmailMutationPort

### DIFF
--- a/crates/domain/src/ports.rs
+++ b/crates/domain/src/ports.rs
@@ -55,3 +55,19 @@ pub trait MailboxSubscriptionPort: Send + Sync {
     /// IMAP UNSUBSCRIBE — retire la mailbox de la liste des abonnements.
     async fn unsubscribe_mailbox(&self, mailbox: &str) -> DomainResult<()>;
 }
+
+/// Port mutation email — opérations sur un email identifié par id.
+///
+/// Cycle 25 : 4ème port migré depuis `DatabaseInterface`
+/// (`src/logic/traits.rs`). Autonome : signatures 100 % primitives
+/// (`&str`) et aucun type infrastructure. Regroupe les mutations
+/// sur un email identifié par son id (flag update, delete, archive).
+#[async_trait]
+pub trait EmailMutationPort: Send + Sync {
+    /// Met à jour un flag IMAP sur l'email `email_id`.
+    async fn update_email_flag(&self, email_id: &str, flag: &str) -> DomainResult<()>;
+    /// Supprime l'email `email_id`.
+    async fn delete_email(&self, email_id: &str) -> DomainResult<()>;
+    /// Archive l'email `email_id`.
+    async fn archive_email(&self, email_id: &str) -> DomainResult<()>;
+}

--- a/src/logic/traits.rs
+++ b/src/logic/traits.rs
@@ -194,3 +194,8 @@ pub use simple_smtp_domain::ports::MailboxSessionPort;
 // couvre IMAP SUBSCRIBE / UNSUBSCRIBE (signatures primitives, aucun
 // type infrastructure).
 pub use simple_smtp_domain::ports::MailboxSubscriptionPort;
+
+// Cycle 25 hexagonal — 4ème port migré : `EmailMutationPort` couvre
+// update_email_flag / delete_email / archive_email (signatures &str,
+// aucun type mongodb/bson).
+pub use simple_smtp_domain::ports::EmailMutationPort;


### PR DESCRIPTION
Cycle 25 — 4ème port hexagonal.

Migre depuis `DatabaseInterface` (src/logic/traits.rs) :
- `update_email_flag(&str, &str)`
- `delete_email(&str)`
- `archive_email(&str)`

Regroupés dans `EmailMutationPort` (crates/domain/src/ports.rs).

Autonome : signatures `&str`, aucun type mongodb/bson.
Re-export via `src/logic/traits.rs`. domain_purity=0 préservé.