### PR TITLE
refactor(hexagonal): cycle 29 — 8th port ExternalImapAccountQueryPort

### DIFF
--- a/crates/domain/src/ports.rs
+++ b/crates/domain/src/ports.rs
@@ -107,3 +107,24 @@ pub trait EmailQueryPort: Send + Sync {
     /// Récupère un email par son `email_id`, ou `None` s'il n'existe pas.
     async fn find_email(&self, email_id: &str) -> DomainResult<Option<crate::Email>>;
 }
+
+/// Port autonome pour la lecture des comptes IMAP externes.
+///
+/// Port hexagonal (cycle 29, 8ème port) exposant les opérations de
+/// **lecture** sur `ExternalImapAccount`. Autonome : dépend uniquement
+/// du type domaine `ExternalImapAccount` et de primitives (`&str`).
+/// Sépare les responsabilités de query côté domaine des couches
+/// d'infrastructure (MongoDB, cache, etc.).
+#[async_trait]
+pub trait ExternalImapAccountQueryPort: Send + Sync {
+    /// Récupère un compte IMAP externe par son `id`, ou `None` s'il n'existe pas.
+    async fn find_external_imap_account(
+        &self,
+        id: &str,
+    ) -> DomainResult<Option<crate::ExternalImapAccount>>;
+    /// Liste tous les comptes IMAP externes appartenant à `owner_user_id`.
+    async fn list_external_imap_accounts_by_owner(
+        &self,
+        owner_user_id: &str,
+    ) -> DomainResult<Vec<crate::ExternalImapAccount>>;
+}

--- a/src/logic/traits.rs
+++ b/src/logic/traits.rs
@@ -209,3 +209,6 @@ pub use simple_smtp_domain::ports::MailboxCrudPort;
 // IMAP SEARCH / EXPUNGE / COPY / STORE (signatures primitives : &str,
 // Vec<String>, Vec<u32>). Aucun type infrastructure.
 pub use simple_smtp_domain::ports::MessageStoreFlagsPort;
+
+/// Re-export du port autonome `ExternalImapAccountQueryPort` (cycle 29 hexagonal, 8ème port).
+pub use simple_smtp_domain::ports::ExternalImapAccountQueryPort;


### PR DESCRIPTION
Cycle 29: adds 8th autonomous hexagonal port ExternalImapAccountQueryPort (read ops on ExternalImapAccount). Re-exported via src/logic/traits.rs.