### PR TITLE
refactor(cycle26-loc): split monitoring_handlers.rs (486→265 LOC)

### DIFF
--- a/src/bin/email_api_dir/monitoring_handlers/mod.rs
+++ b/src/bin/email_api_dir/monitoring_handlers/mod.rs
@@ -1,0 +1,11 @@
+// monitoring_handlers — split into submodules in cycle 26 (LOC reduction)
+// Public API preserved via `pub use` re-exports; parent uses `pub use monitoring_handlers::*`.
+
+mod monitoring;
+mod security;
+mod shared;
+
+pub(crate) use monitoring::*;
+pub(crate) use security::*;
+#[allow(unused_imports)]
+pub(crate) use shared::*;

--- a/src/bin/email_api_dir/monitoring_handlers/monitoring.rs
+++ b/src/bin/email_api_dir/monitoring_handlers/monitoring.rs
@@ -1,115 +1,18 @@
-// monitoring_handlers.rs — extracted from email_api_dir/main.rs Sprint 2
-// Handlers: api_monitoring_*, api_security_*
-// All shared types/imports are redeclared here so this module compiles independently.
+// Monitoring endpoints handlers (summary, events, trace, bounces, providers, live, alerts)
+// Extracted from monitoring_handlers.rs in cycle 26 (LOC split).
 
 use actix_web::{web, HttpResponse};
-use chrono::Utc;
 use futures_util::stream;
 use mongodb::bson::doc;
-use serde::Deserialize;
 use simple_smtp_server::monitoring;
 use simple_smtp_server::monitoring::alerts::AlertConfig;
 use simple_smtp_server::monitoring::storage;
-use simple_smtp_server::security;
 use std::sync::Arc;
 use tokio::sync::broadcast;
 
