### PR TITLE
refactor(hexagonal): cycle 26 — MailboxCrudPort (port #5)

### DIFF
--- a/crates/domain/src/ports.rs
+++ b/crates/domain/src/ports.rs
@@ -70,19 +70,4 @@ pub trait MailboxCrudPort: Send + Sync {
     async fn rename_mailbox(&self, old_name: &str, new_name: &str) -> DomainResult<()>;
 }
 
-/// Port CRUD mailbox — création / suppression / renommage (non user-scopé).
-///
-/// Cycle 25 (b) : 5ème port migré depuis `DatabaseInterface`
-/// (`src/logic/traits.rs`). Signatures 100 % primitives (`&str`),
-/// aucune dépendance à mongodb / bson / entities. Couvre les
-/// variantes historiques non user-scopées ; les `*_for_user`
-/// correspondantes restent pour un cycle ultérieur.
-#[async_trait]
-pub trait MailboxCrudPort: Send + Sync {
-    /// CREATE — crée une mailbox par nom.
-    async fn create_mailbox(&self, mailbox: &str) -> DomainResult<()>;
-    /// DELETE — supprime une mailbox par nom.
-    async fn delete_mailbox(&self, mailbox: &str) -> DomainResult<()>;
-    /// RENAME — renomme une mailbox (`old_name` → `new_name`).
-    async fn rename_mailbox(&self, old_name: &str, new_name: &str) -> DomainResult<()>;
-}
+

--- a/crates/domain/src/ports.rs
+++ b/crates/domain/src/ports.rs
@@ -10,12 +10,6 @@ use crate::errors::DomainResult;
 use async_trait::async_trait;
 
 /// Port applicatif — orchestration de haut niveau (use-cases).
-///
-/// Correspond à l'ancien `LogicTrait` de `src/logic/traits.rs`, mais
-/// s'exprime en termes de `DomainResult` pour rester indépendant de
-/// l'infrastructure. Les adapters (ex. `Logic` côté crate racine)
-/// implémentent ce port en convertissant leurs erreurs concrètes via
-/// `From<mongodb::Error> for DomainError`.
 #[async_trait]
 pub trait LogicPort: Send + Sync {
     async fn create_user(
@@ -27,10 +21,6 @@ pub trait LogicPort: Send + Sync {
 }
 
 /// Port session mailbox — opérations IMAP sans argument.
-///
-/// Cycle 23 : extrait de `DatabaseInterface` (`src/logic/traits.rs`).
-/// Ces trois primitives ne dépendent d'aucun type infrastructure et
-/// constituent la 2ème migration hexagonale (Phase 3).
 #[async_trait]
 pub trait MailboxSessionPort: Send + Sync {
     /// IMAP NOOP — keep-alive / poll d'état.
@@ -42,12 +32,6 @@ pub trait MailboxSessionPort: Send + Sync {
 }
 
 /// Port souscription mailbox — IMAP SUBSCRIBE / UNSUBSCRIBE.
-///
-/// Cycle 24 : 3ème port migré depuis `DatabaseInterface`
-/// (`src/logic/traits.rs`). Autonome : signatures 100 % primitives
-/// (`&str`) et pas de types infrastructure. Couvre la variante
-/// non-user-scopée héritée ; les variantes `*_for_user` restent pour
-/// une migration ultérieure.
 #[async_trait]
 pub trait MailboxSubscriptionPort: Send + Sync {
     /// IMAP SUBSCRIBE — ajoute la mailbox à la liste des abonnements.
@@ -58,10 +42,8 @@ pub trait MailboxSubscriptionPort: Send + Sync {
 
 /// Port mutation email — opérations sur un email identifié par id.
 ///
-/// Cycle 25 : 4ème port migré depuis `DatabaseInterface`
-/// (`src/logic/traits.rs`). Autonome : signatures 100 % primitives
-/// (`&str`) et aucun type infrastructure. Regroupe les mutations
-/// sur un email identifié par son id (flag update, delete, archive).
+/// Cycle 25 (a) : 4ème port migré depuis `DatabaseInterface`.
+/// Autonome : signatures 100 % primitives (`&str`).
 #[async_trait]
 pub trait EmailMutationPort: Send + Sync {
     /// Met à jour un flag IMAP sur l'email `email_id`.
@@ -70,4 +52,37 @@ pub trait EmailMutationPort: Send + Sync {
     async fn delete_email(&self, email_id: &str) -> DomainResult<()>;
     /// Archive l'email `email_id`.
     async fn archive_email(&self, email_id: &str) -> DomainResult<()>;
+}
+
+/// Port CRUD mailbox — création / suppression / renommage.
+///
+/// Cycle 26 : 5ème port migré depuis `DatabaseInterface`
+/// (`src/logic/traits.rs`). Autonome : signatures 100 % primitives
+/// (`&str`) et aucun type infrastructure. Regroupe les opérations
+/// structurelles sur une mailbox (variante non user-scopée).
+#[async_trait]
+pub trait MailboxCrudPort: Send + Sync {
+    /// IMAP CREATE — crée la mailbox `mailbox`.
+    async fn create_mailbox(&self, mailbox: &str) -> DomainResult<()>;
+    /// IMAP DELETE — supprime la mailbox `mailbox`.
+    async fn delete_mailbox(&self, mailbox: &str) -> DomainResult<()>;
+    /// IMAP RENAME — renomme `old_name` vers `new_name`.
+    async fn rename_mailbox(&self, old_name: &str, new_name: &str) -> DomainResult<()>;
+}
+
+/// Port CRUD mailbox — création / suppression / renommage (non user-scopé).
+///
+/// Cycle 25 (b) : 5ème port migré depuis `DatabaseInterface`
+/// (`src/logic/traits.rs`). Signatures 100 % primitives (`&str`),
+/// aucune dépendance à mongodb / bson / entities. Couvre les
+/// variantes historiques non user-scopées ; les `*_for_user`
+/// correspondantes restent pour un cycle ultérieur.
+#[async_trait]
+pub trait MailboxCrudPort: Send + Sync {
+    /// CREATE — crée une mailbox par nom.
+    async fn create_mailbox(&self, mailbox: &str) -> DomainResult<()>;
+    /// DELETE — supprime une mailbox par nom.
+    async fn delete_mailbox(&self, mailbox: &str) -> DomainResult<()>;
+    /// RENAME — renomme une mailbox (`old_name` → `new_name`).
+    async fn rename_mailbox(&self, old_name: &str, new_name: &str) -> DomainResult<()>;
 }

--- a/src/bin/email_api_dir/monitoring_handlers/shared.rs
+++ b/src/bin/email_api_dir/monitoring_handlers/shared.rs
@@ -1,0 +1,132 @@
+// Shared helpers and query types for monitoring_handlers submodules
+// Extracted from monitoring_handlers.rs in cycle 26 (LOC split).
+
+use chrono::Utc;
+use serde::Deserialize;
+
+// ─── Shared helpers ────────────────────────────────────────────────────────
+
+pub(crate) fn parse_window(s: &str) -> chrono::Duration {
+    let s = s.trim();
+    if let Some(n) = s.strip_suffix('m').and_then(|n| n.parse::<i64>().ok()) {
+        chrono::Duration::minutes(n)
+    } else if let Some(n) = s.strip_suffix('h').and_then(|n| n.parse::<i64>().ok()) {
+        chrono::Duration::hours(n)
+    } else if let Some(n) = s.strip_suffix('d').and_then(|n| n.parse::<i64>().ok()) {
+        chrono::Duration::days(n)
+    } else {
+        chrono::Duration::minutes(15)
+    }
+}
+
+pub(crate) fn since_str(window: &str) -> String {
+    let dur = parse_window(window);
+    (Utc::now() - dur).to_rfc3339()
+}
+
+pub(crate) fn default_monitoring_window() -> String {
+    "15m".into()
+}
+
+pub(crate) fn default_window() -> String {
+    "1h".into()
+}
+
+pub(crate) fn default_mon_page() -> u32 {
+    1
+}
+pub(crate) fn default_mon_page_size() -> u32 {
+    50
+}
+
+pub(crate) fn one() -> u32 {
+    1
+}
+pub(crate) fn twenty() -> u32 {
+    20
+}
+
+// ─── Query types ───────────────────────────────────────────────────────────
+
+#[derive(Deserialize)]
+pub(crate) struct MonitoringWindowQuery {
+    #[serde(default = "default_monitoring_window")]
+    pub window: String,
+}
+
+#[derive(Deserialize)]
+pub(crate) struct MonitoringEventsQuery {
+    pub status: Option<String>,
+    pub from: Option<String>,
+    pub to: Option<String>,
+    pub provider: Option<String>,
+    pub country: Option<String>,
+    pub since: Option<String>,
+    pub until: Option<String>,
+    pub message_id: Option<String>,
+    #[serde(default = "default_mon_page")]
+    pub page: u32,
+    #[serde(default = "default_mon_page_size")]
+    pub page_size: u32,
+}
+
+#[derive(Deserialize)]
+pub(crate) struct MonitoringLiveQuery {
+    pub message_id: Option<String>,
+}
+
+#[derive(Deserialize)]
+pub(crate) struct AdminWindowQuery {
+    #[serde(default = "default_window")]
+    pub window: String,
+}
+
+#[derive(serde::Deserialize)]
+pub(crate) struct SecurityAlertsQuery {
+    #[serde(default = "default_window")]
+    pub window: String,
+    pub severity: Option<String>,
+    pub tenant_id: Option<String>,
+}
+
+#[derive(serde::Deserialize)]
+pub(crate) struct SecurityIncidentsQuery {
+    #[serde(default = "one")]
+    pub page: u32,
+    #[serde(default = "twenty")]
+    pub page_size: u32,
+    pub tenant_id: Option<String>,
+    pub severity: Option<String>,
+}
+
+// ─── Misc helpers used by admin_ops_handlers via super::* ─────────────
+
+pub(crate) fn env_bool(name: &str, default: bool) -> bool {
+    match std::env::var(name) {
+        Ok(v) => matches!(
+            v.trim().to_ascii_lowercase().as_str(),
+            "1" | "true" | "yes" | "on"
+        ),
+        Err(_) => default,
+    }
+}
+
+pub(crate) async fn dns_txt_lookup(name: &str) -> Vec<String> {
+    use trust_dns_resolver::config::{ResolverConfig, ResolverOpts};
+    use trust_dns_resolver::TokioAsyncResolver;
+
+    let resolver = TokioAsyncResolver::tokio(ResolverConfig::default(), ResolverOpts::default());
+    let mut rows: Vec<String> = Vec::new();
+
+    if let Ok(lookup) = resolver.txt_lookup(name).await {
+        for txt in lookup.iter() {
+            for part in txt.txt_data() {
+                if let Ok(s) = std::str::from_utf8(part) {
+                    rows.push(s.to_string());
+                }
+            }
+        }
+    }
+
+    rows
+}

--- a/src/logic/traits.rs
+++ b/src/logic/traits.rs
@@ -199,3 +199,8 @@ pub use simple_smtp_domain::ports::MailboxSubscriptionPort;
 // update_email_flag / delete_email / archive_email (signatures &str,
 // aucun type mongodb/bson).
 pub use simple_smtp_domain::ports::EmailMutationPort;
+
+// Cycle 25 (b) hexagonal — 5ème port migré : `MailboxCrudPort` couvre
+// IMAP CREATE / DELETE / RENAME (variantes non user-scopées).
+// Signatures 100 % primitives (`&str`), aucun type infrastructure.
+pub use simple_smtp_domain::ports::MailboxCrudPort;

--- a/src/logic/traits.rs
+++ b/src/logic/traits.rs
@@ -200,7 +200,7 @@ pub use simple_smtp_domain::ports::MailboxSubscriptionPort;
 // aucun type mongodb/bson).
 pub use simple_smtp_domain::ports::EmailMutationPort;
 
-// Cycle 25 (b) hexagonal — 5ème port migré : `MailboxCrudPort` couvre
+// Cycle 26 hexagonal — 5ème port migré : `MailboxCrudPort` couvre
 // IMAP CREATE / DELETE / RENAME (variantes non user-scopées).
 // Signatures 100 % primitives (`&str`), aucun type infrastructure.
 pub use simple_smtp_domain::ports::MailboxCrudPort;


### PR DESCRIPTION
Cycle 26 hexagonal — 5ème port migré (suit PR #325 EmailMutationPort).

## Migration
- `MailboxCrudPort` : CREATE / DELETE / RENAME mailbox
- Extrait de `DatabaseInterface` (`src/logic/traits.rs`)
- Signatures 100 % primitives (`&str`), aucun type mongodb/bson/entities
- Ajouté dans `crates/domain/src/ports.rs` en `DomainResult`
- Re-export dans `src/logic/traits.rs`

## État hexagonal
Ports migrés : LogicPort, MailboxSessionPort, MailboxSubscriptionPort, EmailMutationPort, **MailboxCrudPort** (5).

domain_purity attendu = 0.