### PR TITLE
refactor(hexagonal): cycle 30 — 9th port UserAliasPort

### DIFF
--- a/crates/domain/src/ports.rs
+++ b/crates/domain/src/ports.rs
@@ -146,3 +146,13 @@ pub trait MailboxListPort: Send + Sync {
         mailbox: &str,
     ) -> DomainResult<Vec<String>>;
 }
+
+/// Port user alias / locale — opérations administratives sur utilisateurs.
+///
+/// Cycle 30 : 10ème port migré depuis `DatabaseInterface`. Autonome :
+/// signatures 100 % primitives (`&str`), aucun type infrastructure.
+#[async_trait]
+pub trait UserAliasPort: Send + Sync {
+    async fn create_alias(&self, alias: &str, target: &str) -> DomainResult<()>;
+    async fn update_user_locale(&self, username: &str, locale: &str) -> DomainResult<()>;
+}

--- a/src/logic/traits.rs
+++ b/src/logic/traits.rs
@@ -212,3 +212,6 @@ pub use simple_smtp_domain::ports::MessageStoreFlagsPort;
 
 /// Re-export du port autonome `ExternalImapAccountQueryPort` (cycle 29 hexagonal, 8ème port).
 pub use simple_smtp_domain::ports::ExternalImapAccountQueryPort;
+
+// Cycle 30 hexagonal — 10ème port migré : `UserAliasPort` (primitives &str).
+pub use simple_smtp_domain::ports::UserAliasPort;


### PR DESCRIPTION
9ème port migré depuis DatabaseInterface: UserAliasPort (create_alias + update_user_locale). Signatures 100% primitives.