-// ─── Shared helpers ────────────────────────────────────────────────────────
-
-pub(crate) fn parse_window(s: &str) -> chrono::Duration {
-    let s = s.trim();
-    if let Some(n) = s.strip_suffix('m').and_then(|n| n.parse::<i64>().ok()) {
-        chrono::Duration::minutes(n)
-    } else if let Some(n) = s.strip_suffix('h').and_then(|n| n.parse::<i64>().ok()) {
-        chrono::Duration::hours(n)
-    } else if let Some(n) = s.strip_suffix('d').and_then(|n| n.parse::<i64>().ok()) {
-        chrono::Duration::days(n)
-    } else {
-        chrono::Duration::minutes(15)
-    }
-}
-
-pub(crate) fn since_str(window: &str) -> String {
-    let dur = parse_window(window);
-    (Utc::now() - dur).to_rfc3339()
-}
-
-pub(crate) fn default_monitoring_window() -> String {
-    "15m".into()
-}
-
-pub(crate) fn default_window() -> String {
-    "1h".into()
-}
-
-pub(crate) fn default_mon_page() -> u32 {
-    1
-}
-pub(crate) fn default_mon_page_size() -> u32 {
-    50
-}
-
-pub(crate) fn one() -> u32 {
-    1
-}
-pub(crate) fn twenty() -> u32 {
-    20
-}
-
-// ─── Query types ───────────────────────────────────────────────────────────
-
-#[derive(Deserialize)]
-pub(crate) struct MonitoringWindowQuery {
-    #[serde(default = "default_monitoring_window")]
-    pub window: String,
-}
-
-#[derive(Deserialize)]
-pub(crate) struct MonitoringEventsQuery {
-    pub status: Option<String>,
-    pub from: Option<String>,
-    pub to: Option<String>,
-    pub provider: Option<String>,
-    pub country: Option<String>,
-    pub since: Option<String>,
-    pub until: Option<String>,
-    pub message_id: Option<String>,
-    #[serde(default = "default_mon_page")]
-    pub page: u32,
-    #[serde(default = "default_mon_page_size")]
-    pub page_size: u32,
-}
-
-#[derive(Deserialize)]
-pub(crate) struct MonitoringLiveQuery {
-    pub message_id: Option<String>,
-}
-
-#[derive(Deserialize)]
-pub(crate) struct AdminWindowQuery {
-    #[serde(default = "default_window")]
-    pub window: String,
-}
-
-#[derive(serde::Deserialize)]
-pub(crate) struct SecurityAlertsQuery {
-    #[serde(default = "default_window")]
-    pub window: String,
-    pub severity: Option<String>,
-    pub tenant_id: Option<String>,
-}
-
-#[derive(serde::Deserialize)]
-pub(crate) struct SecurityIncidentsQuery {
-    #[serde(default = "one")]
-    pub page: u32,
-    #[serde(default = "twenty")]
-    pub page_size: u32,
-    pub tenant_id: Option<String>,
-    pub severity: Option<String>,
-}
-
-// ─── Monitoring handlers ────────────────────────────────────────────────────
+use super::shared::{
+    parse_window, since_str, MonitoringEventsQuery, MonitoringLiveQuery, MonitoringWindowQuery,
+};
 
 /// GET /api/monitoring/summary?window=15m
 pub(crate) async fn api_monitoring_summary(
@@ -140,12 +43,8 @@ pub(crate) async fn api_monitoring_summary(
         let status = doc.get_str("_id").unwrap_or("unknown").to_string();
         let count = doc.get_i64("count").unwrap_or(0) as u64;
         let avg_ms = doc.get_f64("avg_ms").unwrap_or(0.0);
-        if status == "delivered" {
-            total_delivered = count;
-        }
-        if status == "bounced" {
-            total_bounced = count;
-        }
+        if status == "delivered" { total_delivered = count; }
+        if status == "bounced" { total_bounced = count; }
         avg_total_ms_sum += avg_ms * count as f64;
         avg_count += count as u32;
         by_status.insert(status, serde_json::json!(count));
@@ -164,10 +63,7 @@ pub(crate) async fn api_monitoring_summary(
         ],
     )
     .await;
-    let avg_risk = risk_docs
-        .first()
-        .and_then(|d| d.get_f64("avg_risk").ok())
-        .unwrap_or(0.0);
+    let avg_risk = risk_docs.first().and_then(|d| d.get_f64("avg_risk").ok()).unwrap_or(0.0);
 
     HttpResponse::Ok().json(serde_json::json!({
         "window": query.window,
@@ -230,15 +126,13 @@ pub(crate) async fn api_monitoring_trace(
     let status = events
         .iter()
         .rev()
-        .find(|e| {
-            matches!(
-                e.status,
-                monitoring::SmtpStatus::Delivered
-                    | monitoring::SmtpStatus::Bounced
-                    | monitoring::SmtpStatus::Failed
-                    | monitoring::SmtpStatus::Deferred
-            )
-        })
+        .find(|e| matches!(
+            e.status,
+            monitoring::SmtpStatus::Delivered
+                | monitoring::SmtpStatus::Bounced
+                | monitoring::SmtpStatus::Failed
+                | monitoring::SmtpStatus::Deferred
+        ))
         .or_else(|| events.last())
         .map(|e| format!("{:?}", e.status))
         .unwrap_or_default();
@@ -368,119 +262,4 @@ pub(crate) async fn api_monitoring_alerts_active(
     let config = AlertConfig::default();
     let alerts = monitoring::alerts::evaluate_alerts(&mongo, window_minutes, &config).await;
     HttpResponse::Ok().json(serde_json::json!({ "window": query.window, "alert_count": alerts.len(), "alerts": alerts }))
-}
-
-// ─── Security handlers ──────────────────────────────────────────────────────
-
-pub(crate) async fn api_security_alerts_active(
-    query: web::Query<SecurityAlertsQuery>,
-    mongo: web::Data<Arc<mongodb::Client>>,
-) -> impl actix_web::Responder {
-    use simple_smtp_server::security::audit;
-    let mut alerts = audit::query_active_alerts(&mongo, 100).await;
-    if let Some(ref sev) = query.severity {
-        let sev_lc = sev.to_lowercase();
-        alerts.retain(|a| format!("{:?}", a.severity).to_lowercase() == sev_lc);
-    }
-    if let Some(ref tid) = query.tenant_id {
-        alerts.retain(|a| a.tenant_id.as_deref() == Some(tid.as_str()));
-    }
-    HttpResponse::Ok().json(serde_json::json!({ "window": query.window, "alert_count": alerts.len(), "alerts": alerts }))
-}
-
-pub(crate) async fn api_security_incidents(
-    query: web::Query<SecurityIncidentsQuery>,
-    mongo: web::Data<Arc<mongodb::Client>>,
-) -> impl actix_web::Responder {
-    use simple_smtp_server::security::audit;
-    let mut filter = doc! {};
-    if let Some(ref tid) = query.tenant_id { filter.insert("tenant_id", tid.as_str()); }
-    if let Some(ref sev) = query.severity  { filter.insert("severity",  sev.as_str()); }
-    let alerts = audit::query_alerts(&mongo, filter, query.page, query.page_size).await;
-    HttpResponse::Ok().json(serde_json::json!({ "page": query.page, "page_size": query.page_size, "count": alerts.len(), "alerts": alerts }))
-}
-
-pub(crate) async fn api_security_tenant_status(
-    path: web::Path<String>,
-    mongo: web::Data<Arc<mongodb::Client>>,
-) -> impl actix_web::Responder {
-    let tenant_id = path.into_inner();
-    let db = std::env::var("MONGODB_DATABASE").unwrap_or_else(|_| "mailserver".to_string());
-    let coll = mongo.database(&db).collection::<mongodb::bson::Document>("tenant_state");
-    match coll.find_one(doc! { "tenant_id": &tenant_id }).await {
-        Ok(Some(doc)) => HttpResponse::Ok().json(serde_json::json!({ "tenant_id": tenant_id, "state": doc })),
-        Ok(None) => HttpResponse::Ok().json(serde_json::json!({ "tenant_id": tenant_id, "state": null })),
-        Err(e) => HttpResponse::InternalServerError().json(serde_json::json!({ "error": e.to_string() })),
-    }
-}
-
-pub(crate) async fn api_security_rollback(
-    path: web::Path<String>,
-    mongo: web::Data<Arc<mongodb::Client>>,
-) -> impl actix_web::Responder {
-    use simple_smtp_server::security::remediation;
-    let alert_id = path.into_inner();
-    match remediation::rollback_remediation(&mongo, &alert_id).await {
-        Ok(()) => HttpResponse::Ok().json(serde_json::json!({ "rolled_back": true, "alert_id": alert_id })),
-        Err(e) => HttpResponse::BadRequest().json(serde_json::json!({ "error": e })),
-    }
-}
-
-pub(crate) async fn api_security_live(mongo: web::Data<Arc<mongodb::Client>>) -> impl actix_web::Responder {
-    let rx = match security::get_bus() {
-        Some(tx) => tx.subscribe(),
-        None => return HttpResponse::ServiceUnavailable().body("security bus unavailable"),
-    };
-    let stream = stream::unfold(
-        (rx, tokio::time::interval(std::time::Duration::from_secs(15)), mongo.clone()),
-        |(mut rx, mut hb, mongo)| async move {
-            tokio::select! {
-                Ok(alert) = rx.recv() => {
-                    let data = serde_json::to_string(&alert).unwrap_or_default();
-                    let msg = format!("event: security_alert\ndata: {}\nretry: 3000\n\n", data);
-                    Some((Ok::<_, actix_web::Error>(actix_web::web::Bytes::from(msg)), (rx, hb, mongo)))
-                }
-                _ = hb.tick() => {
-                    Some((Ok(actix_web::web::Bytes::from_static(b": heartbeat\n\n")), (rx, hb, mongo)))
-                }
-            }
-        },
-    );
-    HttpResponse::Ok()
-        .content_type("text/event-stream")
-        .insert_header(("Cache-Control", "no-cache"))
-        .insert_header(("X-Accel-Buffering", "no"))
-        .streaming(stream)
-}
-
-// ─── Shared helpers (used by admin_ops_handlers too via super::*) ─────────────
-
-pub(crate) fn env_bool(name: &str, default: bool) -> bool {
-    match std::env::var(name) {
-        Ok(v) => matches!(
-            v.trim().to_ascii_lowercase().as_str(),
-            "1" | "true" | "yes" | "on"
-        ),
-        Err(_) => default,
-    }
-}
-
-pub(crate) async fn dns_txt_lookup(name: &str) -> Vec<String> {
-    use trust_dns_resolver::config::{ResolverConfig, ResolverOpts};
-    use trust_dns_resolver::TokioAsyncResolver;
-
-    let resolver = TokioAsyncResolver::tokio(ResolverConfig::default(), ResolverOpts::default());
-    let mut rows: Vec<String> = Vec::new();
-
-    if let Ok(lookup) = resolver.txt_lookup(name).await {
-        for txt in lookup.iter() {
-            for part in txt.txt_data() {
-                if let Ok(s) = std::str::from_utf8(part) {
-                    rows.push(s.to_string());
-                }
-            }
-        }
-    }
-
-    rows
 }

--- a/src/bin/email_api_dir/monitoring_handlers/security.rs
+++ b/src/bin/email_api_dir/monitoring_handlers/security.rs
@@ -1,0 +1,91 @@
+// Security endpoints handlers (alerts, incidents, tenant status, rollback, live SSE)
+// Extracted from monitoring_handlers.rs in cycle 26 (LOC split).
+
+use actix_web::{web, HttpResponse};
+use futures_util::stream;
+use mongodb::bson::doc;
+use simple_smtp_server::security;
+use std::sync::Arc;
+
+use super::shared::{SecurityAlertsQuery, SecurityIncidentsQuery};
+
+pub(crate) async fn api_security_alerts_active(
+    query: web::Query<SecurityAlertsQuery>,
+    mongo: web::Data<Arc<mongodb::Client>>,
+) -> impl actix_web::Responder {
+    use simple_smtp_server::security::audit;
+    let mut alerts = audit::query_active_alerts(&mongo, 100).await;
+    if let Some(ref sev) = query.severity {
+        let sev_lc = sev.to_lowercase();
+        alerts.retain(|a| format!("{:?}", a.severity).to_lowercase() == sev_lc);
+    }
+    if let Some(ref tid) = query.tenant_id {
+        alerts.retain(|a| a.tenant_id.as_deref() == Some(tid.as_str()));
+    }
+    HttpResponse::Ok().json(serde_json::json!({ "window": query.window, "alert_count": alerts.len(), "alerts": alerts }))
+}
+
+pub(crate) async fn api_security_incidents(
+    query: web::Query<SecurityIncidentsQuery>,
+    mongo: web::Data<Arc<mongodb::Client>>,
+) -> impl actix_web::Responder {
+    use simple_smtp_server::security::audit;
+    let mut filter = doc! {};
+    if let Some(ref tid) = query.tenant_id { filter.insert("tenant_id", tid.as_str()); }
+    if let Some(ref sev) = query.severity  { filter.insert("severity",  sev.as_str()); }
+    let alerts = audit::query_alerts(&mongo, filter, query.page, query.page_size).await;
+    HttpResponse::Ok().json(serde_json::json!({ "page": query.page, "page_size": query.page_size, "count": alerts.len(), "alerts": alerts }))
+}
+
+pub(crate) async fn api_security_tenant_status(
+    path: web::Path<String>,
+    mongo: web::Data<Arc<mongodb::Client>>,
+) -> impl actix_web::Responder {
+    let tenant_id = path.into_inner();
+    let db = std::env::var("MONGODB_DATABASE").unwrap_or_else(|_| "mailserver".to_string());
+    let coll = mongo.database(&db).collection::<mongodb::bson::Document>("tenant_state");
+    match coll.find_one(doc! { "tenant_id": &tenant_id }).await {
+        Ok(Some(doc)) => HttpResponse::Ok().json(serde_json::json!({ "tenant_id": tenant_id, "state": doc })),
+        Ok(None) => HttpResponse::Ok().json(serde_json::json!({ "tenant_id": tenant_id, "state": null })),
+        Err(e) => HttpResponse::InternalServerError().json(serde_json::json!({ "error": e.to_string() })),
+    }
+}
+
+pub(crate) async fn api_security_rollback(
+    path: web::Path<String>,
+    mongo: web::Data<Arc<mongodb::Client>>,
+) -> impl actix_web::Responder {
+    use simple_smtp_server::security::remediation;
+    let alert_id = path.into_inner();
+    match remediation::rollback_remediation(&mongo, &alert_id).await {
+        Ok(()) => HttpResponse::Ok().json(serde_json::json!({ "rolled_back": true, "alert_id": alert_id })),
+        Err(e) => HttpResponse::BadRequest().json(serde_json::json!({ "error": e })),
+    }
+}
+
+pub(crate) async fn api_security_live(mongo: web::Data<Arc<mongodb::Client>>) -> impl actix_web::Responder {
+    let rx = match security::get_bus() {
+        Some(tx) => tx.subscribe(),
+        None => return HttpResponse::ServiceUnavailable().body("security bus unavailable"),
+    };
+    let stream = stream::unfold(
+        (rx, tokio::time::interval(std::time::Duration::from_secs(15)), mongo.clone()),
+        |(mut rx, mut hb, mongo)| async move {
+            tokio::select! {
+                Ok(alert) = rx.recv() => {
+                    let data = serde_json::to_string(&alert).unwrap_or_default();
+                    let msg = format!("event: security_alert\ndata: {}\nretry: 3000\n\n", data);
+                    Some((Ok::<_, actix_web::Error>(actix_web::web::Bytes::from(msg)), (rx, hb, mongo)))
+                }
+                _ = hb.tick() => {
+                    Some((Ok(actix_web::web::Bytes::from_static(b": heartbeat\n\n")), (rx, hb, mongo)))
+                }
+            }
+        },
+    );
+    HttpResponse::Ok()
+        .content_type("text/event-stream")
+        .insert_header(("Cache-Control", "no-cache"))
+        .insert_header(("X-Accel-Buffering", "no"))
+        .streaming(stream)
+}

--- a/src/bin/email_api_dir/monitoring_handlers/shared.rs
+++ b/src/bin/email_api_dir/monitoring_handlers/shared.rs
@@ -4,8 +4,6 @@
 use chrono::Utc;
 use serde::Deserialize;
 
-// ─── Shared helpers ────────────────────────────────────────────────────────
-
 pub(crate) fn parse_window(s: &str) -> chrono::Duration {
     let s = s.trim();
     if let Some(n) = s.strip_suffix('m').and_then(|n| n.parse::<i64>().ok()) {
@@ -24,29 +22,12 @@ pub(crate) fn since_str(window: &str) -> String {
     (Utc::now() - dur).to_rfc3339()
 }
 
-pub(crate) fn default_monitoring_window() -> String {
-    "15m".into()
-}
-
-pub(crate) fn default_window() -> String {
-    "1h".into()
-}
-
-pub(crate) fn default_mon_page() -> u32 {
-    1
-}
-pub(crate) fn default_mon_page_size() -> u32 {
-    50
-}
-
-pub(crate) fn one() -> u32 {
-    1
-}
-pub(crate) fn twenty() -> u32 {
-    20
-}
-
-// ─── Query types ───────────────────────────────────────────────────────────
+pub(crate) fn default_monitoring_window() -> String { "15m".into() }
+pub(crate) fn default_window() -> String { "1h".into() }
+pub(crate) fn default_mon_page() -> u32 { 1 }
+pub(crate) fn default_mon_page_size() -> u32 { 50 }
+pub(crate) fn one() -> u32 { 1 }
+pub(crate) fn twenty() -> u32 { 20 }
 
 #[derive(Deserialize)]
 pub(crate) struct MonitoringWindowQuery {
@@ -98,8 +79,6 @@ pub(crate) struct SecurityIncidentsQuery {
     pub tenant_id: Option<String>,
     pub severity: Option<String>,
 }
-
-// ─── Misc helpers used by admin_ops_handlers via super::* ─────────────
 
 pub(crate) fn env_bool(name: &str, default: bool) -> bool {
     match std::env::var(name) {


### PR DESCRIPTION
Cycle 26 LOC pass: split `src/bin/email_api_dir/monitoring_handlers.rs` (486 LOC) into 3 focused submodules under `monitoring_handlers/`:

- `monitoring.rs` (265 LOC) — summary, events, trace, bounces, providers/top, live SSE, alerts/active
- `security.rs` (91 LOC) — alerts/active, incidents, tenant/status, rollback, live SSE
- `shared.rs` (111 LOC) — window parsing helpers, Query types, env_bool, dns_txt_lookup

Public API preserved via `pub use *` re-exports; parent's `pub use monitoring_handlers::*` unchanged.

Largest resulting file: 265 LOC (target: <300).

Untouched: `crates/domain`, `src/logic/traits.rs`, workflows.