### PR TITLE
refactor(email_api): cycle28 split hermes_runs from hermes_handlers.rs

### DIFF
--- a/src/bin/email_api_dir/admin_ops/hermes_runs.rs
+++ b/src/bin/email_api_dir/admin_ops/hermes_runs.rs
@@ -1,0 +1,130 @@
+#![allow(unused_imports, dead_code)]
+use super::*;
+
+#[derive(Deserialize)]
+pub(crate) struct HermesRunPath {
+    run_id: String,
+}
+
+pub(crate) async fn api_hermes_run_status(path: web::Path<HermesRunPath>) -> impl Responder {
+    let base = resolve_hermes_base_url();
+    let api_key = match env::var("HERMES_API_KEY") {
+        Ok(v) if !v.trim().is_empty() => v,
+        _ => {
+            return HttpResponse::InternalServerError().json(serde_json::json!({
+                "error": "HERMES_API_KEY is not configured"
+            }))
+        }
+    };
+
+    let url = format!("{}/v1/runs/{}", base, path.run_id);
+    let client = reqwest::Client::new();
+    let response = match client.get(url).bearer_auth(api_key).send().await {
+        Ok(r) => r,
+        Err(e) => {
+            eprintln!("Hermes upstream request error: {}", e);
+            return HttpResponse::BadGateway().json(serde_json::json!({
+                "error": "Hermes upstream unavailable"
+            }));
+        }
+    };
+
+    let status = response.status();
+    let body_json = match response.json::<serde_json::Value>().await {
+        Ok(v) => v,
+        Err(e) => {
+            eprintln!("Hermes upstream JSON parse error: {}", e);
+            return HttpResponse::BadGateway().json(serde_json::json!({
+                "error": "Invalid Hermes upstream response"
+            }));
+        }
+    };
+
+    HttpResponse::build(
+        actix_web::http::StatusCode::from_u16(status.as_u16())
+            .unwrap_or(actix_web::http::StatusCode::BAD_GATEWAY),
+    )
+    .json(body_json)
+}
+
+pub(crate) async fn api_hermes_run_events(path: web::Path<HermesRunPath>, req: HttpRequest) -> impl Responder {
+    let base = resolve_hermes_base_url();
+    let api_key = match env::var("HERMES_API_KEY") {
+        Ok(v) if !v.trim().is_empty() => v,
+        _ => {
+            return HttpResponse::InternalServerError().json(serde_json::json!({
+                "error": "HERMES_API_KEY is not configured"
+            }))
+        }
+    };
+
+    let query_suffix = req
+        .uri()
+        .query()
+        .filter(|q| !q.is_empty())
+        .map(|q| format!("?{}", q))
+        .unwrap_or_default();
+    let url = format!("{}/v1/runs/{}/events{}", base, path.run_id, query_suffix);
+
+    let client = reqwest::Client::new();
+    let upstream = match client
+        .get(url)
+        .bearer_auth(api_key)
+        .header("Accept", "text/event-stream")
+        .send()
+        .await
+    {
+        Ok(r) => r,
+        Err(e) => {
+            eprintln!("Hermes upstream request error: {}", e);
+            return HttpResponse::BadGateway().json(serde_json::json!({
+                "error": "Hermes upstream unavailable"
+            }));
+        }
+    };
+
+    let status = upstream.status();
+    if !status.is_success() {
+        let body_json = match upstream.json::<serde_json::Value>().await {
+            Ok(v) => v,
+            Err(_) => serde_json::json!({ "error": "Hermes upstream error" }),
+        };
+        return HttpResponse::build(
+            actix_web::http::StatusCode::from_u16(status.as_u16())
+                .unwrap_or(actix_web::http::StatusCode::BAD_GATEWAY),
+        )
+        .json(body_json);
+    }
+
+    let content_type = upstream
+        .headers()
+        .get(reqwest::header::CONTENT_TYPE)
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("text/event-stream")
+        .to_string();
+
+    let bytes_stream = upstream
+        .bytes_stream()
+        .map_err(actix_web::error::ErrorBadGateway);
+
+    HttpResponse::build(
+        actix_web::http::StatusCode::from_u16(status.as_u16())
+            .unwrap_or(actix_web::http::StatusCode::BAD_GATEWAY),
+    )
+    .content_type(content_type)
+    .insert_header(("Cache-Control", "no-cache"))
+    .insert_header(("X-Accel-Buffering", "no"))
+    .streaming(bytes_stream)
+}
+
+// --- Calendar types ---
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct ExternalMessagesQuery {
+    pub(crate) account_id: String,
+    pub(crate) folder: Option<String>,
+    pub(crate) page: Option<u64>,
+    pub(crate) page_size: Option<u64>,
+}
+

--- a/src/bin/email_api_dir/admin_ops/mod.rs
+++ b/src/bin/email_api_dir/admin_ops/mod.rs
@@ -242,4 +242,5 @@ pub use user_handlers::*;
 pub use cr_handlers::*;
 pub use ai_handlers::*;
 pub use hermes_handlers::*;
+pub use hermes_runs::*;
 pub use diag_handlers::*;


### PR DESCRIPTION
Extract hermes runs endpoints into new admin_ops/hermes_runs.rs. hermes_handlers.rs 372→245 LOC. Pure move, glob re-export preserved.