### PR TITLE
refactor(monitoring/alerts): split into env + rules submodules (cycle 36)

### DIFF
--- a/src/monitoring/alerts/env.rs
+++ b/src/monitoring/alerts/env.rs
@@ -1,0 +1,24 @@
+//! Environment variable helpers for alert configuration.
+
+pub(super) fn env_f32(key: &str, default: f32) -> f32 {
+    std::env::var(key)
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(default)
+}
+
+pub(super) fn env_u64(key: &str, default: u64) -> u64 {
+    std::env::var(key)
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(default)
+}
+
+pub(super) fn env_list(key: &str) -> Vec<String> {
+    std::env::var(key)
+        .unwrap_or_default()
+        .split(',')
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+        .collect()
+}

--- a/src/monitoring/alerts/mod.rs
+++ b/src/monitoring/alerts/mod.rs
@@ -1,0 +1,110 @@
+//! Alert engine: config, active-alert model and orchestrator.
+//!
+//! Individual rule checks live in [`rules`]; env parsing in [`env`].
+
+use chrono::{Duration as ChronoDuration, Utc};
+use mongodb::Client;
+use serde::{Deserialize, Serialize};
+
+mod env;
+mod rules;
+
+use env::{env_f32, env_list, env_u64};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AlertConfig {
+    /// Fraction 0–1 (e.g. 0.1 = 10%).
+    pub bounce_rate_threshold: f32,
+    /// Milliseconds.
+    pub p95_total_ms_threshold: u64,
+    /// Number of errors in the window before alerting.
+    pub smtp_spike_threshold: u64,
+    pub forbidden_countries: Vec<String>,
+    pub forbidden_companies: Vec<String>,
+    /// Fraction 0–1: (sent - delivered) / sent above which we alert for silent delivery failures.
+    pub undelivered_ratio_threshold: f32,
+}
+
+impl Default for AlertConfig {
+    fn default() -> Self {
+        AlertConfig {
+            bounce_rate_threshold: env_f32("MONITORING_BOUNCE_RATE_THRESHOLD", 0.1),
+            p95_total_ms_threshold: env_u64("MONITORING_P95_MS_THRESHOLD", 10_000),
+            smtp_spike_threshold: env_u64("MONITORING_SMTP_SPIKE_THRESHOLD", 10),
+            forbidden_countries: env_list("MONITORING_FORBIDDEN_COUNTRIES"),
+            forbidden_companies: env_list("MONITORING_RISKY_COMPANIES"),
+            undelivered_ratio_threshold: env_f32("MONITORING_UNDELIVERED_RATIO_THRESHOLD", 0.1),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ActiveAlert {
+    pub kind: String,
+    pub severity: String,
+    pub message: String,
+    pub value: serde_json::Value,
+    pub threshold: serde_json::Value,
+    pub ts: String,
+}
+
+/// Contexte partagé pour chaque règle : accès mongo + fenêtre.
+pub(crate) struct AlertCtx<'a> {
+    pub client: &'a Client,
+    pub db: String,
+    pub since_str: String,
+    pub window_minutes: i64,
+    pub config: &'a AlertConfig,
+}
+
+impl<'a> AlertCtx<'a> {
+    fn events_coll(&self) -> mongodb::Collection<mongodb::bson::Document> {
+        self.client
+            .database(&self.db)
+            .collection::<mongodb::bson::Document>("smtp_events")
+    }
+}
+
+pub async fn evaluate_alerts(
+    client: &Client,
+    window_minutes: i64,
+    config: &AlertConfig,
+) -> Vec<ActiveAlert> {
+    let ctx = AlertCtx {
+        client,
+        db: std::env::var("MONGODB_DATABASE").unwrap_or_else(|_| "mailserver".to_string()),
+        since_str: (Utc::now() - ChronoDuration::minutes(window_minutes)).to_rfc3339(),
+        window_minutes,
+        config,
+    };
+
+    let mut alerts = Vec::new();
+    if let Some(a) = rules::check_bounce_rate(&ctx).await {
+        alerts.push(a);
+    }
+    alerts.extend(rules::check_smtp_spikes(&ctx).await);
+    if let Some(a) = rules::check_forbidden_countries(&ctx).await {
+        alerts.push(a);
+    }
+    alerts.extend(rules::check_forbidden_companies(&ctx).await);
+    if let Some(a) = rules::check_silent_delivery_failures(&ctx).await {
+        alerts.push(a);
+    }
+    if let Some(a) = rules::check_p95_latency(&ctx).await {
+        alerts.push(a);
+    }
+    alerts
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_alert_config_defaults() {
+        let cfg = AlertConfig::default();
+        assert!(cfg.bounce_rate_threshold > 0.0);
+        assert!(cfg.p95_total_ms_threshold > 0);
+        assert!(cfg.smtp_spike_threshold > 0);
+    }
+}

--- a/src/monitoring/alerts/rules.rs
+++ b/src/monitoring/alerts/rules.rs
@@ -1,63 +1,12 @@
-use chrono::{Duration as ChronoDuration, Utc};
+//! Individual alert rule checks. Each function inspects Mongo state and
+//! returns zero or more [`ActiveAlert`]s.
+
+use chrono::Utc;
 use mongodb::bson::doc;
-use mongodb::Client;
-use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct AlertConfig {
-    /// Fraction 0–1 (e.g. 0.1 = 10%).
-    pub bounce_rate_threshold: f32,
-    /// Milliseconds.
-    pub p95_total_ms_threshold: u64,
-    /// Number of errors in the window before alerting.
-    pub smtp_spike_threshold: u64,
-    pub forbidden_countries: Vec<String>,
-    pub forbidden_companies: Vec<String>,
-    /// Fraction 0–1: (sent - delivered) / sent above which we alert for silent delivery failures.
-    pub undelivered_ratio_threshold: f32,
-}
+use super::{ActiveAlert, AlertCtx};
 
-impl Default for AlertConfig {
-    fn default() -> Self {
-        AlertConfig {
-            bounce_rate_threshold: env_f32("MONITORING_BOUNCE_RATE_THRESHOLD", 0.1),
-            p95_total_ms_threshold: env_u64("MONITORING_P95_MS_THRESHOLD", 10_000),
-            smtp_spike_threshold: env_u64("MONITORING_SMTP_SPIKE_THRESHOLD", 10),
-            forbidden_countries: env_list("MONITORING_FORBIDDEN_COUNTRIES"),
-            forbidden_companies: env_list("MONITORING_RISKY_COMPANIES"),
-            undelivered_ratio_threshold: env_f32("MONITORING_UNDELIVERED_RATIO_THRESHOLD", 0.1),
-        }
-    }
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct ActiveAlert {
-    pub kind: String,
-    pub severity: String,
-    pub message: String,
-    pub value: serde_json::Value,
-    pub threshold: serde_json::Value,
-    pub ts: String,
-}
-
-/// Contexte partagé pour chaque règle : accès mongo + fenêtre.
-struct AlertCtx<'a> {
-    client: &'a Client,
-    db: String,
-    since_str: String,
-    window_minutes: i64,
-    config: &'a AlertConfig,
-}
-
-impl<'a> AlertCtx<'a> {
-    fn events_coll(&self) -> mongodb::Collection<mongodb::bson::Document> {
-        self.client
-            .database(&self.db)
-            .collection::<mongodb::bson::Document>("smtp_events")
-    }
-}
-
-async fn check_bounce_rate(ctx: &AlertCtx<'_>) -> Option<ActiveAlert> {
+pub(super) async fn check_bounce_rate(ctx: &AlertCtx<'_>) -> Option<ActiveAlert> {
     let coll = ctx.events_coll();
     let total = coll
         .count_documents(doc! { "ts": { "$gte": &ctx.since_str } })
@@ -88,7 +37,7 @@ async fn check_bounce_rate(ctx: &AlertCtx<'_>) -> Option<ActiveAlert> {
     })
 }
 
-async fn check_smtp_spikes(ctx: &AlertCtx<'_>) -> Vec<ActiveAlert> {
+pub(super) async fn check_smtp_spikes(ctx: &AlertCtx<'_>) -> Vec<ActiveAlert> {
     let coll = ctx.events_coll();
     let mut out = Vec::new();
     for &code in &[421u32, 450, 550, 554] {
@@ -117,7 +66,7 @@ async fn check_smtp_spikes(ctx: &AlertCtx<'_>) -> Vec<ActiveAlert> {
     out
 }
 
-async fn check_forbidden_countries(ctx: &AlertCtx<'_>) -> Option<ActiveAlert> {
+pub(super) async fn check_forbidden_countries(ctx: &AlertCtx<'_>) -> Option<ActiveAlert> {
     if ctx.config.forbidden_countries.is_empty() {
         return None;
     }
@@ -151,7 +100,7 @@ async fn check_forbidden_countries(ctx: &AlertCtx<'_>) -> Option<ActiveAlert> {
     })
 }
 
-async fn check_forbidden_companies(ctx: &AlertCtx<'_>) -> Vec<ActiveAlert> {
+pub(super) async fn check_forbidden_companies(ctx: &AlertCtx<'_>) -> Vec<ActiveAlert> {
     let coll = ctx.events_coll();
     let mut out = Vec::new();
     for company in &ctx.config.forbidden_companies {
@@ -179,7 +128,7 @@ async fn check_forbidden_companies(ctx: &AlertCtx<'_>) -> Vec<ActiveAlert> {
     out
 }
 
-async fn check_silent_delivery_failures(ctx: &AlertCtx<'_>) -> Option<ActiveAlert> {
+pub(super) async fn check_silent_delivery_failures(ctx: &AlertCtx<'_>) -> Option<ActiveAlert> {
     let mail_coll = ctx
         .client
         .database(&ctx.db)
@@ -215,8 +164,8 @@ async fn check_silent_delivery_failures(ctx: &AlertCtx<'_>) -> Option<ActiveAler
     })
 }
 
-async fn check_p95_latency(ctx: &AlertCtx<'_>) -> Option<ActiveAlert> {
-    let p95 = super::storage::p95_total_ms(
+pub(super) async fn check_p95_latency(ctx: &AlertCtx<'_>) -> Option<ActiveAlert> {
+    let p95 = crate::monitoring::storage::p95_total_ms(
         ctx.client,
         doc! { "ts": { "$gte": &ctx.since_str } },
         1000,
@@ -236,79 +185,4 @@ async fn check_p95_latency(ctx: &AlertCtx<'_>) -> Option<ActiveAlert> {
         threshold: serde_json::json!(ctx.config.p95_total_ms_threshold),
         ts: Utc::now().to_rfc3339(),
     })
-}
-
-pub async fn evaluate_alerts(
-    client: &Client,
-    window_minutes: i64,
-    config: &AlertConfig,
-) -> Vec<ActiveAlert> {
-    let ctx = AlertCtx {
-        client,
-        db: std::env::var("MONGODB_DATABASE").unwrap_or_else(|_| "mailserver".to_string()),
-        since_str: (Utc::now() - ChronoDuration::minutes(window_minutes)).to_rfc3339(),
-        window_minutes,
-        config,
-    };
-
-    let mut alerts = Vec::new();
-    if let Some(a) = check_bounce_rate(&ctx).await {
-        alerts.push(a);
-    }
-    alerts.extend(check_smtp_spikes(&ctx).await);
-    if let Some(a) = check_forbidden_countries(&ctx).await {
-        alerts.push(a);
-    }
-    alerts.extend(check_forbidden_companies(&ctx).await);
-    if let Some(a) = check_silent_delivery_failures(&ctx).await {
-        alerts.push(a);
-    }
-    if let Some(a) = check_p95_latency(&ctx).await {
-        alerts.push(a);
-    }
-    alerts
-}
-
-// ---------------------------------------------------------------------------
-// Env helpers
-// ---------------------------------------------------------------------------
-
-fn env_f32(key: &str, default: f32) -> f32 {
-    std::env::var(key)
-        .ok()
-        .and_then(|v| v.parse().ok())
-        .unwrap_or(default)
-}
-
-fn env_u64(key: &str, default: u64) -> u64 {
-    std::env::var(key)
-        .ok()
-        .and_then(|v| v.parse().ok())
-        .unwrap_or(default)
-}
-
-fn env_list(key: &str) -> Vec<String> {
-    std::env::var(key)
-        .unwrap_or_default()
-        .split(',')
-        .map(|s| s.trim().to_string())
-        .filter(|s| !s.is_empty())
-        .collect()
-}
-
-// ---------------------------------------------------------------------------
-// Tests
-// ---------------------------------------------------------------------------
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_alert_config_defaults() {
-        let cfg = AlertConfig::default();
-        assert!(cfg.bounce_rate_threshold > 0.0);
-        assert!(cfg.p95_total_ms_threshold > 0);
-        assert!(cfg.smtp_spike_threshold > 0);
-    }
 }


### PR DESCRIPTION
Cycle 36 Rust LOC>300 reduction.

**Before**: `src/monitoring/alerts.rs` = 314 LOC
**After**:
- `src/monitoring/alerts/mod.rs` = 110 (config, ActiveAlert, AlertCtx, orchestrator)
- `src/monitoring/alerts/rules.rs` = 188 (6 rule checks)
- `src/monitoring/alerts/env.rs` = 24 (env parsing)

Pure move + visibility. Public API unchanged.