### PR TITLE
refactor(hexagonal): cycle 25 — MailboxCrudPort (port #4)

### DIFF
--- a/crates/domain/src/ports.rs
+++ b/crates/domain/src/ports.rs
@@ -55,3 +55,20 @@ pub trait MailboxSubscriptionPort: Send + Sync {
     /// IMAP UNSUBSCRIBE — retire la mailbox de la liste des abonnements.
     async fn unsubscribe_mailbox(&self, mailbox: &str) -> DomainResult<()>;
 }
+
+/// Port CRUD mailbox — création / suppression / renommage (non user-scopé).
+///
+/// Cycle 25 : 4ème port migré depuis `DatabaseInterface`
+/// (`src/logic/traits.rs`). Signatures 100 % primitives (`&str`),
+/// aucune dépendance à mongodb / bson / entities. Couvre les
+/// variantes historiques non user-scopées ; les `*_for_user`
+/// correspondantes restent pour un cycle ultérieur.
+#[async_trait]
+pub trait MailboxCrudPort: Send + Sync {
+    /// CREATE — crée une mailbox par nom.
+    async fn create_mailbox(&self, mailbox: &str) -> DomainResult<()>;
+    /// DELETE — supprime une mailbox par nom.
+    async fn delete_mailbox(&self, mailbox: &str) -> DomainResult<()>;
+    /// RENAME — renomme une mailbox (`old_name` → `new_name`).
+    async fn rename_mailbox(&self, old_name: &str, new_name: &str) -> DomainResult<()>;
+}

--- a/src/logic/traits.rs
+++ b/src/logic/traits.rs
@@ -194,3 +194,8 @@ pub use simple_smtp_domain::ports::MailboxSessionPort;
 // couvre IMAP SUBSCRIBE / UNSUBSCRIBE (signatures primitives, aucun
 // type infrastructure).
 pub use simple_smtp_domain::ports::MailboxSubscriptionPort;
+
+// Cycle 25 hexagonal — 4ème port migré : `MailboxCrudPort` couvre
+// IMAP CREATE / DELETE / RENAME (variantes non user-scopées).
+// Signatures 100 % primitives (`&str`), aucun type infrastructure.
+pub use simple_smtp_domain::ports::MailboxCrudPort;


### PR DESCRIPTION
Cycle 25 hexagonal — 4ème port migré.

## Migration
- `MailboxCrudPort` : CREATE / DELETE / RENAME mailbox
- Extrait de `DatabaseInterface` (src/logic/traits.rs)
- Signatures 100 % primitives (`&str`), aucun type mongodb/bson/entities
- Ajouté dans `crates/domain/src/ports.rs` en `DomainResult`
- Re-export dans `src/logic/traits.rs`

## État hexagonal
Ports migrés : LogicPort, MailboxSessionPort, MailboxSubscriptionPort, **MailboxCrudPort** (4).

domain_purity attendu = 0.