### PR TITLE
refactor(smtp_client): split mx.rs (cycle 39 LOC, 306→183)

### DIFF
--- a/src/smtp_client/mx.rs
+++ b/src/smtp_client/mx.rs
@@ -1,52 +1,8 @@
 use super::*;
 
-/// Contexte partagé pour l'émission d'événements de monitoring pendant l'envoi.
-struct SendContext {
-    message_id: String,
-    correlation_id: String,
-    from: String,
-    to: String,
-    mon: bool,
-}
-
-impl SendContext {
-    fn from_email(email: &Email) -> Self {
-        let message_id = email
-            .headers
-            .iter()
-            .find(|(k, _)| k.to_lowercase() == "message-id")
-            .map(|(_, v)| v.trim_matches(|c| c == '<' || c == '>').to_string())
-            .unwrap_or_else(|| email.id.clone());
-        Self {
-            message_id,
-            correlation_id: Uuid::new_v4().to_string(),
-            from: email.from.clone(),
-            to: email.to.clone(),
-            mon: crate::monitoring::monitoring_enabled(),
-        }
-    }
-
-    fn emit(&self, ev_type: crate::monitoring::SmtpEventType) -> crate::monitoring::SmtpEvent {
-        let mut ev = crate::monitoring::SmtpEvent::new(&self.message_id, ev_type, &self.from, &self.to);
-        ev.correlation_id = self.correlation_id.clone();
-        ev
-    }
-
-    fn emit_bounce_soft(&self, reason: String, mx_host: Option<String>, remote_ip: Option<String>, total_ms: Option<u64>, dns_ms: Option<u64>) {
-        if !self.mon {
-            return;
-        }
-        let mut ev = self.emit(crate::monitoring::SmtpEventType::Bounced);
-        ev.mx_host = mx_host;
-        ev.remote_ip = remote_ip;
-        ev.total_ms = total_ms;
-        ev.dns_ms = dns_ms;
-        ev.status = crate::monitoring::SmtpStatus::Failed;
-        ev.bounce_type = Some(crate::monitoring::BounceType::Soft);
-        ev.bounce_reason = Some(reason);
-        crate::monitoring::emit(ev);
-    }
-}
+#[path = "mx_events.rs"]
+mod events;
+use events::{SendContext, spawn_connect_event, emit_final_event};
 
 /// Résolution DNS + sélection du premier MX record et du port SMTP ouvert.
 async fn resolve_mx_target(
@@ -118,33 +74,6 @@ async fn resolve_mx_target(
     Ok((smtp_server, smtp_port, dns_ms))
 }
 
-/// Enrichissement GeoIP + émission asynchrone de l'événement SmtpConnect.
-fn spawn_connect_event(ctx: &SendContext, remote_ip: String, mx: String, port: u16, connect_ms: u64) {
-    if !ctx.mon {
-        return;
-    }
-    let mid = ctx.message_id.clone();
-    let cid = ctx.correlation_id.clone();
-    let from = ctx.from.clone();
-    let to = ctx.to.clone();
-    tokio::spawn(async move {
-        let geo = crate::monitoring::enrichment::enrich_ip(&remote_ip).await;
-        let mut ev = crate::monitoring::SmtpEvent::new(
-            &mid,
-            crate::monitoring::SmtpEventType::SmtpConnect,
-            &from,
-            &to,
-        );
-        ev.correlation_id = cid;
-        ev.mx_host = Some(mx);
-        ev.remote_port = Some(port);
-        ev.connect_ms = Some(connect_ms);
-        ev = ev.with_geo(geo);
-        ev.compute_risk_score();
-        crate::monitoring::emit(ev);
-    });
-}
-
 /// EHLO + STARTTLS + second EHLO chiffré. Retourne le stream prêt pour MAIL FROM.
 async fn perform_smtp_handshake(
     mut stream: TcpStream,
@@ -192,58 +121,6 @@ async fn perform_smtp_handshake(
     }
 
     Ok((stream_type, tls_ms))
-}
-
-/// Émet l'événement Delivered ou Bounced selon le résultat de la transaction SMTP.
-fn emit_final_event(
-    ctx: &SendContext,
-    result: &std::io::Result<()>,
-    smtp_server: &str,
-    remote_ip: &str,
-    dns_ms: u64,
-    connect_ms: u64,
-    tls_ms: u64,
-    total_ms: u64,
-) {
-    if !ctx.mon {
-        return;
-    }
-    match result {
-        Ok(_) => {
-            let mut ev = ctx.emit(crate::monitoring::SmtpEventType::Delivered);
-            ev.mx_host = Some(smtp_server.to_string());
-            ev.remote_ip = Some(remote_ip.to_string());
-            ev.dns_ms = Some(dns_ms);
-            ev.connect_ms = Some(connect_ms);
-            ev.tls_ms = Some(tls_ms);
-            ev.total_ms = Some(total_ms);
-            ev.smtp_code = Some(250);
-            ev.smtp_reply = Some("250 OK".into());
-            ev.status = crate::monitoring::SmtpStatus::Delivered;
-            ev.compute_risk_score();
-            crate::monitoring::emit(ev);
-        }
-        Err(e) => {
-            let err_msg = e.to_string();
-            let smtp_code = crate::monitoring::parse_smtp_code(&err_msg);
-            let bounce_type = match smtp_code {
-                Some(c) if c >= 550 => crate::monitoring::BounceType::Hard,
-                Some(421) | Some(450) => crate::monitoring::BounceType::Soft,
-                _ => crate::monitoring::BounceType::Soft,
-            };
-            let mut ev = ctx.emit(crate::monitoring::SmtpEventType::Bounced);
-            ev.mx_host = Some(smtp_server.to_string());
-            ev.remote_ip = Some(remote_ip.to_string());
-            ev.total_ms = Some(total_ms);
-            ev.smtp_code = smtp_code;
-            ev.smtp_reply = Some(err_msg.clone());
-            ev.status = crate::monitoring::SmtpStatus::Bounced;
-            ev.bounce_type = Some(bounce_type);
-            ev.bounce_reason = Some(err_msg);
-            ev.compute_risk_score();
-            crate::monitoring::emit(ev);
-        }
-    }
 }
 
 pub(super) async fn send_via_mx(email: &Email) -> std::io::Result<()> {

--- a/src/smtp_client/mx_events.rs
+++ b/src/smtp_client/mx_events.rs
@@ -1,8 +1,8 @@
 //! Contexte d'envoi + émission d'événements de monitoring pour `mx.rs`.
 //! Extrait de `mx.rs` (cycle 39) pour maintenir chaque fichier sous le seuil LOC.
 
-use super::*;
 use crate::entities::Email;
+use uuid::Uuid;
 
 /// Contexte partagé pour l'émission d'événements de monitoring pendant l'envoi.
 pub(super) struct SendContext {


### PR DESCRIPTION
## Cycle 39 - Rust LOC guardrail

Split `src/smtp_client/mx.rs` (306 LOC, over 300 threshold) into two focused modules:

- **mx.rs** (183 LOC): transport orchestration — `resolve_mx_target`, `perform_smtp_handshake`, `send_via_mx`
- **mx_events.rs** (140 LOC, new): monitoring — `SendContext`, `spawn_connect_event`, `emit_final_event`

No behavior change. `send_via_mx` public surface unchanged. Both files now well under 300 LOC.

### Notes
- `test-smtp.rs` (352 LOC) confirmed orphan (not referenced in Cargo.toml) — left as-is.
- `monitoring/mod.rs` (302 LOC) still borderline; deferred to future cycle.