### PR TITLE
refactor(test-smtp): split into stream/mail/session/tls submodules

### DIFF
--- a/crates/domain/src/ports.rs
+++ b/crates/domain/src/ports.rs
@@ -259,3 +259,20 @@ pub trait EmailDeliveryPort: Send + Sync {
     /// Dépose un email dans la boîte INBOX de `username`.
     async fn deliver_to_inbox(&self, username: &str, email: &Email) -> DomainResult<()>;
 }
+
+/// Port mailbox status — statut IMAP d'une mailbox (EXISTS, RECENT, UIDNEXT, UIDVALIDITY, UNSEEN).
+///
+/// Cycle 37 : 17ème port autonome. Signatures 100 % primitives (`&str`, `String`, `u32`).
+/// Retourne soit un vecteur de couples clé/valeur (`get_mailbox_status_items`)
+/// représentant la réponse IMAP STATUS, autonome et sans dépendance infrastructure.
+#[async_trait]
+pub trait MailboxStatusPort: Send + Sync {
+    /// Récupère le statut d'une mailbox sous forme de couples (clé, valeur).
+    ///
+    /// Les clés typiques : `MESSAGES`, `RECENT`, `UIDNEXT`, `UIDVALIDITY`, `UNSEEN`.
+    async fn get_mailbox_status_items(
+        &self,
+        username: &str,
+        mailbox: &str,
+    ) -> DomainResult<Vec<(String, String)>>;
+}


### PR DESCRIPTION
Cycle 37 Rust LOC. Splits src/test-smtp.rs (352 LOC) into a thin binary entrypoint (73 LOC) + four submodules under src/test_smtp/ wired via #[path]: stream.rs (63), mail.rs (59), session.rs (91), tls.rs (19). Also drops a large commented-out legacy process_command block and a dead handle_client tokio::spawn stub. No behavioural changes. All files now under the 300 LOC target.